### PR TITLE
Control fields overhaul + CLI support

### DIFF
--- a/tsp/src/cesr/packet/fuzzing.rs
+++ b/tsp/src/cesr/packet/fuzzing.rs
@@ -1,0 +1,129 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct Wrapper(pub Payload<'static, Vec<u8>, Vec<u8>>);
+
+impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        const DIGEST: [u8; 32] = {
+            let mut buf = [0; 32];
+            let mut i = 0;
+            while i < buf.len() {
+                buf[i] = i as u8;
+                i += 1;
+            }
+
+            buf
+        };
+
+        #[derive(arbitrary::Arbitrary)]
+        enum Variants {
+            GenericMessage,
+            NestedMessage,
+            RoutedMessage,
+            DirectRelationProposal,
+            DirectRelationAffirm,
+            NestedRelationProposal,
+            NestedRelationAffirm,
+            RelationshipCancel,
+        }
+
+        #[allow(dead_code)]
+        fn check_exhaustive(payload: Payload<Vec<u8>, Vec<u8>>) -> Variants {
+            match payload {
+                Payload::GenericMessage(_) => Variants::GenericMessage,
+                Payload::NestedMessage(_) => Variants::NestedMessage,
+                Payload::RoutedMessage(_, _) => Variants::RoutedMessage,
+                Payload::DirectRelationProposal { .. } => Variants::DirectRelationProposal,
+                Payload::DirectRelationAffirm { .. } => Variants::DirectRelationAffirm,
+                Payload::NestedRelationProposal { .. } => Variants::NestedRelationProposal,
+                Payload::NestedRelationAffirm { .. } => Variants::NestedRelationAffirm,
+                Payload::RelationshipCancel { .. } => Variants::RelationshipCancel,
+            }
+        }
+
+        let variant = Variants::arbitrary(u)?;
+
+        use arbitrary::Arbitrary;
+        let payload = match variant {
+            Variants::GenericMessage => Payload::GenericMessage(Arbitrary::arbitrary(u)?),
+            Variants::NestedMessage => Payload::NestedMessage(Arbitrary::arbitrary(u)?),
+            Variants::RoutedMessage => {
+                Payload::RoutedMessage(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?)
+            }
+            Variants::DirectRelationProposal => Payload::DirectRelationProposal {
+                nonce: Nonce(Arbitrary::arbitrary(u)?),
+                hops: Arbitrary::arbitrary(u)?,
+            },
+            Variants::DirectRelationAffirm => Payload::DirectRelationAffirm { reply: &DIGEST },
+            Variants::NestedRelationProposal => Payload::NestedRelationProposal {
+                new_vid: Arbitrary::arbitrary(u)?,
+            },
+            Variants::NestedRelationAffirm => Payload::NestedRelationAffirm {
+                reply: &DIGEST,
+                new_vid: Arbitrary::arbitrary(u)?,
+                connect_to_vid: Arbitrary::arbitrary(u)?,
+            },
+            Variants::RelationshipCancel => Payload::RelationshipCancel {
+                nonce: Nonce(Arbitrary::arbitrary(u)?),
+                reply: &DIGEST,
+            },
+        };
+
+        Ok(Wrapper(payload))
+    }
+}
+
+impl<'a> PartialEq<Payload<'a, &'a [u8], &'a [u8]>> for Wrapper {
+    fn eq(&self, other: &Payload<'a, &'a [u8], &'a [u8]>) -> bool {
+        match (&self.0, other) {
+            (Payload::GenericMessage(l0), Payload::GenericMessage(r0)) => l0 == r0,
+            (Payload::NestedMessage(l0), Payload::NestedMessage(r0)) => l0 == r0,
+            (Payload::RoutedMessage(l0, l1), Payload::RoutedMessage(r0, r1)) => {
+                l0 == r0 && l1 == r1
+            }
+            (
+                Payload::DirectRelationProposal {
+                    nonce: l_nonce,
+                    hops: l_hops,
+                },
+                Payload::DirectRelationProposal {
+                    nonce: r_nonce,
+                    hops: r_hops,
+                },
+            ) => l_nonce.0 == r_nonce.0 && l_hops == r_hops,
+            (
+                Payload::DirectRelationAffirm { reply: l_reply },
+                Payload::DirectRelationAffirm { reply: r_reply },
+            ) => l_reply == r_reply,
+            (
+                Payload::NestedRelationProposal { new_vid: l_vid },
+                Payload::NestedRelationProposal { new_vid: r_vid },
+            ) => l_vid == r_vid,
+            (
+                Payload::NestedRelationAffirm {
+                    reply: l_reply,
+                    new_vid: l_vid,
+                    connect_to_vid: l_vid2,
+                },
+                Payload::NestedRelationAffirm {
+                    reply: r_reply,
+                    new_vid: r_vid,
+                    connect_to_vid: r_vid2,
+                },
+            ) => l_reply == r_reply && l_vid == r_vid && l_vid2 == r_vid2,
+
+            (
+                Payload::RelationshipCancel {
+                    nonce: l_nonce,
+                    reply: l_reply,
+                },
+                Payload::RelationshipCancel {
+                    nonce: r_nonce,
+                    reply: r_reply,
+                },
+            ) => l_nonce.0 == r_nonce.0 && l_reply == r_reply,
+            _ => false,
+        }
+    }
+}

--- a/tsp/src/crypto/tsp_hpke.rs
+++ b/tsp/src/crypto/tsp_hpke.rs
@@ -41,6 +41,18 @@ where
         Payload::AcceptRelationship { ref thread_id } => {
             crate::cesr::Payload::DirectRelationAffirm { reply: thread_id }
         }
+        Payload::RequestNestedRelationship { vid } => {
+            crate::cesr::Payload::NestedRelationProposal { new_vid: vid }
+        }
+        Payload::AcceptNestedRelationship {
+            ref thread_id,
+            vid,
+            connect_to_vid,
+        } => crate::cesr::Payload::NestedRelationAffirm {
+            reply: thread_id,
+            new_vid: vid,
+            connect_to_vid,
+        },
         Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
             nonce: fresh_nonce(&mut csprng),
             reply: thread_id,
@@ -163,8 +175,18 @@ where
         crate::cesr::Payload::DirectRelationAffirm { reply: &thread_id } => {
             Payload::AcceptRelationship { thread_id }
         }
-        crate::cesr::Payload::NestedRelationProposal { .. } => todo!(),
-        crate::cesr::Payload::NestedRelationAffirm { .. } => todo!(),
+        crate::cesr::Payload::NestedRelationProposal { new_vid } => {
+            Payload::RequestNestedRelationship { vid: new_vid }
+        }
+        crate::cesr::Payload::NestedRelationAffirm {
+            new_vid,
+            connect_to_vid,
+            reply: &thread_id,
+        } => Payload::AcceptNestedRelationship {
+            vid: new_vid,
+            connect_to_vid,
+            thread_id,
+        },
         crate::cesr::Payload::RelationshipCancel {
             reply: &thread_id, ..
         } => Payload::CancelRelationship { thread_id },

--- a/tsp/src/test.rs
+++ b/tsp/src/test.rs
@@ -559,7 +559,7 @@ async fn test_relation_forming() {
         .await
         .unwrap();
 
-    let crate::definitions::ReceivedTspMessage::AcceptRelationship { sender } =
+    let crate::definitions::ReceivedTspMessage::AcceptRelationship { sender, .. } =
         alice_messages.next().await.unwrap().unwrap()
     else {
         panic!("alice did not receive a relation accept")


### PR DESCRIPTION
It used to be the case that for nested mode to work, both sides would already need to know their respective vid's (which is an unrealistic scenario). This PR addresses this so communication can be initiated using NEW_NEST_REL messages.

This PR should probably be squashed since not all commits 'compile'; because of the DCO sign-off requirement I'd like to do that after the review but before the merge.

But because this is a large PR I want to leave the option of reviewing commit-by-commit open.