### PR TITLE
run tests with target `wasm32-unknown-unknown`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+runner = "wasmtime run --invoke _start"
+
+[target.wasm32-wasi]
+runner = "wasmtime run --invoke _start"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,6 +36,35 @@ jobs:
         run: cargo test -- --nocapture && cargo test --doc
         shell: bash
 
+  check-wasm32-unknown-unknown:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: linux-x86-64-gnu-${{ hashFiles('Cargo.toml') }}
+          restore-keys: linux-x86-64-gnu-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Run tests with wasm-pack
+        working-directory: tsp
+        run: wasm-pack test --node -- -p tsp --no-default-features --features "resolve"
+
   fuzz:
     name: run cargo-fuzz
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [ "tsp", "examples", "fuzz" , "tsp-python"]
+members = [ "tsp", "examples", "fuzz" , "tsp-python", "tsp-javascript"]
 
 [workspace.package]
 version = "0.1.0"

--- a/tsp-javascript/Cargo.toml
+++ b/tsp-javascript/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tsp-javascript"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+description.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["console"] }
+tsp = { path = "../tsp", default-features = false, features = ["resolve"] }
+serde.workspace = true
+serde-wasm-bindgen = "0.4"

--- a/tsp-javascript/src/lib.rs
+++ b/tsp-javascript/src/lib.rs
@@ -1,0 +1,294 @@
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+pub struct Error(tsp::Error);
+
+impl From<Error> for JsValue {
+    fn from(e: Error) -> Self {
+        JsValue::from_str(&format!("{:?}", e.0))
+    }
+}
+
+#[derive(Default, Clone)]
+#[wasm_bindgen]
+pub struct Store(tsp::Store);
+
+#[wasm_bindgen]
+pub struct SealedMessage {
+    #[wasm_bindgen(getter_with_clone)]
+    pub url: String,
+    #[wasm_bindgen(getter_with_clone)]
+    pub bytes: Vec<u8>,
+}
+
+#[wasm_bindgen]
+impl Store {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[wasm_bindgen]
+    pub fn add_private_vid(&self, vid: OwnedVid) -> Result<(), Error> {
+        self.0.add_private_vid(vid.0).map_err(Error)
+    }
+
+    #[wasm_bindgen]
+    pub fn seal_message(
+        &self,
+        sender: String,
+        receiver: String,
+        nonconfidential_data: Option<Vec<u8>>,
+        message: Vec<u8>,
+    ) -> Result<SealedMessage, Error> {
+        let (url, bytes) = self
+            .0
+            .seal_message(
+                &sender,
+                &receiver,
+                nonconfidential_data.as_deref(),
+                &message,
+            )
+            .map_err(Error)?;
+
+        Ok(SealedMessage {
+            url: url.to_string(),
+            bytes,
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn open_message(&self, mut message: Vec<u8>) -> Result<FlatReceivedTspMessage, Error> {
+        self.0
+            .open_message(&mut message)
+            .map(FlatReceivedTspMessage::from)
+            .map_err(Error)
+    }
+}
+
+#[wasm_bindgen]
+pub struct OwnedVid(tsp::OwnedVid);
+
+#[wasm_bindgen]
+impl OwnedVid {
+    #[wasm_bindgen]
+    pub fn new_did_peer(url: String) -> Self {
+        OwnedVid(tsp::OwnedVid::new_did_peer(url.parse().unwrap()))
+    }
+
+    #[wasm_bindgen]
+    pub fn identifier(&self) -> String {
+        use tsp::VerifiedVid;
+        self.0.identifier().to_string()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum ReceivedTspMessageVariant {
+    GenericMessage = 0,
+    RequestRelationship = 1,
+    AcceptRelationship = 2,
+    CancelRelationship = 3,
+    ForwardRequest = 4,
+}
+
+impl From<&tsp::ReceivedTspMessage> for ReceivedTspMessageVariant {
+    fn from(value: &tsp::ReceivedTspMessage) -> Self {
+        match value {
+            tsp::ReceivedTspMessage::GenericMessage { .. } => Self::GenericMessage,
+            tsp::ReceivedTspMessage::RequestRelationship { .. } => Self::RequestRelationship,
+            tsp::ReceivedTspMessage::AcceptRelationship { .. } => Self::AcceptRelationship,
+            tsp::ReceivedTspMessage::CancelRelationship { .. } => Self::CancelRelationship,
+            tsp::ReceivedTspMessage::ForwardRequest { .. } => Self::ForwardRequest,
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum MessageType {
+    Signed,
+    SignedAndEncrypted,
+}
+
+#[wasm_bindgen(inspectable)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlatReceivedTspMessage {
+    pub variant: ReceivedTspMessageVariant,
+    sender: Option<String>,
+    nonconfidential_data: Option<Option<Vec<u8>>>,
+    message: Option<Vec<u8>>,
+    pub message_type: Option<MessageType>,
+    route: Option<Option<Vec<Vec<u8>>>>,
+    nested_vid: Option<Option<String>>,
+    thread_id: Option<Vec<u8>>,
+    next_hop: Option<String>,
+    payload: Option<Vec<u8>>,
+    opaque_payload: Option<Vec<u8>>,
+    unknown_vid: Option<String>,
+}
+
+#[wasm_bindgen]
+impl FlatReceivedTspMessage {
+    #[wasm_bindgen(getter)]
+    pub fn sender(&self) -> Option<String> {
+        self.sender.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn nonconfidential_data(&self) -> JsValue {
+        match &self.nonconfidential_data {
+            Some(inner) => match inner {
+                Some(data) => serde_wasm_bindgen::to_value(data).unwrap(),
+                None => JsValue::NULL,
+            },
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn message(&self) -> JsValue {
+        match dbg!(&self.message) {
+            Some(data) => serde_wasm_bindgen::to_value(data).unwrap(),
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn route(&self) -> JsValue {
+        match &self.route {
+            Some(inner) => match inner {
+                Some(routes) => serde_wasm_bindgen::to_value(routes).unwrap(),
+                None => JsValue::NULL,
+            },
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn nested_vid(&self) -> JsValue {
+        match &self.nested_vid {
+            Some(inner) => match inner {
+                Some(vid) => JsValue::from_str(vid),
+                None => JsValue::NULL,
+            },
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn thread_id(&self) -> JsValue {
+        match &self.thread_id {
+            Some(data) => serde_wasm_bindgen::to_value(data).unwrap(),
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn next_hop(&self) -> JsValue {
+        match &self.next_hop {
+            Some(next_hop) => JsValue::from_str(next_hop),
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn payload(&self) -> JsValue {
+        match &self.payload {
+            Some(data) => serde_wasm_bindgen::to_value(data).unwrap(),
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn opaque_payload(&self) -> JsValue {
+        match &self.opaque_payload {
+            Some(data) => serde_wasm_bindgen::to_value(data).unwrap(),
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn unknown_vid(&self) -> JsValue {
+        match &self.unknown_vid {
+            Some(unknown_vid) => JsValue::from_str(unknown_vid),
+            None => JsValue::NULL,
+        }
+    }
+}
+
+impl From<tsp::ReceivedTspMessage> for FlatReceivedTspMessage {
+    fn from(value: tsp::ReceivedTspMessage) -> Self {
+        let variant = ReceivedTspMessageVariant::from(&value);
+
+        let mut this = FlatReceivedTspMessage {
+            variant,
+            sender: None,
+            nonconfidential_data: None,
+            message: None,
+            message_type: None,
+            route: None,
+            nested_vid: None,
+            thread_id: None,
+            next_hop: None,
+            payload: None,
+            opaque_payload: None,
+            unknown_vid: None,
+        };
+
+        match value {
+            tsp::ReceivedTspMessage::GenericMessage {
+                sender,
+                nonconfidential_data,
+                message,
+                message_type,
+            } => {
+                this.sender = Some(sender);
+                this.nonconfidential_data = Some(nonconfidential_data);
+                this.message = Some(message);
+                this.message_type = match message_type {
+                    tsp::definitions::MessageType::Signed => Some(MessageType::Signed),
+                    tsp::definitions::MessageType::SignedAndEncrypted => {
+                        Some(MessageType::SignedAndEncrypted)
+                    }
+                };
+            }
+            tsp::ReceivedTspMessage::RequestRelationship {
+                sender,
+                route,
+                nested_vid,
+                thread_id,
+            } => {
+                this.sender = Some(sender);
+                this.route = Some(route);
+                this.nested_vid = Some(nested_vid);
+                this.thread_id = Some(thread_id.to_vec());
+            }
+            tsp::ReceivedTspMessage::AcceptRelationship { sender, nested_vid } => {
+                this.sender = Some(sender);
+                this.nested_vid = Some(nested_vid);
+            }
+            tsp::ReceivedTspMessage::CancelRelationship { sender } => {
+                this.sender = Some(sender);
+            }
+            tsp::ReceivedTspMessage::ForwardRequest {
+                sender,
+                next_hop,
+                route,
+                opaque_payload,
+            } => {
+                this.sender = Some(sender);
+                this.next_hop = Some(next_hop);
+                this.route = Some(Some(route));
+                this.opaque_payload = Some(opaque_payload);
+            }
+            #[cfg(feature = "async")]
+            tsp::ReceivedTspMessage::PendingMessage { .. } => {
+                unreachable!()
+            }
+        };
+
+        this
+    }
+}

--- a/tsp-node/.gitignore
+++ b/tsp-node/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tsp-node/index.js
+++ b/tsp-node/index.js
@@ -1,0 +1,149 @@
+const wasm = require('tsp-javascript');
+
+const MessageType = {
+    Signed: 0, 
+    SignedAndEncrypted: 1, 
+};
+
+class Store {
+    constructor() {
+        this.inner = new wasm.Store();
+    }
+
+    add_private_vid(...args) {
+        return this.inner.add_private_vid(...args);
+    }
+
+    seal_message(sender, receiver, nonconfidential_data, message) {
+        let byteArray;
+        
+        if (typeof message === 'string') {
+            const encoder = new TextEncoder();
+            byteArray = encoder.encode(message);
+        } else if (message instanceof Uint8Array) {
+            byteArray = message;
+        } else {
+            throw new TypeError("Message must be a string or a Uint8Array");
+        }
+
+        return this.inner.seal_message(sender, receiver, nonconfidential_data, byteArray);
+    }
+
+    open_message(...args) {
+        const flatMessage = this.inner.open_message(...args);
+        return ReceivedTspMessage.fromFlat(flatMessage);
+    }
+}
+
+class ReceivedTspMessage {
+    static fromFlat(msg) {
+        switch (msg.variant) {
+            case 0:
+                return new GenericMessage(
+                    msg.sender,
+                    msg.nonconfidential_data,
+                    new Uint8Array(msg.message),
+                    msg.message_type
+                );
+
+            case 1: 
+                throw new Error("todo!");
+
+            case 2: 
+                return new AcceptRelationship(
+                    msg.sender,
+                    msg.nested_vid
+                );
+
+            case 3: 
+                return new CancelRelationship(
+                    msg.sender
+                );
+
+            case 4: 
+                throw new Error("todo!");
+
+            case 5: 
+                throw new Error("todo!");
+
+            default:
+                throw new Error(`Unrecognized variant: ${msg.variant}`);
+        }
+    }
+}
+
+class GenericMessage extends ReceivedTspMessage {
+    constructor(sender, nonconfidentialData, message, messageType) {
+        super();
+        this.sender = sender;
+        this.nonconfidentialData = nonconfidentialData;
+        this.message = message;
+        this.messageType = messageType;
+    }
+}
+
+class AcceptRelationship extends ReceivedTspMessage {
+    constructor(sender, nestedVid) {
+        super();
+        this.sender = sender;
+        this.nestedVid = nestedVid;
+    }
+}
+
+class CancelRelationship extends ReceivedTspMessage {
+    constructor(sender) {
+        super();
+        this.sender = sender;
+    }
+}
+
+function arraysEqual(arr1, arr2) {
+    if (arr1.length !== arr2.length) {
+        return false;
+    }
+    for (let i = 0; i < arr1.length; i++) {
+        if (arr1[i] !== arr2[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function main() {
+    function new_vid() {
+        return wasm.OwnedVid.new_did_peer("tcp://127.0.0.1:1337");
+    }
+
+    let store = new Store();
+
+    let alice = new_vid()
+    let bob = new_vid()
+
+    let alice_identifier = alice.identifier();
+    let bob_identifier = bob.identifier();
+
+    store.add_private_vid(alice)
+    store.add_private_vid(bob)
+
+    let message = "hello world"
+
+    let sealed = store.seal_message(alice_identifier, bob_identifier, null, message);
+
+    console.assert(sealed.url == "tcp://127.0.0.1:1337");
+
+    let received = store.open_message(sealed.bytes);
+
+    if (received instanceof GenericMessage) {
+        const { sender, message: messageBytes, messageType } = received;
+        console.assert(sender === alice_identifier, "Sender does not match Alice's identifier");
+        let receivedMessage = String.fromCharCode.apply(null, messageBytes);
+        console.assert(receivedMessage == message, "Received message does not match");
+        console.assert(messageType === MessageType.SignedAndEncrypted, "Message type does not match SignedAndEncrypted");
+        console.log("success:", receivedMessage);
+    } else {
+        console.log(`unexpected message type`, received);
+        console.assert(false, "Unexpected message type");
+    }
+}
+
+main()

--- a/tsp-node/package-lock.json
+++ b/tsp-node/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "tsp-node",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tsp-node",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "tsp-javascript": "file:../tsp-javascript/pkg"
+      }
+    },
+    "../tsp-javascript/pkg": {
+      "version": "0.1.0",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/tsp-javascript": {
+      "resolved": "../tsp-javascript/pkg",
+      "link": true
+    }
+  }
+}

--- a/tsp-node/package.json
+++ b/tsp-node/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tsp-node",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "tsp-javascript": "file:../tsp-javascript/pkg"
+  }
+}

--- a/tsp/Cargo.toml
+++ b/tsp/Cargo.toml
@@ -78,6 +78,14 @@ bs58 ={ workspace = true, optional = true }
 # fuzzing
 arbitrary ={ workspace = true, optional = true }
 
+# not used directly, but we need to configure
+# the JS feature in this transitive dependency
+# required for compiling to wasm32-unknown-unknown
+[dependencies.getrandom]
+version = "*"
+features = ["js"]
+
 [dev-dependencies]
 serial_test = { version = "3.0" }
-arbitrary ={ workspace = true }
+arbitrary = { workspace = true }
+wasm-bindgen-test = "0.3.0"

--- a/tsp/src/cesr/detect.rs
+++ b/tsp/src/cesr/detect.rs
@@ -16,6 +16,7 @@ mod test {
     use base64ct::{Base64UrlUnpadded, Encoding};
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_binary() {
         let base64 = *b"-FAB";
         let binary = Base64UrlUnpadded::decode_vec(std::str::from_utf8(&base64).unwrap()).unwrap();

--- a/tsp/src/cesr/packet.rs
+++ b/tsp/src/cesr/packet.rs
@@ -766,9 +766,12 @@ pub fn decode_tsp_message<'a, Vid: TryFrom<&'a [u8]>>(
 
 #[cfg(test)]
 mod test {
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use super::*;
 
     #[test]
+    #[wasm_bindgen_test]
     fn envelope_without_nonconfidential_data() {
         fn dummy_crypt(data: &[u8]) -> &[u8] {
             data
@@ -813,6 +816,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn envelope_with_nonconfidential_data() {
         fn dummy_crypt(data: &[u8]) -> &[u8] {
             data
@@ -857,6 +861,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn envelope_without_confidential_data() {
         let fixed_sig = [1; 64];
 
@@ -888,6 +893,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn s_envelope_with_confidential_data_failure() {
         fn dummy_crypt(data: &[u8]) -> &[u8] {
             data
@@ -911,6 +917,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn envelope_failure() {
         let fixed_sig = [1; 64];
 
@@ -931,6 +938,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn trailing_data() {
         let fixed_sig = [1; 64];
 
@@ -980,16 +988,19 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn mut_envelope_with_nonconfidential_data() {
         test_turn_around(Payload::GenericMessage(&b"Hello TSP!"[..]));
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_nested_msg() {
         test_turn_around(Payload::NestedMessage(&b"Hello TSP!"[..]));
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_routed_msg() {
         test_turn_around(Payload::RoutedMessage(
             vec![b"foo", b"bar"],
@@ -1037,6 +1048,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_relation_forming() {
         let temp = (1u8..33).collect::<Vec<u8>>();
         let nonce: &[u8; 32] = temp.as_slice().try_into().unwrap();
@@ -1060,6 +1072,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_message_to_parts() {
         use base64ct::{Base64UrlUnpadded, Encoding};
 

--- a/tsp/src/error.rs
+++ b/tsp/src/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
     #[error("Error: {0}")]
     FromUtf8(#[from] std::string::FromUtf8Error),
     #[error("Error: {0}")]
+    #[cfg(feature = "async")]
     Storage(#[from] aries_askar::Error),
     #[error("Error decoding persisted state: {0}")]
     DecodeState(&'static str),

--- a/tsp/src/lib.rs
+++ b/tsp/src/lib.rs
@@ -105,8 +105,10 @@ mod test;
 #[cfg(feature = "async")]
 pub use async_store::AsyncStore;
 
+#[cfg(feature = "async")]
+pub use vault::Vault;
+
 pub use definitions::{Payload, PrivateVid, ReceivedTspMessage, RelationshipStatus, VerifiedVid};
 pub use error::Error;
 pub use store::Store;
-pub use vault::Vault;
 pub use vid::{ExportVid, OwnedVid, Vid};

--- a/tsp/src/store.rs
+++ b/tsp/src/store.rs
@@ -815,7 +815,7 @@ impl Store {
     }
 
     fn make_propositioning_vid(&self, parent_vid: &str) -> Result<OwnedVid, Error> {
-        let transport = Url::from_file_path("/dev/null").expect("error generating a URL");
+        let transport = Url::parse("https://example.net").expect("error generating a URL");
 
         let vid = OwnedVid::new_did_peer(transport);
         self.add_private_vid(vid.clone())?;

--- a/tsp/src/store.rs
+++ b/tsp/src/store.rs
@@ -934,6 +934,8 @@ impl Store {
 
 #[cfg(test)]
 mod test {
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use crate::{definitions::MessageType, OwnedVid, ReceivedTspMessage, Store, VerifiedVid};
 
     fn new_vid() -> OwnedVid {
@@ -941,6 +943,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_add_private_vid() {
         let store = Store::new();
         let vid = new_vid();
@@ -951,6 +954,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_add_verified_vid() {
         let store = Store::new();
         let owned_vid = new_vid();
@@ -961,6 +965,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_remove() {
         let store = Store::new();
         let vid = new_vid();
@@ -975,6 +980,7 @@ mod test {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_open_seal() {
         let store = Store::new();
         let alice = new_vid();

--- a/tsp/src/vid/deserialize.rs
+++ b/tsp/src/vid/deserialize.rs
@@ -110,6 +110,7 @@ pub(crate) mod serde_key_data_option {
     }
 }
 
+#[cfg(feature = "async")]
 #[cfg(test)]
 mod test {
     use super::OwnedVid;

--- a/tsp/src/vid/did/peer.rs
+++ b/tsp/src/vid/did/peer.rs
@@ -147,12 +147,14 @@ mod test {
     use hpke::{kem::X25519HkdfSha256 as KemType, Kem, Serializable};
     use rand::rngs::OsRng;
     use url::Url;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     use crate::Vid;
 
     use super::{encode_did_peer, verify_did_peer};
 
     #[test]
+    #[wasm_bindgen_test]
     fn encode_decode() {
         let sigkey = Ed::SigningKey::generate(&mut OsRng);
         let (_enckey, public_enckey) = KemType::gen_keypair(&mut OsRng);

--- a/tsp/src/vid/did/web.rs
+++ b/tsp/src/vid/did/web.rs
@@ -245,8 +245,8 @@ mod tests {
             error::VidError,
         },
     };
-    use std::fs;
     use url::Url;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     fn resolve_did_string(did: &str) -> Result<Url, VidError> {
         let parts = did.split(':').collect::<Vec<&str>>();
@@ -275,10 +275,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "wasi"), ignore)]
+    #[wasm_bindgen_test]
     fn test_resolve_document() {
-        let alice_did_doc = fs::read_to_string("../examples/test/alice-did.json").unwrap();
-        let alice_did_doc: DidDocument = serde_json::from_str(&alice_did_doc).unwrap();
+        let alice_did_doc = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../examples/test/alice-did.json"
+        ));
+        let alice_did_doc: DidDocument = serde_json::from_str(alice_did_doc).unwrap();
 
         let alice = resolve_document(alice_did_doc, "did:web:did.tsp-test.org:user:alice");
 
@@ -287,8 +290,11 @@ mod tests {
             "did:web:did.tsp-test.org:user:alice"
         );
 
-        let bob_did_doc = fs::read_to_string("../examples/test/bob-did.json").unwrap();
-        let bob_did_doc: DidDocument = serde_json::from_str(&bob_did_doc).unwrap();
+        let bob_did_doc = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../examples/test/bob-did.json"
+        ));
+        let bob_did_doc: DidDocument = serde_json::from_str(bob_did_doc).unwrap();
 
         let bob = resolve_document(bob_did_doc, "did:web:did.tsp-test.org:user:bob");
 

--- a/tsp/src/vid/did/web.rs
+++ b/tsp/src/vid/did/web.rs
@@ -60,11 +60,10 @@ pub struct PublicKeyJwk {
 pub async fn resolve(id: &str, parts: Vec<&str>) -> Result<Vid, VidError> {
     #[cfg(test)]
     {
-        let did_doc = tokio::fs::read_to_string(format!(
+        let did_doc = std::fs::read_to_string(format!(
             "../examples/test/{}-did.json",
             parts.get(4).unwrap_or(&"invalid")
         ))
-        .await
         .map_err(|_| VidError::ResolveVid("JSON not found in test dir"))?;
 
         let did_doc: DidDocument = serde_json::from_str(&did_doc).unwrap();
@@ -276,6 +275,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "wasi"), ignore)]
     fn test_resolve_document() {
         let alice_did_doc = fs::read_to_string("../examples/test/alice-did.json").unwrap();
         let alice_did_doc: DidDocument = serde_json::from_str(&alice_did_doc).unwrap();


### PR DESCRIPTION
runs tests with wasm-pack on CI:

```
> wasm-pack test --node -- tsp -p tsp --no-default-features --features "resolve"
[INFO]: 🎯  Checking for the Wasm target...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
[INFO]: ⬇️  Installing wasm-bindgen...
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running unittests src/lib.rs (/target/wasm32-unknown-unknown/debug/deps/tsp-7d5ea948380fa8ef.wasm)
Set timeout to 20 seconds...
running 17 tests                                  

test tsp::cesr::packet::test::test_message_to_parts ... ok
test tsp::cesr::packet::test::test_relation_forming ... ok
test tsp::cesr::packet::test::test_routed_msg ... ok
test tsp::cesr::packet::test::test_nested_msg ... ok
test tsp::cesr::packet::test::mut_envelope_with_nonconfidential_data ... ok
test tsp::cesr::packet::test::trailing_data ... ok
test tsp::cesr::packet::test::envelope_failure ... ok
test tsp::cesr::packet::test::s_envelope_with_confidential_data_failure ... ok
test tsp::cesr::packet::test::envelope_without_confidential_data ... ok
test tsp::cesr::packet::test::envelope_with_nonconfidential_data ... ok
test tsp::cesr::packet::test::envelope_without_nonconfidential_data ... ok
test tsp::vid::did::web::tests::test_resolve_document ... ok
test tsp::vid::did::peer::test::encode_decode ... ok
test tsp::store::test::test_open_seal ... ok
test tsp::store::test::test_remove ... ok
test tsp::store::test::test_add_verified_vid ... ok
test tsp::store::test::test_add_private_vid ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 filtered out
```

and this now also works

```
cargo test -p tsp --target wasm32-wasi --no-default-features --features "resolve"
```

this configures `wasmtime` as the test runner, so that needs to be available on the system
