### PR TITLE
Move API logic from async to sync store

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -330,11 +330,11 @@ async fn run() -> Result<(), Error> {
                 .await
                 .expect("Could not read message from stdin");
 
-            let cesr_message = match vid_database
+            match vid_database
                 .send(sender_vid, receiver_vid, non_confidential_data, &message)
                 .await
             {
-                Ok(m) => m,
+                Ok(()) => {},
                 Err(e) => {
                     tracing::error!(
                         "error sending message from {sender_vid} to {receiver_vid}: {e}"
@@ -345,6 +345,7 @@ async fn run() -> Result<(), Error> {
             };
 
             if args.pretty_print {
+                let cesr_message = vid_database.as_store().seal_message(sender_vid, receiver_vid, non_confidential_data, &message)?.1;
                 print_message(&cesr_message);
             }
 

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -334,7 +334,7 @@ async fn run() -> Result<(), Error> {
                 .send(sender_vid, receiver_vid, non_confidential_data, &message)
                 .await
             {
-                Ok(()) => {},
+                Ok(()) => {}
                 Err(e) => {
                     tracing::error!(
                         "error sending message from {sender_vid} to {receiver_vid}: {e}"
@@ -345,7 +345,10 @@ async fn run() -> Result<(), Error> {
             };
 
             if args.pretty_print {
-                let cesr_message = vid_database.as_store().seal_message(sender_vid, receiver_vid, non_confidential_data, &message)?.1;
+                let cesr_message = vid_database
+                    .as_store()
+                    .seal_message(sender_vid, receiver_vid, non_confidential_data, &message)?
+                    .1;
                 print_message(&cesr_message);
             }
 

--- a/tsp/src/async_store.rs
+++ b/tsp/src/async_store.rs
@@ -1,7 +1,5 @@
 use crate::{
-    definitions::{
-        Digest, Payload, ReceivedTspMessage, RelationshipStatus, TSPStream, VerifiedVid,
-    },
+    definitions::{Digest, ReceivedTspMessage, TSPStream, VerifiedVid},
     error::Error,
     store::Store,
     ExportVid, OwnedVid, PrivateVid,
@@ -59,15 +57,6 @@ impl AsyncStore {
     /// Adds a relation to an already existing vid, making it a nested Vid
     pub fn set_relation_for_vid(&self, vid: &str, relation_vid: Option<&str>) -> Result<(), Error> {
         self.inner.set_relation_for_vid(vid, relation_vid)
-    }
-
-    /// Sets the relationship status for a VID
-    pub(super) fn set_relation_status_for_vid(
-        &self,
-        vid: &str,
-        relation_status: RelationshipStatus,
-    ) -> Result<(), Error> {
-        self.inner.set_relation_status_for_vid(vid, relation_status)
     }
 
     /// Adds a route to an already existing vid, making it a nested Vid
@@ -195,32 +184,13 @@ impl AsyncStore {
         receiver: &str,
         route: Option<&[&str]>,
     ) -> Result<(), Error> {
-        let sender = self.inner.get_private_vid(sender)?;
-        let receiver = self.inner.get_verified_vid(receiver)?;
+        let (endpoint, message) = self
+            .inner
+            .make_relationship_request(sender, receiver, route)?;
 
-        let path = route;
-        let route = route.map(|collection| collection.iter().map(|vid| vid.as_ref()).collect());
+        tracing::info!("sending message to {endpoint}");
 
-        let (tsp_message, thread_id) = crate::crypto::seal_and_hash(
-            &*sender,
-            &*receiver,
-            None,
-            Payload::RequestRelationship { route },
-        )?;
-
-        let (transport, tsp_message) = if let Some(hop_list) = path {
-            self.set_route_for_vid(receiver.identifier(), hop_list)?;
-            self.resolve_route_and_send(hop_list, &tsp_message)?
-        } else {
-            (receiver.endpoint().clone(), tsp_message)
-        };
-
-        crate::transport::send_message(&transport, &tsp_message).await?;
-
-        self.set_relation_status_for_vid(
-            receiver.identifier(),
-            RelationshipStatus::Unidirectional { thread_id },
-        )?;
+        crate::transport::send_message(&endpoint, &message).await?;
 
         Ok(())
     }
@@ -235,29 +205,13 @@ impl AsyncStore {
         thread_id: Digest,
         route: Option<&[&str]>,
     ) -> Result<(), Error> {
-        let (transport, tsp_message) = self.inner.seal_message_payload(
-            sender,
-            receiver,
-            None,
-            Payload::AcceptRelationship { thread_id },
-        )?;
+        let (endpoint, message) = self
+            .inner
+            .make_relationship_accept(sender, receiver, thread_id, route)?;
 
-        let (transport, tsp_message) = if let Some(hop_list) = route {
-            self.set_route_for_vid(receiver, hop_list)?;
-            self.resolve_route_and_send(hop_list, &tsp_message)?
-        } else {
-            (transport.to_owned(), tsp_message)
-        };
+        tracing::info!("sending message to {endpoint}");
 
-        crate::transport::send_message(&transport, &tsp_message).await?;
-
-        self.set_relation_status_for_vid(
-            receiver,
-            RelationshipStatus::Bidirectional {
-                thread_id,
-                outstanding_nested_thread_ids: Default::default(),
-            },
-        )?;
+        crate::transport::send_message(&endpoint, &message).await?;
 
         Ok(())
     }
@@ -269,18 +223,11 @@ impl AsyncStore {
         sender: &str,
         receiver: &str,
     ) -> Result<(), Error> {
-        self.set_relation_status_for_vid(receiver, RelationshipStatus::Unrelated)?;
+        let (endpoint, message) = self.inner.make_relationship_cancel(sender, receiver)?;
 
-        let thread_id = Default::default(); // FNORD
+        tracing::info!("sending message to {endpoint}");
 
-        let (transport, message) = self.inner.seal_message_payload(
-            sender,
-            receiver,
-            None,
-            Payload::CancelRelationship { thread_id },
-        )?;
-
-        crate::transport::send_message(&transport, &message).await?;
+        crate::transport::send_message(&endpoint, &message).await?;
 
         Ok(())
     }
@@ -291,26 +238,15 @@ impl AsyncStore {
         parent_sender: &str,
         receiver: &str,
     ) -> Result<OwnedVid, Error> {
-        let sender = self.inner.get_private_vid(parent_sender)?;
-        let receiver = self.inner.get_verified_vid(receiver)?;
+        let ((endpoint, message), vid) = self
+            .inner
+            .make_nested_relationship_request(parent_sender, receiver)?;
 
-        let nested_vid = self.make_propositioning_vid(sender.identifier())?;
+        tracing::info!("sending message to {endpoint}");
 
-        let (tsp_message, thread_id) = crate::crypto::seal_and_hash(
-            &*sender,
-            &*receiver,
-            None,
-            Payload::RequestNestedRelationship {
-                vid: nested_vid.vid().as_ref(),
-            },
-        )?;
+        crate::transport::send_message(&endpoint, &message).await?;
 
-        self.inner
-            .add_nested_thread_id(receiver.identifier(), thread_id)?;
-
-        crate::transport::send_message(receiver.endpoint(), &tsp_message).await?;
-
-        Ok(nested_vid)
+        Ok(vid)
     }
 
     /// Accept a nested relationship with the (nested) VID identified by `nested_receiver`.
@@ -323,47 +259,15 @@ impl AsyncStore {
         nested_receiver: &str,
         thread_id: Digest,
     ) -> Result<OwnedVid, Error> {
-        let nested_vid = self.make_propositioning_vid(parent_sender)?;
-        self.set_relation_for_vid(nested_vid.identifier(), Some(nested_receiver))?;
-        self.set_relation_for_vid(nested_receiver, Some(nested_vid.identifier()))?;
-
-        let receiver_vid = self.inner.get_vid(nested_receiver)?;
-        let parent_receiver = receiver_vid
-            .get_parent_vid()
-            .ok_or(Error::Relationship(format!(
-                "missing parent for {nested_receiver}"
-            )))?;
-
-        let (transport, tsp_message) = self.inner.seal_message_payload(
+        let ((endpoint, message), vid) = self.inner.make_nested_relationship_accept(
             parent_sender,
-            parent_receiver,
-            None,
-            Payload::AcceptNestedRelationship {
-                thread_id,
-                vid: nested_vid.vid().as_ref(),
-                connect_to_vid: nested_receiver.as_ref(),
-            },
-        )?;
-
-        crate::transport::send_message(&transport, &tsp_message).await?;
-
-        self.set_relation_status_for_vid(
             nested_receiver,
-            RelationshipStatus::Bidirectional {
-                thread_id,
-                outstanding_nested_thread_ids: Default::default(),
-            },
+            thread_id,
         )?;
 
-        Ok(nested_vid)
-    }
+        tracing::info!("sending message to {endpoint}");
 
-    fn make_propositioning_vid(&self, parent_vid: &str) -> Result<OwnedVid, Error> {
-        let transport = Url::from_file_path("/dev/null").expect("error generating a URL");
-
-        let vid = OwnedVid::new_did_peer(transport);
-        self.inner.add_private_vid(vid.clone())?;
-        self.set_parent_for_vid(vid.identifier(), Some(parent_vid))?;
+        crate::transport::send_message(&endpoint, &message).await?;
 
         Ok(vid)
     }
@@ -382,18 +286,6 @@ impl AsyncStore {
         crate::transport::send_message(&transport, &message).await?;
 
         Ok(transport)
-    }
-
-    /// Send a message given a route, extracting the next hop and verifying it in the process
-    fn resolve_route_and_send(
-        &self,
-        hop_list: &[&str],
-        opaque_message: &[u8],
-    ) -> Result<(Url, Vec<u8>), Error> {
-        let (next_hop, path) = self.inner.resolve_route(hop_list)?;
-
-        self.inner
-            .forward_routed_message(&next_hop, path, opaque_message)
     }
 
     /// Pass along a in-transit routed TSP `opaque_message` that is not meant for us, given earlier resolved VIDs.

--- a/tsp/src/async_store.rs
+++ b/tsp/src/async_store.rs
@@ -51,7 +51,7 @@ impl AsyncStore {
 
     /// Expose the inner non-async database
     pub fn as_store(&self) -> &Store {
-	&self.inner
+        &self.inner
     }
 
     /// Import the database from serializable default types

--- a/tsp/src/async_store.rs
+++ b/tsp/src/async_store.rs
@@ -49,6 +49,11 @@ impl AsyncStore {
         self.inner.export()
     }
 
+    /// Expose the inner non-async database
+    pub fn as_store(&self) -> &Store {
+	&self.inner
+    }
+
     /// Import the database from serializable default types
     pub fn import(&self, vids: Vec<ExportVid>) -> Result<(), Error> {
         self.inner.import(vids)
@@ -140,7 +145,7 @@ impl AsyncStore {
         receiver: &str,
         nonconfidential_data: Option<&[u8]>,
         message: &[u8],
-    ) -> Result<Vec<u8>, Error> {
+    ) -> Result<(), Error> {
         let (endpoint, message) =
             self.inner
                 .seal_message(sender, receiver, nonconfidential_data, message)?;
@@ -149,7 +154,7 @@ impl AsyncStore {
 
         crate::transport::send_message(&endpoint, &message).await?;
 
-        Ok(message)
+        Ok(())
     }
 
     /// Request a direct relationship with a resolved VID using the TSP

--- a/tsp/src/store.rs
+++ b/tsp/src/store.rs
@@ -399,10 +399,7 @@ impl Store {
     }
 
     /// Resolve a route, extract the next hop and verify the route
-    pub fn resolve_route<'a>(
-        &'a self,
-        hop_list: &'a [&str],
-    ) -> Result<(String, Vec<&'a [u8]>), Error> {
+    fn resolve_route<'a>(&'a self, hop_list: &'a [&str]) -> Result<(String, Vec<&'a [u8]>), Error> {
         let Some(next_hop) = hop_list.first() else {
             return Err(Error::InvalidRoute(
                 "relationship route must not be empty".into(),
@@ -875,9 +872,7 @@ impl Store {
         Ok(())
     }
 
-    //TODO: this should not be `pub` after the refactor that moves logic from async_store
-    //back into the "sync" store
-    pub fn add_nested_thread_id(&self, vid: &str, thread_id: Digest) -> Result<(), Error> {
+    fn add_nested_thread_id(&self, vid: &str, thread_id: Digest) -> Result<(), Error> {
         let mut vids = self.vids.write()?;
         let Some(context) = vids.get_mut(vid) else {
             return Err(Error::MissingVid(vid.into()));


### PR DESCRIPTION
We had too much logic in the `async` functions; this refactors that.