### PR TITLE
remove nonce from REL_CANCEL, add nonce to NEW_NEST_REL

### DIFF
--- a/tsp/src/cesr/packet/fuzzing.rs
+++ b/tsp/src/cesr/packet/fuzzing.rs
@@ -57,6 +57,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
             },
             Variants::DirectRelationAffirm => Payload::DirectRelationAffirm { reply: &DIGEST },
             Variants::NestedRelationProposal => Payload::NestedRelationProposal {
+                nonce: Nonce(Arbitrary::arbitrary(u)?),
                 new_vid: Arbitrary::arbitrary(u)?,
             },
             Variants::NestedRelationAffirm => Payload::NestedRelationAffirm {
@@ -64,10 +65,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
                 new_vid: Arbitrary::arbitrary(u)?,
                 connect_to_vid: Arbitrary::arbitrary(u)?,
             },
-            Variants::RelationshipCancel => Payload::RelationshipCancel {
-                nonce: Nonce(Arbitrary::arbitrary(u)?),
-                reply: &DIGEST,
-            },
+            Variants::RelationshipCancel => Payload::RelationshipCancel { reply: &DIGEST },
         };
 
         Ok(Wrapper(payload))
@@ -97,9 +95,15 @@ impl<'a> PartialEq<Payload<'a, &'a [u8], &'a [u8]>> for Wrapper {
                 Payload::DirectRelationAffirm { reply: r_reply },
             ) => l_reply == r_reply,
             (
-                Payload::NestedRelationProposal { new_vid: l_vid },
-                Payload::NestedRelationProposal { new_vid: r_vid },
-            ) => l_vid == r_vid,
+                Payload::NestedRelationProposal {
+                    new_vid: l_vid,
+                    nonce: l_nonce,
+                },
+                Payload::NestedRelationProposal {
+                    new_vid: r_vid,
+                    nonce: r_nonce,
+                },
+            ) => l_nonce.0 == r_nonce.0 && l_vid == r_vid,
             (
                 Payload::NestedRelationAffirm {
                     reply: l_reply,
@@ -114,15 +118,9 @@ impl<'a> PartialEq<Payload<'a, &'a [u8], &'a [u8]>> for Wrapper {
             ) => l_reply == r_reply && l_vid == r_vid && l_vid2 == r_vid2,
 
             (
-                Payload::RelationshipCancel {
-                    nonce: l_nonce,
-                    reply: l_reply,
-                },
-                Payload::RelationshipCancel {
-                    nonce: r_nonce,
-                    reply: r_reply,
-                },
-            ) => l_nonce.0 == r_nonce.0 && l_reply == r_reply,
+                Payload::RelationshipCancel { reply: l_reply },
+                Payload::RelationshipCancel { reply: r_reply },
+            ) => l_reply == r_reply,
             _ => false,
         }
     }

--- a/tsp/src/crypto/tsp_hpke.rs
+++ b/tsp/src/crypto/tsp_hpke.rs
@@ -44,7 +44,10 @@ where
             crate::cesr::Payload::DirectRelationAffirm { reply: thread_id }
         }
         Payload::RequestNestedRelationship { vid } => {
-            crate::cesr::Payload::NestedRelationProposal { new_vid: vid }
+            crate::cesr::Payload::NestedRelationProposal {
+                nonce: fresh_nonce(&mut csprng),
+                new_vid: vid,
+            }
         }
         Payload::AcceptNestedRelationship {
             ref thread_id,
@@ -55,10 +58,9 @@ where
             new_vid: vid,
             connect_to_vid,
         },
-        Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
-            nonce: fresh_nonce(&mut csprng),
-            reply: thread_id,
-        },
+        Payload::CancelRelationship { ref thread_id } => {
+            crate::cesr::Payload::RelationshipCancel { reply: thread_id }
+        }
         Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(data),
         Payload::RoutedMessage(hops, data) => crate::cesr::Payload::RoutedMessage(hops, data),
     };
@@ -215,7 +217,7 @@ where
         crate::cesr::Payload::DirectRelationAffirm { reply: &thread_id } => {
             Payload::AcceptRelationship { thread_id }
         }
-        crate::cesr::Payload::NestedRelationProposal { new_vid } => {
+        crate::cesr::Payload::NestedRelationProposal { new_vid, .. } => {
             Payload::RequestNestedRelationship { vid: new_vid }
         }
         crate::cesr::Payload::NestedRelationAffirm {

--- a/tsp/src/crypto/tsp_nacl.rs
+++ b/tsp/src/crypto/tsp_nacl.rs
@@ -42,7 +42,10 @@ pub(crate) fn seal(
             crate::cesr::Payload::DirectRelationAffirm { reply: thread_id }
         }
         Payload::RequestNestedRelationship { vid } => {
-            crate::cesr::Payload::NestedRelationProposal { new_vid: vid }
+            crate::cesr::Payload::NestedRelationProposal {
+                nonce: fresh_nonce(&mut csprng),
+                new_vid: vid,
+            }
         }
         Payload::AcceptNestedRelationship {
             ref thread_id,
@@ -53,10 +56,9 @@ pub(crate) fn seal(
             new_vid: vid,
             connect_to_vid,
         },
-        Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
-            nonce: fresh_nonce(&mut csprng),
-            reply: thread_id,
-        },
+        Payload::CancelRelationship { ref thread_id } => {
+            crate::cesr::Payload::RelationshipCancel { reply: thread_id }
+        }
         Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(data),
         Payload::RoutedMessage(hops, data) => crate::cesr::Payload::RoutedMessage(hops, data),
     };
@@ -167,7 +169,7 @@ pub(crate) fn open<'a>(
         crate::cesr::Payload::DirectRelationAffirm { reply: &thread_id } => {
             Payload::AcceptRelationship { thread_id }
         }
-        crate::cesr::Payload::NestedRelationProposal { new_vid } => {
+        crate::cesr::Payload::NestedRelationProposal { new_vid, .. } => {
             Payload::RequestNestedRelationship { vid: new_vid }
         }
         crate::cesr::Payload::NestedRelationAffirm {


### PR DESCRIPTION
The function of Nonce's are to ensure that a `thread_id` is unique; they do not function to ensure that the ciphertext is sufficiently indistinguishable (HPKE/Libsodium will take care of that). So we only need them in the relationship-request messages.