### PR TITLE
remove ROUTE_MSG as a seperate encoding

### DIFF
--- a/fuzz/fuzz_targets/payload_encode_decode.rs
+++ b/fuzz/fuzz_targets/payload_encode_decode.rs
@@ -4,23 +4,16 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: tsp::cesr::fuzzing::Wrapper| {
     let mut buf = Vec::new();
-    tsp::cesr::encode_payload(&data.0, None, &mut buf).unwrap();
+    match tsp::cesr::encode_payload(&data.0, None, &mut buf) {
+        Ok(()) => {
+            let result = tsp::cesr::decode_payload(&buf).unwrap();
 
-    match tsp::cesr::decode_payload(&buf) {
-        Ok(result) => assert_eq!(data, result.payload),
-        Err(e) => {
-            // most of these errors should be unreachable if encoding succeeded
-            match e {
-                tsp::cesr::error::DecodeError::UnexpectedData => todo!(),
-                tsp::cesr::error::DecodeError::UnexpectedMsgType => todo!(),
-                tsp::cesr::error::DecodeError::TrailingGarbage => todo!(),
-                tsp::cesr::error::DecodeError::SignatureError => todo!(),
-                tsp::cesr::error::DecodeError::VidError => todo!(),
-                tsp::cesr::error::DecodeError::VersionMismatch => todo!(),
-                tsp::cesr::error::DecodeError::InvalidCryptoType => todo!(),
-                tsp::cesr::error::DecodeError::InvalidSignatureType => todo!(),
-                tsp::cesr::error::DecodeError::MissingHops => (),
-            }
+            assert_eq!(data, result.payload);
         }
+        Err(tsp::cesr::error::EncodeError::MissingHops) => match &data.0 {
+            tsp::cesr::Payload::RoutedMessage(route, _) => assert!(route.is_empty()),
+            _ => todo!(),
+        },
+        _ => todo!(),
     }
 });

--- a/tsp/src/cesr/error.rs
+++ b/tsp/src/cesr/error.rs
@@ -2,6 +2,7 @@
 #[derive(Clone, Copy, Debug)]
 pub enum EncodeError {
     PayloadTooLarge,
+    MissingHops,
 }
 
 /// An error type to indicate something went wrong with decoding

--- a/tsp/src/cesr/error.rs
+++ b/tsp/src/cesr/error.rs
@@ -14,7 +14,6 @@ pub enum DecodeError {
     SignatureError,
     VidError,
     VersionMismatch,
-    MissingHops,
     InvalidCryptoType,
     InvalidSignatureType,
 }

--- a/tsp/src/cesr/packet.rs
+++ b/tsp/src/cesr/packet.rs
@@ -215,6 +215,9 @@ pub fn encode_payload(
         }
         Payload::RoutedMessage(hops, data) => {
             encode_fixed_data(TSP_TYPECODE, &msgtype::GEN_MSG, output);
+            if hops.is_empty() {
+                return Err(EncodeError::MissingHops);
+            }
             encode_hops(hops, output)?;
             checked_encode_variable_data(TSP_PLAINTEXT, data.as_ref(), output)?;
         }


### PR DESCRIPTION
We don't actually need a seperate CESR encoding for 'routed messages' vs 'direct' messages.

I've tried also removing the distinction in the `cesr::Payload` type but I found that actually removes a bit of semantic typing that I think is actually useful.