### PR TITLE
Add a custom encoding for very large (>50mb) data

### DIFF
--- a/tsp/src/cesr/decode.rs
+++ b/tsp/src/cesr/decode.rs
@@ -193,3 +193,34 @@ pub fn decode_genus(
 
     Some(())
 }
+
+/// Decode variable size data (intended size >=50mb) that doesn't fit in known CESR encodings.
+///
+/// Since CESR has no native type for this, we use the convention that "big data"
+/// Is announced by encoding the size as a 64bit integer (prefix "N"), which is then
+/// followed by the raw data padded in the usual sense for CESR (pre-padding)
+/// This is a temporary encoding, depending on how CESR will address this in the future.
+pub fn decode_large_blob_index(stream: &[u8]) -> Option<std::ops::Range<usize>> {
+    let selector = b'N' - b'A';
+    let size = u64::from_be_bytes(*decode_fixed_data(
+        selector as u32,
+        &mut <_>::clone(&stream),
+    )?) as usize;
+    let padded_size = size.next_multiple_of(3);
+    let lead_bytes = padded_size - size;
+
+    let range = 9 + lead_bytes..9 + padded_size;
+    // make sure the range is valid before returning it
+    stream.get(range.clone())?;
+
+    Some(range)
+}
+
+#[cfg(test)]
+pub fn decode_large_blob<'a>(stream: &mut &'a [u8]) -> Option<&'a [u8]> {
+    let range = decode_large_blob_index(stream)?;
+    let slice = &stream[range.start..range.end];
+    *stream = &stream[range.end..];
+
+    Some(slice)
+}

--- a/tsp/src/cesr/encode.rs
+++ b/tsp/src/cesr/encode.rs
@@ -88,3 +88,20 @@ pub fn encode_genus(
     stream.extend(&u32::to_be_bytes(word1)[1..]);
     stream.extend(&u32::to_be_bytes(word2)[1..]);
 }
+
+/// Encode variable size data (intended size >=50mb) that doesn't fit in known CESR encodings.
+///
+/// Since CESR has no native type for this, we use the convention that "big data"
+/// Is announced by encoding the size as a 64bit integer (prefix "N"), which is then
+/// followed by the raw data padded in the usual sense for CESR (pre-padding)
+/// This is a temporary encoding, depending on how CESR will address this in the future.
+pub fn encode_large_blob(payload: &[u8], stream: &mut impl for<'a> Extend<&'a u8>) {
+    let size = payload.len() as u64;
+    let padded_size = size.next_multiple_of(3);
+    let lead_bytes = padded_size - size;
+
+    let selector = (b'N' - b'A') as u32;
+    encode_fixed_data(selector, &u64::to_be_bytes(size), stream);
+    stream.extend(&<[u8; 2]>::default()[0..lead_bytes as usize]);
+    stream.extend(payload);
+}

--- a/tsp/src/cesr/error.rs
+++ b/tsp/src/cesr/error.rs
@@ -1,7 +1,7 @@
 /// An error type to indicate something went wrong with encoding
 #[derive(Clone, Copy, Debug)]
 pub enum EncodeError {
-    PayloadTooLarge,
+    ExcessiveFieldSize,
     MissingHops,
 }
 

--- a/tsp/src/cesr/mod.rs
+++ b/tsp/src/cesr/mod.rs
@@ -366,4 +366,24 @@ ACTD7NDX93ZGTkZBBuSeSGsAQ7u0hngpNTZTK_Um7rUZGnLRNJvo5oOnnC1J2iBQHuxoq8PyjdT3BHS2
         assert_eq!(decode_indexed_data::<64>(0, slice).unwrap().0, 1);
         assert_eq!(decode_indexed_data::<64>(0, slice).unwrap().0, 2);
     }
+
+    #[test]
+    fn blob_encode_decode() {
+        let mut data = vec![];
+        encode_large_blob(b"Where there is power, there is resistance.", &mut data); // 0 lead bytes
+        encode_large_blob(b"TrustSpanP!", &mut data); // 1 lead byte
+        encode_large_blob(b"I always speak the truth. Not the whole truth, because there's no way, to say it all.", &mut data); // 2 lead bytes
+        encode_variable_data(5, b"TrustSpanP!", &mut data); // not a blob
+        let mut input = &data[..];
+        assert_eq!(
+            decode_large_blob(&mut input).unwrap(),
+            b"Where there is power, there is resistance."
+        );
+        assert_eq!(decode_large_blob(&mut input).unwrap(), b"TrustSpanP!");
+        assert_eq!(
+            decode_large_blob(&mut input).unwrap(),
+            b"I always speak the truth. Not the whole truth, because there's no way, to say it all."
+        );
+        assert!(decode_large_blob(&mut input).is_none());
+    }
 }


### PR DESCRIPTION
Closing #40 

This is achieved by a rather crude encoding which even discards identifier information; but it suffices for a PoC.

Note: this PR builds upon #41 (so that should be merged first), but can be reworked so it fits on current main without it if desired; however, since nested message unpacking involves an allocation+copy, having more than 50mb of data feels like it's a DDoS risk. The actual delta is in [6344a2e](https://github.com/openwallet-foundation-labs/tsp/pull/42/commits/6344a2e20f7e69a81276b61fe938e60f21af334b)