### PR TITLE
Remove the need for any data copies in the async interface

### DIFF
--- a/tsp-javascript/src/lib.rs
+++ b/tsp-javascript/src/lib.rs
@@ -299,8 +299,8 @@ pub enum ReceivedTspMessageVariant {
     Referral = 6,
 }
 
-impl From<&tsp::ReceivedTspMessage> for ReceivedTspMessageVariant {
-    fn from(value: &tsp::ReceivedTspMessage) -> Self {
+impl<T> From<&tsp::ReceivedTspMessage<T>> for ReceivedTspMessageVariant {
+    fn from(value: &tsp::ReceivedTspMessage<T>) -> Self {
         match value {
             tsp::ReceivedTspMessage::GenericMessage { .. } => Self::GenericMessage,
             tsp::ReceivedTspMessage::RequestRelationship { .. } => Self::RequestRelationship,
@@ -421,8 +421,8 @@ impl FlatReceivedTspMessage {
     }
 }
 
-impl From<tsp::ReceivedTspMessage> for FlatReceivedTspMessage {
-    fn from(value: tsp::ReceivedTspMessage) -> Self {
+impl From<tsp::ReceivedTspMessage<Vec<u8>>> for FlatReceivedTspMessage {
+    fn from(value: tsp::ReceivedTspMessage<Vec<u8>>) -> Self {
         let variant = ReceivedTspMessageVariant::from(&value);
 
         let mut this = FlatReceivedTspMessage {

--- a/tsp-python/src/lib.rs
+++ b/tsp-python/src/lib.rs
@@ -220,8 +220,8 @@ enum ReceivedTspMessageVariant {
     Referral,
 }
 
-impl From<&tsp::ReceivedTspMessage> for ReceivedTspMessageVariant {
-    fn from(value: &tsp::ReceivedTspMessage) -> Self {
+impl<T> From<&tsp::ReceivedTspMessage<T>> for ReceivedTspMessageVariant {
+    fn from(value: &tsp::ReceivedTspMessage<T>) -> Self {
         match value {
             tsp::ReceivedTspMessage::GenericMessage { .. } => Self::GenericMessage,
             tsp::ReceivedTspMessage::RequestRelationship { .. } => Self::RequestRelationship,
@@ -282,8 +282,8 @@ impl FlatReceivedTspMessage {
     }
 }
 
-impl From<tsp::ReceivedTspMessage> for FlatReceivedTspMessage {
-    fn from(value: tsp::ReceivedTspMessage) -> Self {
+impl From<tsp::ReceivedTspMessage<Vec<u8>>> for FlatReceivedTspMessage {
+    fn from(value: tsp::ReceivedTspMessage<Vec<u8>>) -> Self {
         let variant = ReceivedTspMessageVariant::from(&value);
 
         let mut this = FlatReceivedTspMessage {

--- a/tsp/Cargo.toml
+++ b/tsp/Cargo.toml
@@ -37,6 +37,7 @@ async = [
 ]
 resolve = ["serialize", "dep:reqwest"]
 serialize = ["dep:serde", "dep:serde_json", "dep:serde_with", "dep:bs58"]
+lazy-data = []
 
 [dependencies]
 # generic

--- a/tsp/src/async_store.rs
+++ b/tsp/src/async_store.rs
@@ -386,6 +386,8 @@ impl AsyncStore {
                         };
 
                         #[cfg(feature = "lazy-data")]
+                        let m = std::sync::Arc::new(m);
+                        #[cfg(feature = "lazy-data")]
                         let opened_msg = opened_msg.map(|msg| {
                             msg.map(|range| crate::owned_slice::OwnedSlice(m.clone(), range))
                         });

--- a/tsp/src/definitions/conversions.rs
+++ b/tsp/src/definitions/conversions.rs
@@ -1,11 +1,11 @@
 use super::ReceivedTspMessage;
 
 // Rust, there has to be a better way.
-impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
+impl<T> ReceivedTspMessage<T> {
     /// Turn a ReceivedTspMessage that contains references to borrowed data into a freestanding version;
     /// if it already was a freestanding version, nothing happens.
     // We only offer this version as the 'public' version, since the second can be confusing
-    pub fn into_owned(self) -> ReceivedTspMessage
+    pub fn into_owned(self) -> ReceivedTspMessage<Vec<u8>>
     where
         T: Into<Vec<u8>>,
     {
@@ -14,7 +14,7 @@ impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
 
     /// Convert the data representation used by a ReceivedTspMessage; we are careful with the payload data
     /// since it may be very large.
-    pub(crate) fn map<U: AsRef<[u8]>>(self, f: impl Fn(T) -> U) -> ReceivedTspMessage<U> {
+    pub(crate) fn map<U>(self, f: impl Fn(T) -> U) -> ReceivedTspMessage<U> {
         use ReceivedTspMessage::*;
         match self {
             GenericMessage {

--- a/tsp/src/definitions/mod.rs
+++ b/tsp/src/definitions/mod.rs
@@ -65,8 +65,13 @@ pub enum RelationshipStatus {
     Unrelated,
 }
 
+#[cfg(not(feature = "lazy-data"))]
+type DefaultPayload = Vec<u8>;
+#[cfg(feature = "lazy-data")]
+type DefaultPayload = crate::owned_slice::OwnedSlice<Vec<u8>>;
+
 #[derive(Debug)]
-pub enum ReceivedTspMessage<Data: AsRef<[u8]> = Vec<u8>> {
+pub enum ReceivedTspMessage<Data = DefaultPayload> {
     GenericMessage {
         sender: String,
         nonconfidential_data: Option<Data>,

--- a/tsp/src/definitions/mod.rs
+++ b/tsp/src/definitions/mod.rs
@@ -68,7 +68,7 @@ pub enum RelationshipStatus {
 #[cfg(not(feature = "lazy-data"))]
 type DefaultPayload = Vec<u8>;
 #[cfg(feature = "lazy-data")]
-type DefaultPayload = crate::owned_slice::OwnedSlice<Vec<u8>>;
+type DefaultPayload = crate::owned_slice::OwnedSlice<std::sync::Arc<Vec<u8>>>;
 
 #[derive(Debug)]
 pub enum ReceivedTspMessage<Data = DefaultPayload> {

--- a/tsp/src/lib.rs
+++ b/tsp/src/lib.rs
@@ -113,3 +113,6 @@ pub use definitions::{Payload, PrivateVid, ReceivedTspMessage, RelationshipStatu
 pub use error::Error;
 pub use store::Store;
 pub use vid::{ExportVid, OwnedVid, Vid};
+
+#[cfg(feature = "lazy-data")]
+mod owned_slice;

--- a/tsp/src/owned_slice.rs
+++ b/tsp/src/owned_slice.rs
@@ -8,6 +8,14 @@ impl<Inner: 'static + ?Sized + AsRef<[u8]>, T: Deref<Target = Inner>> Deref for 
     }
 }
 
+impl<Inner: 'static + ?Sized + AsRef<[u8]>, T: Deref<Target = Inner>> AsRef<[u8]>
+    for OwnedSlice<T>
+{
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
 // this function feels strange, but it is completely safe Rust
 // requirement for not panicking: "y" is a slice from "x"
 pub fn to_range(x: std::ops::Range<*const u8>, y: &[u8]) -> std::ops::Range<usize> {

--- a/tsp/src/owned_slice.rs
+++ b/tsp/src/owned_slice.rs
@@ -1,0 +1,41 @@
+#[derive(Debug, Clone)]
+pub struct OwnedSlice<T>(pub(super) T, pub(super) std::ops::Range<usize>);
+
+impl<Inner: 'static + ?Sized + AsRef<[u8]>, T: Deref<Target = Inner>> Deref for OwnedSlice<T> {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.0.as_ref()[self.1.clone()]
+    }
+}
+
+// this function feels strange, but it is completely safe Rust
+// requirement for not panicking: "y" is a slice from "x"
+pub fn to_range(x: std::ops::Range<*const u8>, y: &[u8]) -> std::ops::Range<usize> {
+    let (x_begin, x_end) = (x.start as usize, x.end as usize);
+    let y_begin = y.as_ptr() as usize;
+    if y_begin < x_begin || y_begin + y.len() > x_end {
+        panic!("attempt to obtain the range of an improper subslice")
+    }
+    let offset = y_begin - x_begin;
+
+    offset..offset + y.len()
+}
+
+use std::ops::Deref;
+
+// allow for two layers of dereferencing
+impl<Inner: 'static + ?Sized + AsRef<[u8]>, T: Deref<Target = Inner>, B: AsRef<[u8]>> PartialEq<B>
+    for OwnedSlice<T>
+{
+    fn eq(&self, other: &B) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl<Inner: 'static + ?Sized + AsRef<[u8]>, T: Deref<Target = Inner>> PartialEq<OwnedSlice<T>>
+    for &[u8]
+{
+    fn eq(&self, other: &OwnedSlice<T>) -> bool {
+        self == &other.as_ref()
+    }
+}


### PR DESCRIPTION
Hidden behind the feature flag `lazy-data`; builds upon and requires #41 