### PR TITLE
Feature flag fix

### DIFF
--- a/tsp/Cargo.toml
+++ b/tsp/Cargo.toml
@@ -36,7 +36,7 @@ async = [
     "dep:quinn",
 ]
 resolve = ["serialize", "dep:reqwest"]
-serialize = ["dep:serde", "dep:serde_json", "dep:serde_with", "dep:bs58"]
+serialize = ["dep:serde", "dep:serde_with"]
 
 [dependencies]
 # generic
@@ -71,9 +71,9 @@ quinn = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 # serialize
 serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = false }
 serde_with = { workspace = true, optional = true }
-bs58 = { workspace = true, optional = true }
+bs58 = { workspace = true, optional = false }
 # fuzzing
 arbitrary = { workspace = true, optional = true }
 

--- a/tsp/src/vid/did/mod.rs
+++ b/tsp/src/vid/did/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) const SCHEME: &str = "did";
 
 pub(crate) mod peer;
+
+#[cfg(feature = "resolve")]
 pub(crate) mod web;

--- a/tsp/src/vid/mod.rs
+++ b/tsp/src/vid/mod.rs
@@ -12,12 +12,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serialize")]
 pub mod deserialize;
 
-#[cfg(feature = "resolve")]
 pub mod did;
 
 pub mod error;
 
-#[cfg(feature = "resolve")]
 pub mod resolve;
 
 #[cfg(feature = "resolve")]
@@ -138,7 +136,6 @@ impl OwnedVid {
         }
     }
 
-    #[cfg(feature = "resolve")]
     pub fn new_did_peer(transport: Url) -> OwnedVid {
         let (sigkey, public_sigkey) = crate::crypto::gen_sign_keypair();
         let (enckey, public_enckey) = crate::crypto::gen_encrypt_keypair();

--- a/tsp/src/vid/resolve.rs
+++ b/tsp/src/vid/resolve.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::Vid;
 
+#[cfg(feature = "resolve")]
 /// Resolve and verify the vid identified by `id`, by using online and offline methods
 pub async fn verify_vid(id: &str) -> Result<Vid, VidError> {
     let parts = id.split(':').collect::<Vec<&str>>();


### PR DESCRIPTION
TSP wouldn't compile without feature flags; this fixes this by making `resolve`  really optional and enabling `bs58` and `serde_json` by default even if `serialize` isn't specified -- these two crates are necessary for dealing with `did:peer` which is essential for a complete TSP operation.

Actually maybe we should make `serialize` mandatory anyway.