### PR TITLE
Examples stopped working due to persistence

### DIFF
--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -9,7 +9,6 @@ randuser() {
 
 cointoss() {
     (( $RANDOM % 2 ))
-    true
 }
 
 echo "---- cleanup the database"

--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -1,27 +1,42 @@
 #!/bin/bash
 
 # install using
-#cargo install --path .
+cargo install --path .
+
+randuser() {
+    head -c4 /dev/urandom | shasum | head -c8
+}
+
+cointoss() {
+    (( $RANDOM % 2 ))
+    true
+}
 
 echo "---- cleanup the database"
 rm -f marlon.sqlite marc.sqlite p.sqlite q.sqlite
 
-echo "---- create a new sender identity"
-tsp --database marlon create --alias marlon marlon
+echo "---- create sender, receiver, and intermediaries"
 
-echo "---- create a new receiver identity"
-tsp --database marc create --alias marc marc
+for entity in marc marlon p q q2; do
+    if cointoss; then
+	echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:web"
+	tsp --database "${entity%%[0-9]*}" create --alias $entity `randuser`
+    else
+	echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:peer"
+	tsp --database "${entity%%[0-9]*}" create-peer $entity
+    fi
+done
+DID_MARLON=$(tsp --database marlon print marlon)
+DID_P=$(tsp --database p print p)
+DID_Q=$(tsp --database q print q)
+DID_Q2=$(tsp --database q print q2)
+DID_MARC=$(tsp --database marc print marc)
 
 echo "---- verify the address of the receiver"
-tsp --database marlon verify --alias marc did:web:tsp-test.org:user:marc
-
-echo "---- create intermediaries"
-tsp --database p create --alias p p
-tsp --database q create --alias q q
-tsp --database q create --alias q2 q2
+tsp --database marlon verify --alias marc "$DID_MARC"
 
 echo "---- establish outer relation a<->p"
-tsp --database marlon verify --alias p did:web:tsp-test.org:user:p
+tsp --database marlon verify --alias p "$DID_P"
 
 sleep 2 && tsp --database marlon request -s marlon -r p &
 received=$(tsp --yes --database p receive --one p)
@@ -33,7 +48,7 @@ sleep 2 && tsp --database p accept -s p -r marlon --thread-id "$thread_id" &
 tsp --database marlon receive --one marlon
 
 echo "---- establish outer relation p<->q"
-tsp --database q verify --alias p did:web:tsp-test.org:user:p
+tsp --database q verify --alias p "$DID_P"
 
 sleep 2 && tsp --database q request -s q -r p &
 received=$(tsp --yes --database p receive --one p)
@@ -45,7 +60,7 @@ sleep 2 && tsp --database p accept -s p -r q --thread-id "$thread_id" &
 tsp --database q receive --one q
 
 echo "---- establish outer relation q2<->b"
-tsp --database marc verify --alias q2 did:web:tsp-test.org:user:q2
+tsp --database marc verify --alias q2 "$DID_Q2"
 
 sleep 2 && tsp --database marc request -s marc -r q2 &
 received=$(tsp --yes --database q receive --one q2)
@@ -57,12 +72,12 @@ sleep 2 && tsp --database q accept -s q2 -r marc --thread-id "$thread_id" &
 tsp --database marc receive --one marc
 
 echo "---- setup the route"
-tsp --database marlon set-route marc did:web:tsp-test.org:user:p,did:web:tsp-test.org:user:q,did:web:tsp-test.org:user:q2
+tsp --database marlon set-route marc "p,$DID_Q,$DID_Q2"
 tsp --database marlon set-relation marc marlon
 tsp --database marlon set-relation p marlon
 
-tsp --database p set-relation did:web:tsp-test.org:user:q p
-tsp --database q set-relation did:web:tsp-test.org:user:q2 did:web:tsp-test.org:user:marc
+tsp --database p set-relation q p
+tsp --database q set-relation q2 marc
 
 echo "---- send a routed message"
 

--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -16,13 +16,19 @@ rm -f marlon.sqlite marc.sqlite p.sqlite q.sqlite
 
 echo "---- create sender, receiver, and intermediaries"
 
-for entity in marc marlon p q q2; do
+for entity in marlon p q q2 marc; do
     if cointoss; then
 	echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:web"
 	tsp --database "${entity%%[0-9]*}" create --alias $entity `randuser`
     else
-	echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:peer"
-	tsp --database "${entity%%[0-9]*}" create-peer $entity
+	if cointoss; then
+	    echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:peer with https:// transport"
+	    tsp --database "${entity%%[0-9]*}" create-peer $entity
+	else
+	    echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:peer with local transport"
+	    port=$((RANDOM % 1000 + 1000))
+	    tsp --database "${entity%%[0-9]*}" create-peer --tcp localhost:$port $entity
+	fi
     fi
 done
 DID_MARLON=$(tsp --database marlon print marlon)

--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -14,7 +14,8 @@ cointoss() {
 echo "---- cleanup the database"
 rm -f marlon.sqlite marc.sqlite p.sqlite q.sqlite
 
-echo "---- create sender, receiver, and intermediaries"
+echo
+echo "==== create sender, receiver, and intermediaries"
 
 for entity in marlon p q q2 marc; do
     if cointoss; then
@@ -26,7 +27,7 @@ for entity in marlon p q q2 marc; do
 	    tsp --database "${entity%%[0-9]*}" create-peer $entity
 	else
 	    echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:peer with local transport"
-	    port=$((RANDOM % 1000 + 1000))
+	    port=$((${port:-1000} + RANDOM % 1000))
 	    tsp --database "${entity%%[0-9]*}" create-peer --tcp localhost:$port $entity
 	fi
     fi
@@ -36,6 +37,10 @@ DID_P=$(tsp --database p print p)
 DID_Q=$(tsp --database q print q)
 DID_Q2=$(tsp --database q print q2)
 DID_MARC=$(tsp --database marc print marc)
+
+sleep 5
+echo
+echo "==== let the nodes introduce each other"
 
 echo "---- verify the address of the receiver"
 tsp --database marlon verify --alias marc "$DID_MARC"
@@ -84,7 +89,10 @@ tsp --database marlon set-relation p marlon
 tsp --database p set-relation q p
 tsp --database q set-relation q2 marc
 
-echo "---- send a routed message"
+sleep 5
+
+echo
+echo "==== send a routed message"
 
 sleep 2 && echo -n "Indirect Message from Marlon to Marc was received!" | tsp --database marlon send -s marlon -r marc &
 tsp --yes --database p receive --one p &

--- a/examples/cli-test-direct.sh
+++ b/examples/cli-test-direct.sh
@@ -3,20 +3,27 @@
 # install using
 cargo install --path .
 
+randuser() {
+    head -c4 /dev/urandom | shasum | head -c8
+}
+
 echo "---- cleanup the database"
 rm -f marlon.sqlite marc.sqlite
 
 echo "---- create a new sender identity"
-tsp --database marlon create --alias marlon marlon
+tsp --database marlon create --alias marlon `randuser`
 
 echo "---- create a new receiver identity"
-tsp --database marc create --alias marc marc
+tsp --database marc create --alias marc `randuser`
+
+DID_MARC=$(tsp --database marc print marc)
+DID_MARLON=$(tsp --database marlon print marlon)
 
 echo "---- verify the address of the receiver"
-tsp --database marlon verify --alias marc did:web:tsp-test.org:user:marc
+tsp --database marlon verify --alias marc "$DID_MARC"
 
 echo "---- verify the address of the sender"
-tsp --database marc verify --alias marlon did:web:tsp-test.org:user:marlon
+tsp --database marc verify --alias marlon "$DID_MARLON"
 
 echo "---- wait 2 seconds and then send a message to the receiver"
 sleep 2 && echo "Oh hello Marc" | tsp --database marlon send -s marlon -r marc &

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -1,4 +1,4 @@
-use base64ct::{Base64UrlUnpadded, Encoding};
+use base64ct::{Base64Unpadded, Base64UrlUnpadded, Encoding};
 use clap::{Parser, Subcommand};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -456,7 +456,7 @@ async fn run() -> Result<(), Error> {
                             route: _,
                             nested_vid: None,
                         } => {
-                            let thread_id = Base64UrlUnpadded::encode_string(&thread_id);
+                            let thread_id = Base64Unpadded::encode_string(&thread_id);
                             info!(
                                 "received relationship request from {sender}, thread-id '{thread_id}'",
                             );
@@ -474,7 +474,7 @@ async fn run() -> Result<(), Error> {
                             route: _,
                             nested_vid: Some(vid),
                         } => {
-                            let thread_id = Base64UrlUnpadded::encode_string(&thread_id);
+                            let thread_id = Base64Unpadded::encode_string(&thread_id);
                             info!("received nested relationship request from '{vid}' (new identity for {sender}), thread-id '{thread_id}'");
                             println!("{vid}\t{thread_id}");
                         }
@@ -639,7 +639,7 @@ async fn run() -> Result<(), Error> {
             let receiver_vid = aliases.get(&receiver_vid).unwrap_or(&receiver_vid);
 
             let mut digest: [u8; 32] = Default::default();
-            Base64UrlUnpadded::decode(&thread_id, &mut digest).unwrap();
+            Base64Unpadded::decode(&thread_id, &mut digest).unwrap();
 
             if nested {
                 match vid_database

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -285,7 +285,20 @@ async fn route_message(State(state): State<Arc<AppState>>, body: Bytes) -> Respo
     let sender = String::from_utf8_lossy(sender).to_string();
     let receiver = String::from_utf8_lossy(receiver).to_string();
 
-    tracing::debug!("forwarded message {sender} {receiver}");
+    // translate received identifier into the transport; either because it is a
+    // known user or because it is a did:peer. note that this allows "snooping" messages
+    // that are not intended for you --- but that will allow to build interesting demo cases
+    // since the unintended recipient cannot read the message: the security of TSP is not based
+    // on security of the transport layer.
+    let receiver = if let Some(receiver) = state.db.read().await.get(&receiver) {
+        receiver.vid.endpoint().to_string()
+    } else if let Ok(vid) = tsp::vid::resolve::verify_vid_offline(&receiver) {
+        vid.endpoint().to_string()
+    } else {
+        return (StatusCode::BAD_REQUEST, "unknown receiver").into_response();
+    };
+
+    tracing::debug!("forwarded message from {sender} to endpoint {receiver}");
 
     // insert message in queue
     let _ = state.tx.send((sender, receiver, body.into()));
@@ -350,7 +363,7 @@ async fn websocket_user_handler(
     Path(name): Path<String>,
 ) -> impl IntoResponse {
     let mut messages_rx = state.tx.subscribe();
-    let current = format!("did:web:{DOMAIN}:user:{name}");
+    let current = format!("https://{DOMAIN}/user/{name}");
 
     tracing::debug!("new websocket connection for {current}");
 


### PR DESCRIPTION
This fixes the examples:

* for demo's and tests with `did:web`, a random ID is chosen (this code works on both MacOS and Linux)

* `did:peer` transport was broken in the demo-server; basically the http:// transport in the demo-server assumed everybody was using `did:web`; that was easy to fix by making the actual endpoint the determining factor for whether a websocket should receive a message or not.