### PR TITLE
Deduce relation status

### DIFF
--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -83,7 +83,6 @@ tsp --database marc receive --one marc
 
 echo "---- setup the route"
 tsp --database marlon set-route marc "p,$DID_Q,$DID_Q2"
-tsp --database marlon set-relation marc marlon
 
 tsp --database q set-relation q2 marc
 

--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -17,7 +17,14 @@ rm -f marlon.sqlite marc.sqlite p.sqlite q.sqlite
 echo
 echo "==== create sender, receiver, and intermediaries"
 
-for entity in marlon p q q2 marc; do
+if cointoss; then
+    echo "------ drop off vid (q2) will be a public vid"
+    Q2=q2
+else
+    echo "------ drop off vid will be a nested vid (out-of-band)"
+fi
+
+for entity in marlon p q $Q2 marc; do
     if cointoss; then
 	echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:web"
 	tsp --database "${entity%%[0-9]*}" create --alias $entity `randuser`
@@ -27,7 +34,7 @@ for entity in marlon p q q2 marc; do
 	    tsp --database "${entity%%[0-9]*}" create-peer $entity
 	else
 	    echo "------ $entity (identifier for ${entity%%[0-9]*}) uses did:peer with local transport"
-	    port=$((${port:-1000} + RANDOM % 1000))
+	    port=$((${port:-1024} + RANDOM % 1000))
 	    tsp --database "${entity%%[0-9]*}" create-peer --tcp localhost:$port $entity
 	fi
     fi
@@ -35,9 +42,10 @@ done
 DID_MARLON=$(tsp --database marlon print marlon)
 DID_P=$(tsp --database p print p)
 DID_Q=$(tsp --database q print q)
-DID_Q2=$(tsp --database q print q2)
+[ "$Q2" ] && DID_Q2=$(tsp --database q print q2)
 DID_MARC=$(tsp --database marc print marc)
 
+wait
 sleep 5
 echo
 echo "==== let the nodes introduce each other"
@@ -69,25 +77,49 @@ tsp --database p set-alias q "$vid"
 sleep 2 && tsp --database p accept -s p -r q --thread-id "$thread_id" &
 tsp --database q receive --one q
 
-echo "---- establish outer relation q2<->b"
-tsp --database marc verify --alias q2 "$DID_Q2"
+if [ "$Q2" ]; then
+    echo "---- establish outer relation q2<->b"
+    tsp --database marc verify --alias q2 "$DID_Q2"
 
-sleep 2 && tsp --database marc request -s marc -r q2 &
-received=$(tsp --yes --database q receive --one q2)
-vid=$(echo "$received" | cut -f1)
-thread_id=$(echo "$received" | cut -f2)
-tsp --database q set-alias marc "$vid"
+    sleep 2 && tsp --database marc request -s marc -r q2 &
+    received=$(tsp --yes --database q receive --one q2)
+    vid=$(echo "$received" | cut -f1)
+    thread_id=$(echo "$received" | cut -f2)
+    tsp --database q set-alias marc "$vid"
 
-sleep 2 && tsp --database q accept -s q2 -r marc --thread-id "$thread_id" &
-tsp --database marc receive --one marc
+    sleep 2 && tsp --database q accept -s q2 -r marc --thread-id "$thread_id" &
+    tsp --database marc receive --one marc
+
+    tsp --database q set-relation q2 marc
+else
+    echo "---- establish outer relation q<->b"
+    tsp --database marc verify --alias q "$DID_Q"
+
+    sleep 2 && tsp --database marc request -s marc -r q &
+    received=$(tsp --yes --database q receive --one q)
+    vid=$(echo "$received" | cut -f1)
+    thread_id=$(echo "$received" | cut -f2)
+    tsp --database q set-alias marc "$vid"
+
+    sleep 2 && tsp --database q accept -s q -r marc --thread-id "$thread_id" &
+    tsp --database marc receive --one marc
+
+    echo "---- establish nested relation q<->b"
+
+    sleep 2 && tsp --database marc request --nested -s marc -r q > /dev/null &
+    received=$(tsp --database q receive --one q)
+    nested_marc=$(echo "$received" | cut -f1)
+    thread_id=$(echo "$received" | cut -f2)
+
+    sleep 2 && tsp --database q accept --nested -s q -r "$nested_marc" --thread-id "$thread_id" > /tmp/vid &
+    DID_Q2=$(tsp --database marc receive --one marc)
+fi
 
 echo "---- setup the route"
 tsp --database marlon set-route marc "p,$DID_Q,$DID_Q2"
 
-tsp --database q set-relation q2 marc
-
+wait
 sleep 5
-
 echo
 echo "==== send a routed message"
 

--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -85,7 +85,6 @@ echo "---- setup the route"
 tsp --database marlon set-route marc "p,$DID_Q,$DID_Q2"
 tsp --database marlon set-relation marc marlon
 
-tsp --database p set-relation q p
 tsp --database q set-relation q2 marc
 
 sleep 5

--- a/examples/cli-demo-routed.sh
+++ b/examples/cli-demo-routed.sh
@@ -84,7 +84,6 @@ tsp --database marc receive --one marc
 echo "---- setup the route"
 tsp --database marlon set-route marc "p,$DID_Q,$DID_Q2"
 tsp --database marlon set-relation marc marlon
-tsp --database marlon set-relation p marlon
 
 tsp --database p set-relation q p
 tsp --database q set-relation q2 marc


### PR DESCRIPTION
In the routing demo, the relation status had to be set up by hand. This fixes that.

The exception is the "drop off" VID (the last hop in the list). Since this is a VID of the final sender, a unique relation with the recipient **has to be set up** in some way:

- Explicitly (by using `tsp set-relation`)
- By making the final VID belong to a nested relationship (in which case it is by definition uniquely tied to another VID)

