### PR TITLE
Changes with respect to string owning vs borrowing in the SDK API

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -275,7 +275,7 @@ async fn run() -> Result<(), Error> {
                 aliases.insert(alias.clone(), vid.clone());
             }
 
-            vid_database.set_relation_for_vid(&vid, sender.as_deref())?;
+            vid_database.set_relation_for_vid(&vid, sender)?;
 
             write_database(&vault, &vid_database, aliases).await?;
 
@@ -346,7 +346,7 @@ async fn run() -> Result<(), Error> {
             let vid = aliases.get(&vid).unwrap_or(&vid);
             let other_vid = aliases.get(&other_vid).unwrap_or(&other_vid);
 
-            vid_database.set_parent_for_vid(vid, Some(other_vid))?;
+            vid_database.set_parent_for_vid(vid, Some(other_vid.to_string()))?;
 
             info!("{vid} is now a child of {other_vid}");
 
@@ -376,7 +376,7 @@ async fn run() -> Result<(), Error> {
             let vid = aliases.get(&vid).cloned().unwrap_or(vid);
             let other_vid = aliases.get(&other_vid).cloned().unwrap_or(other_vid);
 
-            vid_database.set_relation_for_vid(&vid, Some(&other_vid))?;
+            vid_database.set_relation_for_vid(&vid, Some(other_vid.clone()))?;
             write_database(&vault, &vid_database, aliases).await?;
 
             info!("{vid} has relation to {other_vid}");

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -138,7 +138,7 @@ async fn main() {
 
         db.set_relation_for_vid(
             &format!("did:web:did.{domain}:user:q"),
-            Some(&format!("did:web:did.{domain}:user:p")),
+            Some(format!("did:web:did.{domain}:user:p")),
         )
         .unwrap();
 
@@ -160,7 +160,7 @@ async fn main() {
             .unwrap();
         db.set_relation_for_vid(
             &format!("did:web:did.{domain}:user:q"),
-            Some(&format!("did:web:did.{domain}:user:b")),
+            Some(format!("did:web:did.{domain}:user:b")),
         )
         .unwrap();
 

--- a/tsp-javascript/src/lib.rs
+++ b/tsp-javascript/src/lib.rs
@@ -61,7 +61,7 @@ impl Store {
         relation_vid: Option<String>,
     ) -> Result<(), Error> {
         self.0
-            .set_relation_for_vid(&vid, relation_vid.as_deref())
+            .set_relation_for_vid(&vid, relation_vid)
             .map_err(Error)
     }
 

--- a/tsp-python/src/lib.rs
+++ b/tsp-python/src/lib.rs
@@ -36,7 +36,7 @@ impl Store {
 
     fn set_relation_for_vid(&self, vid: String, relation_vid: Option<String>) -> PyResult<()> {
         self.0
-            .set_relation_for_vid(&vid, relation_vid.as_deref())
+            .set_relation_for_vid(&vid, relation_vid)
             .map_err(py_exception)
     }
 

--- a/tsp/src/async_store.rs
+++ b/tsp/src/async_store.rs
@@ -60,7 +60,11 @@ impl AsyncStore {
     }
 
     /// Adds a relation to an already existing vid, making it a nested Vid
-    pub fn set_relation_for_vid(&self, vid: &str, relation_vid: Option<&str>) -> Result<(), Error> {
+    pub fn set_relation_for_vid(
+        &self,
+        vid: &str,
+        relation_vid: Option<String>,
+    ) -> Result<(), Error> {
         self.inner.set_relation_for_vid(vid, relation_vid)
     }
 
@@ -70,7 +74,7 @@ impl AsyncStore {
     }
 
     /// Sets the parent for a VID. This is used to create a nested message.
-    pub fn set_parent_for_vid(&self, vid: &str, parent: Option<&str>) -> Result<(), Error> {
+    pub fn set_parent_for_vid(&self, vid: &str, parent: Option<String>) -> Result<(), Error> {
         self.inner.set_parent_for_vid(vid, parent)
     }
 

--- a/tsp/src/test.rs
+++ b/tsp/src/test.rs
@@ -197,7 +197,10 @@ async fn test_nested_mode() {
     let nested_bob_vid = OwnedVid::new_did_peer(bob_vid.endpoint().clone());
     bob_db.add_private_vid(nested_bob_vid.clone()).unwrap();
     bob_db
-        .set_parent_for_vid(nested_bob_vid.identifier(), Some(bob_vid.identifier()))
+        .set_parent_for_vid(
+            nested_bob_vid.identifier(),
+            Some(bob_vid.identifier().into()),
+        )
         .unwrap();
 
     // receive a messages on inner vid
@@ -206,19 +209,25 @@ async fn test_nested_mode() {
     let nested_alice_vid = OwnedVid::new_did_peer(alice_vid.endpoint().clone());
     alice_db.add_private_vid(nested_alice_vid.clone()).unwrap();
     alice_db
-        .set_parent_for_vid(nested_alice_vid.identifier(), Some(alice_vid.identifier()))
+        .set_parent_for_vid(
+            nested_alice_vid.identifier(),
+            Some(alice_vid.identifier().into()),
+        )
         .unwrap();
     alice_db
         .verify_vid(nested_bob_vid.identifier())
         .await
         .unwrap();
     alice_db
-        .set_parent_for_vid(nested_bob_vid.identifier(), Some(bob_vid.identifier()))
+        .set_parent_for_vid(
+            nested_bob_vid.identifier(),
+            Some(bob_vid.identifier().into()),
+        )
         .unwrap();
     alice_db
         .set_relation_for_vid(
             nested_bob_vid.identifier(),
-            Some(nested_alice_vid.identifier()),
+            Some(nested_alice_vid.identifier().into()),
         )
         .unwrap();
 
@@ -227,7 +236,10 @@ async fn test_nested_mode() {
         .await
         .unwrap();
     bob_db
-        .set_parent_for_vid(nested_alice_vid.identifier(), Some(alice_vid.identifier()))
+        .set_parent_for_vid(
+            nested_alice_vid.identifier(),
+            Some(alice_vid.identifier().into()),
+        )
         .unwrap();
 
     // send a message using inner vid
@@ -299,13 +311,13 @@ async fn test_routed_mode() {
     alice_db
         .set_relation_for_vid(
             "did:web:did.tsp-test.org:user:bob",
-            Some("did:web:did.tsp-test.org:user:alice"),
+            Some("did:web:did.tsp-test.org:user:alice".into()),
         )
         .unwrap();
     alice_db
         .set_relation_for_vid(
             "did:web:did.tsp-test.org:user:alice",
-            Some("did:web:did.tsp-test.org:user:alice"),
+            Some("did:web:did.tsp-test.org:user:alice".into()),
         )
         .unwrap();
 
@@ -345,7 +357,7 @@ async fn test_routed_mode() {
     bob_db
         .set_relation_for_vid(
             "did:web:did.tsp-test.org:user:alice",
-            Some("did:web:did.tsp-test.org:user:bob"),
+            Some("did:web:did.tsp-test.org:user:bob".into()),
         )
         .unwrap();
 
@@ -410,7 +422,7 @@ async fn test_routed_mode() {
     bob_db
         .set_relation_for_vid(
             "did:web:did.tsp-test.org:user:bob",
-            Some("did:web:did.tsp-test.org:user:alice"),
+            Some("did:web:did.tsp-test.org:user:alice".into()),
         )
         .unwrap();
     bob_db


### PR DESCRIPTION
Downsides of this PR: it makes it less predictable when an argument is a `&str` and when it is a `String`. Upside: if the data is already 'owned', it saves one re-allocation (but VID's shouldn't be terribly large, so that's no real gain)

I don't know if I'm very enthusiastic about this change myself.