### PR TITLE
Add crypto/signature type data to message parts

### DIFF
--- a/examples/script.js
+++ b/examples/script.js
@@ -150,12 +150,16 @@ function renderMessage(message) {
             ? '<span class="badge bg-success float-end">verified</span>'
             : '<span class="badge bg-danger float-end">unverified</span>'
           ) : ''}
+          ${(part === 'sender' || part === 'signature')
+            ? `<span style="margin-right: 0.375rem;" class="badge text-bg-secondary float-end">
+                ${part === "sender" ? message.cryptoType : message.signatureType}
+              </span>` : ''}
           <span class="text-muted d-block">${message[part].title}:</span>
-          ${message[part].plain ? `<span class="d-block">${message[part].plain}</span>`: ''}
+          ${message[part].plain ? `<span class="d-block">${message[part].plain}</span>` : ''}
           <span class="message-part d-block">CESR selector: ${message[part].prefix}</span>
           <span class="message-part d-block" style="color:${colors[index]}">${message[part].data}</span>
           ${part === 'sender' && !message.ciphertext.plain 
-          ? '<button class="btn btn-outline-primary mt-2 verify">Verify sender</span>': ''}
+            ? '<button class="btn btn-outline-primary mt-2 verify">Verify sender</span>' : ''}
         </li>
       ` : '').join('\n')}
     </ul>

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -336,6 +336,17 @@ fn open_message(message: &[u8], payload: Option<&[u8]>) -> Option<serde_json::Va
         "nonconfidentialData": parts.nonconfidential_data.map(|v| format_part("Non-confidential data", &v, None)),
         "ciphertext": parts.ciphertext.map(|v| format_part("Ciphertext", &v, payload)),
         "signature": format_part("Signature", &parts.signature, None),
+        "cryptoType": match parts.crypto_type {
+            tsp::cesr::CryptoType::Plaintext => "Plain text",
+            tsp::cesr::CryptoType::HpkeAuth => "HPKE Auth",
+            tsp::cesr::CryptoType::HpkeEssr => "HPKE ESSR",
+            tsp::cesr::CryptoType::NaclAuth => "NaCl Auth",
+            tsp::cesr::CryptoType::NaclEssr => "NaCl ESSR",
+        },
+        "signatureType": match parts.signature_type {
+            tsp::cesr::SignatureType::NoSignature => "No Signature",
+            tsp::cesr::SignatureType::Ed25519 => "Ed25519",
+        }
     }))
 }
 

--- a/tsp/src/cesr/packet.rs
+++ b/tsp/src/cesr/packet.rs
@@ -822,7 +822,7 @@ impl<'a> Part<'a> {
 }
 
 /// Describes the CESR-encoded parts of a TSP message
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct MessageParts<'a> {
     pub prefix: Part<'a>,
     pub sender: Part<'a>,
@@ -830,11 +830,14 @@ pub struct MessageParts<'a> {
     pub nonconfidential_data: Option<Part<'a>>,
     pub ciphertext: Option<Part<'a>>,
     pub signature: Part<'a>,
+    pub crypto_type: CryptoType,
+    pub signature_type: SignatureType,
 }
 
 /// Decode a CESR-encoded message into its CESR-encoded parts
 pub fn open_message_into_parts(data: &[u8]) -> Result<MessageParts, DecodeError> {
-    let (mut pos, _, _) = detected_tsp_header_size_and_confidentiality(&mut (data as &[u8]))?;
+    let (mut pos, crypto_type, signature_type) =
+        detected_tsp_header_size_and_confidentiality(&mut (data as &[u8]))?;
 
     let prefix = Part {
         prefix: &data[..pos],
@@ -861,6 +864,8 @@ pub fn open_message_into_parts(data: &[u8]) -> Result<MessageParts, DecodeError>
         nonconfidential_data,
         ciphertext,
         signature,
+        crypto_type,
+        signature_type,
     })
 }
 


### PR DESCRIPTION
Added crypto/signature types to message parts data, and display these types on the webpage of the example server, making it easy to see what kind of cryptography (HPKE/NaCl, Auth/ESSR) and signature (Ed25519/none) were used.