### PR TITLE
Change aries-askar to original source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,7 @@ tokio = { version = "1.0", default-features = false, features = [
     "net",
     "macros",
 ] }
-aries-askar = { git = "https://github.com/marlonbaeten/aries-askar", branch = "ciborium", default-features = false, features = [
-    "sqlite",
-] }
+aries-askar = { version = "0.3.1", default-features = false, features = [ "sqlite" ] }
 # logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = [

--- a/deny.toml
+++ b/deny.toml
@@ -15,13 +15,8 @@ crate = "ring"
 expression = "ISC AND OpenSSL AND MIT"
 license-files = [ { path = "LICENSE", hash = 0xbd0eed23 } ]
 
-[sources]
-allow-git = [
-    "https://github.com/marlonbaeten/rust-hpke",
-    "https://github.com/marlonbaeten/aries-askar",
-]
-
 [advisories]
 ignore = [
-   { id="RUSTSEC-2024-0363", reason = "we cannot upgrade away from this without breaking compatibility with aries-askar" },
+   { id="RUSTSEC-2024-0363", reason = "introduced by aries-askar, on which we are dependent; migrate away from sqlx 0.7" },
+   { id="RUSTSEC-2021-0127", reason = "introduced by aries-askar, on which we are dependent; serde_cbor can be replaced by ciborium" },
 ]

--- a/tsp/src/vault.rs
+++ b/tsp/src/vault.rs
@@ -78,13 +78,7 @@ impl Vault {
                 let decryption_key = LocalKey::from_secret_bytes(KeyAlg::X25519, private.as_ref())?;
                 let decryption_key_name = format!("{id}#decryption-key");
                 if let Err(e) = conn
-                    .insert_key(
-                        &decryption_key_name,
-                        &decryption_key,
-                        None,
-                        None,
-                        None,
-                    )
+                    .insert_key(&decryption_key_name, &decryption_key, None, None, None)
                     .await
                 {
                     if e.kind() != ErrorKind::Duplicate {
@@ -97,13 +91,7 @@ impl Vault {
                 LocalKey::from_public_bytes(KeyAlg::Ed25519, export.public_sigkey.as_ref())?;
             let verification_key_name = format!("{id}#verification-key");
             if let Err(e) = conn
-                .insert_key(
-                    &verification_key_name,
-                    &verification_key,
-                    None,
-                    None,
-                    None,
-                )
+                .insert_key(&verification_key_name, &verification_key, None, None, None)
                 .await
             {
                 if e.kind() != ErrorKind::Duplicate {
@@ -115,13 +103,7 @@ impl Vault {
                 LocalKey::from_public_bytes(KeyAlg::X25519, export.public_enckey.as_ref())?;
             let encryption_key_name = format!("{id}#encryption-key");
             if let Err(e) = conn
-                .insert_key(
-                    &encryption_key_name,
-                    &encryption_key,
-                    None,
-                    None,
-                    None,
-                )
+                .insert_key(&encryption_key_name, &encryption_key, None, None, None)
                 .await
             {
                 if e.kind() != ErrorKind::Duplicate {

--- a/tsp/src/vault.rs
+++ b/tsp/src/vault.rs
@@ -65,7 +65,7 @@ impl Vault {
                 let signing_key_name = format!("{id}#signing-key");
 
                 if let Err(e) = conn
-                    .insert_key(&signing_key_name, &signing_key, None, None, None, None)
+                    .insert_key(&signing_key_name, &signing_key, None, None, None)
                     .await
                 {
                     if e.kind() != ErrorKind::Duplicate {
@@ -81,7 +81,6 @@ impl Vault {
                     .insert_key(
                         &decryption_key_name,
                         &decryption_key,
-                        None,
                         None,
                         None,
                         None,
@@ -104,7 +103,6 @@ impl Vault {
                     None,
                     None,
                     None,
-                    None,
                 )
                 .await
             {
@@ -120,7 +118,6 @@ impl Vault {
                 .insert_key(
                     &encryption_key_name,
                     &encryption_key,
-                    None,
                     None,
                     None,
                     None,


### PR DESCRIPTION
The reason for switching was that `serde_cbor` was that it was unmaintained; but we are ignoring a more severe warning for `sqlx` anyway. We should simply notify upstream to fix those issues, and wait.