### PR TITLE
Add version command

### DIFF
--- a/docs/src/cli/installation.md
+++ b/docs/src/cli/installation.md
@@ -60,7 +60,8 @@ Options:
       --password <PASSWORD>      Password used to encrypt the wallet [default: unsecure]
   -s, --server <SERVER>          Test server domain [default: demo.teaspoon.world]
       --did-server <DID_SERVER>  DID server domain [default: did.teaspoon.world]
-  -v, --verbose                  
+      --verbose                  
   -y, --yes                      Always answer yes to any prompts
   -h, --help                     Print help
+  -V, --version                  Print version
 ```

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -33,8 +33,7 @@ tsp create example --alias example
 
 In subsequent commands we can type `example` instead of `did:web:did.teaspoon.world:user:example`.
 
-Every `tsp` subcommand also supports the `--verbose` or `-v` flag for a more
-verbose output:
+Every `tsp` subcommand also supports the `--verbose` flag for a more verbose output:
 
 ```sh
 tsp --verbose create example --alias example

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -15,7 +15,7 @@ use tsp_sdk::{
 };
 
 #[derive(Debug, Parser)]
-#[command(name = "tsp")]
+#[command(name = "tsp", version)]
 #[command(about = "Send and receive TSP messages", long_about = None)]
 struct Cli {
     #[command(subcommand)]
@@ -37,7 +37,7 @@ struct Cli {
     server: String,
     #[arg(long, default_value = "did.teaspoon.world", help = "DID server domain")]
     did_server: String,
-    #[arg(short, long)]
+    #[arg(long)]
     verbose: bool,
     #[arg(short, long, help = "Always answer yes to any prompts")]
     yes: bool,


### PR DESCRIPTION
Also removes short-hand for `--verbose` to avoid confusion with version command (and if you want to be verbose you might as well use the full flag name for full verbosity)

Closes #134