### PR TITLE
Allow some additional characters in DIDs

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -40,9 +40,9 @@
                 type="text"
                 id="name"
                 name="name"
-                pattern="[a-z]{3,100}"
+                pattern="[a-zA-Z0-9\-\._~]{3,100}"
                 placeholder="username e.g. alice"
-                title="use only lowercase characters, at least 3"
+                title="use only alphanumeric characters (or '-._~'), at least 3"
                 class="form-control"
                 required
               />

--- a/examples/src/did-web.rs
+++ b/examples/src/did-web.rs
@@ -293,8 +293,15 @@ async fn list_all_ids(domain: String) -> Result<Vec<String>, Box<dyn std::error:
     Ok(dids)
 }
 
+// These characters are unreserved and can safely be used in any URL according to RFC3986
+const ADDITIONAL_CHARS: &str = "-._~";
+
 fn verify_name(name: &str) -> bool {
-    !name.is_empty() && name.len() < 64 && name.chars().all(|c| c.is_alphanumeric())
+    !name.is_empty()
+        && name.len() < 64
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || ADDITIONAL_CHARS.contains(c))
 }
 
 /// Identity struct, used to store the DID document and VID of an endpoint


### PR DESCRIPTION
Allows the characters '-', '.', '_', and '~' in did:webs, as these are URL safe and the did:web specification allows it