### PR TITLE
Fix broken intra-doc links for AsyncSecureStore and SecureStore in crate docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,6 +45,14 @@ jobs:
           arguments: --workspace
           rust-version: '1.85'
 
+  cargo-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --workspace --no-deps
+
   check-wasm32:
     runs-on: ubuntu-22.04
     steps:

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -5,7 +5,7 @@
 //! The Trust Spanning Protocol (TSP) is a protocol for secure communication
 //! between entities identified by their Verified Identities (VIDs).
 //!
-//! The primary API this crates exposes is the [AsyncStore] struct, which
+//! The primary API this crates exposes is the [AsyncSecureStore] struct, which
 //! is used to manage and resolve VIDs, as well as send and receive messages
 //! between them.
 //!
@@ -17,9 +17,9 @@
 //! If your use-case only requires the core protocol, you can disable the
 //! `async` feature to remove the transport layer and resolve methods.
 //!
-//! The [AsyncStore] uses the tokio async runtime and offers a high level API.
+//! The [AsyncSecureStore] uses the tokio async runtime and offers a high level API.
 //!
-//! The [Store] struct implements managing VIDs and sealing / opening
+//! The [SecureStore] struct implements managing VIDs and sealing / opening
 //! TSP messages (low level API), it does not require an async runtime.
 //! ## Example
 //!


### PR DESCRIPTION
This PR fixes the broken intra-doc links in the crate-level documentation by replacing `[AsyncStore]` and `[Store]` with `[AsyncSecureStore]` and `[SecureStore]`, which are the actual re-exported types provided by the crate.

This change avoids documentation build failures

Let me know if you’d prefer using aliases to preserve the original names, and I’ll update the PR accordingly.

I've also attached a screenshot of the original error for reference.
![Screenshot from 2025-05-09 20-42-23](https://github.com/user-attachments/assets/b2673991-fa29-48c3-99a6-e9982401e71b)


