### PR TITLE
Change default transport to intermediary P

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -62,7 +62,7 @@ struct Cli {
     #[arg(
         short,
         long,
-        default_value = "demo.teaspoon.world",
+        default_value = "p.teaspoon.world",
         help = "Test server domain"
     )]
     server: String,


### PR DESCRIPTION
This allows message buffering (as implemented by #186) to work by default