### PR TITLE
Update cargo-deny-action to v2 for CVSS 4.0 support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,11 +47,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check
           arguments: --workspace
-          rust-version: "1.85"
 
   cargo-doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Update `EmbarkStudios/cargo-deny-action` from v1 to v2
- Remove deprecated `rust-version` parameter

## Problem
The RustSec advisory database now includes advisories with CVSS 4.0 scores (e.g., RUSTSEC-2024-0445 for the `idna` crate). The v1 cargo-deny-action uses cargo-deny 0.14.x which cannot parse CVSS 4.0, causing all PRs to fail with:

```
unsupported CVSS version: 4.0
```

This is blocking PR #241 and will block all future PRs until fixed.

## Solution
Updating to v2 uses cargo-deny 0.16+ which supports CVSS 4.0 format.

## Test plan
- [ ] Verify this PR's cargo-deny check passes
- [ ] Re-run CI on PR #241 after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)