### PR TITLE
Remove unmaintained rustls-pemfile dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ rustls = "0.23"
 tokio-rustls = "0.26"
 rustls-pki-types = "1.12"
 rustls-native-certs = "0.8.1"
-rustls-pemfile = "2.2"
 quinn = { version = "0.11", default-features = false, features = [
   "log",
   "runtime-tokio",

--- a/tsp_sdk/Cargo.toml
+++ b/tsp_sdk/Cargo.toml
@@ -33,7 +33,6 @@ async = [
   "dep:tokio-rustls",
   "dep:rustls-pki-types",
   "dep:rustls-native-certs",
-  "dep:rustls-pemfile",
   "dep:quinn",
 ]
 resolve = ["serialize", "dep:reqwest", "dep:didwebvh-rs"]
@@ -73,7 +72,6 @@ rustls = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 rustls-pki-types = { workspace = true, optional = true }
 rustls-native-certs = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
 # resolve
 reqwest = { workspace = true, optional = true }

--- a/tsp_sdk/src/transport/error.rs
+++ b/tsp_sdk/src/transport/error.rs
@@ -18,6 +18,8 @@ pub enum TransportError {
     TLSConfiguration,
     #[error("missing TLS certificate or key file '{0}'")]
     TLSMissingFile(String),
+    #[error("invalid TLS certificate")]
+    TLSCertificate,
     #[error("invalid TLS key '{0}'")]
     TLSKey(String),
     #[error("{0}")]


### PR DESCRIPTION
## Summary
- Migrate from `rustls-pemfile` to `rustls-pki-types` for PEM parsing
- Remove `rustls-pemfile` from workspace and tsp_sdk dependencies
- Add `TLSCertificate` error variant for certificate parsing errors

## Problem
The `rustls-pemfile` crate is unmaintained ([RUSTSEC-2025-0134](https://rustsec.org/advisories/RUSTSEC-2025-0134)), causing cargo-deny CI failures.

## Solution
The functionality has been incorporated into `rustls-pki-types` since v1.9.0 via the `PemObject` trait. This PR migrates to use that API directly.

The project already depends on `rustls-pki-types = "1.12"`, so this is a straightforward migration with no new dependencies.

## Impact
- **TLS transport**: `load_certificate()` function used for TLS server setup
- **Test code**: Test CA certificate loading in `create_tls_config()`

## Test plan
- [x] `cargo build -p tsp_sdk` succeeds
- [x] `cargo test -p tsp_sdk` - all 55 tests pass including `test_tls_transport`
- [ ] CI cargo-deny check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)