### PR TITLE
Fix examples build by enabling tokio io-std feature

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["io-std"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
Enable Tokio’s io-std feature so cli.rs compiles correctly when the workspace uses tokio with default-features = false.