### PR TITLE
Simplify option handling with map

### DIFF
--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -1020,17 +1020,10 @@ pub struct Part<'a> {
 impl<'a> Part<'a> {
     fn decode(identifier: u32, data: &'a [u8], pos: &mut usize) -> Option<Part<'a>> {
         let begin_pos = *pos;
-        match checked_decode_variable_data_index(identifier, data, pos) {
-            Some(range) => {
-                let part = Part {
-                    prefix: &data[begin_pos..range.start],
-                    data: &data[range.start..range.end],
-                };
-
-                Some(part)
-            }
-            None => None,
-        }
+        checked_decode_variable_data_index(identifier, data, pos).map(|range| Part {
+            prefix: &data[begin_pos..range.start],
+            data: &data[range.start..range.end],
+        })
     }
 }
 

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -142,10 +142,9 @@ impl SecureStore {
                 vid.id.to_string(),
                 VidContext {
                     vid: Arc::new(vid.verified_vid()),
-                    private: match vid.private_vid() {
-                        Some(private) => Some(Arc::new(private)),
-                        None => None,
-                    },
+                    private: vid
+                        .private_vid()
+                        .map(|private| -> Arc<dyn PrivateVid> { Arc::new(private) }),
                     relation_status: vid.relation_status,
                     relation_vid: vid.relation_vid,
                     parent_vid: vid.parent_vid,


### PR DESCRIPTION
Replace verbose `match` Option handling with `Option::map` for tiny conciseness gains.

@Folyd I can't find you in the reviewers, so this will have to do for now :)