### PR TITLE
Fix CLI HPKE default path to use ESSR and align docs output

### DIFF
--- a/docs/src/cli/base.md
+++ b/docs/src/cli/base.md
@@ -173,7 +173,7 @@ On the receiving side you should see:
 ```
  INFO tsp: received relationship request from did:web:did.teaspoon.world:endpoint:alice3, thread-id 'lrQoJ1qYIK6HEHZKvpq3p+it6djYE2YIe++5mqhASnE'
 did:web:did.teaspoon.world:endpoint:alice3      lrQoJ1qYIK6HEHZKvpq3p+it6djYE2YIe++5mqhASnE
- INFO tsp: received confidential message (11 bytes) from did:web:did.teaspoon.world:endpoint:alice3 (HPKE Auth, Ed25519 signature)
+ INFO tsp: received confidential message (11 bytes) from did:web:did.teaspoon.world:endpoint:alice3 (HPKE ESSR, Ed25519 signature)
 Hello Bob!
 ```
 

--- a/examples/cli-test-cross-type.sh
+++ b/examples/cli-test-cross-type.sh
@@ -6,8 +6,8 @@ HPKE_TSP="$HPKE/bin/tsp"
 NACL_TSP="$NACL/bin/tsp"
 
 # install two different versions of the TSP command line example tool
-cargo install --path . --bin tsp --root "$HPKE"
-cargo install --path . --bin tsp --features nacl --root "$NACL"
+cargo install --path . --bin tsp --no-default-features --features essr --root "$HPKE"
+cargo install --path . --bin tsp --no-default-features --features nacl --root "$NACL"
 
 randuser() {
     head -c4 /dev/urandom | shasum | head -c8


### PR DESCRIPTION
Closing #232 

## Summary

The docs example output still showed `HPKE Auth`,  this PR corrects it to `HPKE ESSR`.
This PR alsp makes the default HPKE test path explicitly use `hpke-base + essr`.

## Changes

- `examples/cli-test-cross-type.sh`
    - HPKE build now uses:
        - `--no-default-features --features essr`
- NaCl build is now explicit:
    - `--no-default-features --features nacl`
- `docs/src/cli/base.md`
    - Updated example receiver output:
        - `HPKE Auth` -> `HPKE ESSR`