### PR TITLE
Add protocol validation docs as a basis for TSP test vectors (Rev 2)

### DIFF
--- a/docs/validation/00-charter.md
+++ b/docs/validation/00-charter.md
@@ -1,0 +1,104 @@
+# Charter: Protocol-First Validation Set for TSP
+
+## 1. Objective
+
+Define a decision-complete validation design that can be implemented as a conformance suite for TSP, with strict traceability from protocol clauses to verdicts.
+
+## 2. Authority Model
+
+- Source of truth: `https://trustoverip.github.io/tswg-tsp-specification/`
+- Locked baseline: `v1.0 Experimental Implementor's Draft Rev 2`
+- Lock date: `2026-02-25`
+- Local codebase role: informative only, never normative
+
+## 3. Scope
+
+In scope:
+
+- Message envelope and payload structure
+- CESR framing and selectors used by protocol messages
+- Cryptographic profile requirements (algorithm, mode, and signature semantics)
+- Control-message semantics and state transitions
+- Nested and routed mode semantics
+- Transport interface obligations and behavior-level requirements
+- Error handling and unsupported message behavior
+- Cross-language interoperability vector format
+
+Out of scope:
+
+- Performance benchmarks and latency targets
+- Production deployment topology
+- UI/CLI usability
+- Repository-specific internal architecture
+
+## 4. Normative Strength
+
+Each clause is tagged using protocol normative language:
+
+- `MUST`: hard conformance requirement
+- `SHOULD`: recommended requirement
+- `MAY`: optional capability
+- `INFO`: explanatory statement, not a conformance gate
+
+## 5. Clause and Test Identity
+
+- Clause ID format: `<DOMAIN>-<SUBDOMAIN>-<NNN>`
+- Test ID format: `TC-<ClauseID>-<P|N|B>-<NNN>`
+- Evidence ID format: `EV-<TestID>-<NNN>`
+
+Domains are defined in `01-spec-clause-catalog.md`.
+
+## 6. Verdict Model
+
+- `PASS`: observed behavior satisfies the assertion
+- `FAIL`: observed behavior violates the assertion
+- `INCONCLUSIVE`: required evidence missing or corrupted
+- `BLOCKED`: test cannot be executed due to external precondition
+
+Rules:
+
+- Any failed `MUST` clause fails conformance for that profile.
+- Failed `SHOULD` clauses are reported separately and do not fail hard conformance by default.
+- `MAY` clauses are scored as capability claims, not mandatory failures.
+
+## 7. Evidence Model
+
+Each executed test must provide a minimal evidence bundle:
+
+- `packet_hex`: raw encoded input/output bytes
+- `decoded_fields`: canonical decoded view used for assertions
+- `error_code`: protocol error category or implementation error code
+- `trace_ref`: transport/session trace identifier
+- `timestamp_utc`: execution timestamp
+- `implementation_profile`: tested build profile and feature flags
+
+Optional fields:
+
+- `key_material_ref`: reference only, never secret values
+- `interop_peer_ref`: remote implementation identifier for interop tests
+
+## 8. Ambiguity Policy
+
+When specification language is ambiguous:
+
+- Create an issue entry with tag `SPEC_GAP`.
+- Do not silently infer behavior from implementation.
+- Do not downgrade explicit `MUST` requirements.
+- Keep test execution unblocked by marking the affected assertion as:
+  - hard assertion if wording is explicit
+  - pending assertion if wording is unresolved
+
+## 9. Quality Gates
+
+Design quality gates:
+
+- 100% of normative clauses in baseline are assigned Clause IDs
+- 100% of `MUST` and `SHALL` clauses have at least one positive and one negative test design
+- Every test entry has a required evidence definition
+- Every known implementation deviation is recorded in the gap register
+
+Implementation quality gates (for future execution phase):
+
+- Deterministic verdict for all mandatory tests
+- Reproducible vector inputs and expected outputs
+- Full traceability from failing test to clause and source anchor

--- a/docs/validation/01-spec-clause-catalog.md
+++ b/docs/validation/01-spec-clause-catalog.md
@@ -1,0 +1,86 @@
+# Spec Clause Catalog (Rev 2 Baseline)
+
+This file defines normalized clause IDs for the protocol baseline and records the clause-level requirement that must be validated.
+
+Notes:
+
+- Requirement text is intentionally normalized, not verbatim.
+- Source anchor points to section-level locations in the specification site.
+- Clause set in this revision focuses on baseline MUST/SHOULD requirements and key protocol nodes; additional clauses should be incrementally added via the diff process in `06-versioning-and-diff-policy.md`.
+
+## Domain Codes
+
+- `VID`: verified identifier requirements
+- `MSG`: message structure and semantics
+- `CTL`: control payload and relationship flow
+- `NEST`: nested mode semantics
+- `RTE`: routed mode semantics
+- `CRY`: cryptographic profile
+- `ENC`: CESR/framing encoding rules
+- `TRN`: transport interfaces and endpoint obligations
+- `ERR`: unsupported/error behavior
+
+## Clause Records
+
+| Clause ID | Strength | Normalized Requirement | Source Anchor | Status |
+| --- | --- | --- | --- | --- |
+| VID-FORM-001 | MUST | A TSP implementation MUST support VIDs using DID syntax. | `#verified-identifiers` | Mapped |
+| VID-FORM-002 | MUST | A TSP implementation MUST support VIDs using URN syntax. | `#verified-identifiers` | Mapped |
+| VID-FORM-003 | MUST | VIDs used in TSP MUST be globally unique. | `#verified-identifiers` | Mapped |
+| VID-META-001 | MUST | A VID MUST expose transport address discovery via `VID.RESOLVEADDRESS` returning `VID_iaddr`. | `#verified-identifiers` | Mapped |
+| VID-META-002 | MUST | A VID MUST expose encryption public key via `VID.PK_e`. | `#verified-identifiers` | Mapped |
+| VID-META-003 | MUST | A VID MUST expose signature verification key via `VID.PK_v`. | `#verified-identifiers` | Mapped |
+| VID-META-004 | MUST | A VID MUST support `VID.VERIFY` to validate the signature block given a message and VID types. | `#verified-identifiers` | Mapped |
+| VID-META-005 | SHOULD | VID metadata SHOULD carry trust-policy-relevant attributes. | `#verified-identifiers` | Mapped |
+| VID-DISC-001 | SHOULD | If a received TSP message uses unsupported VID types, the receiver SHOULD discard the message. | `#verified-identifiers` | Mapped |
+| VID-INNER-001 | MUST | Correlatable identifiers MUST NOT be used for inner relationships. | `#verified-identifiers` | Mapped |
+| VID-INNER-002 | SHOULD | Inner relationships SHOULD be based on a random and globally unique identifier. | `#verified-identifiers` | Mapped |
+| MSG-GEN-001 | MUST | Every TSP message MUST include sender VID information. | `#messages` | Mapped |
+| MSG-GEN-002 | MUST | Every TSP message MUST include an outer signature. | `#messages` | Mapped |
+| MSG-CONF-001 | MUST | Confidential messages MUST identify sender and recipient VIDs in authenticated envelope data. | `#confidential-message` | Mapped |
+| MSG-CONF-002 | MUST | Confidential messages MUST include exactly one encrypted content group. | `#confidential-message` | Mapped |
+| MSG-CONF-003 | MUST | Confidential messages MUST include at least one signature group. | `#confidential-message` | Mapped |
+| MSG-NONC-001 | MUST | Non-confidential messages MUST include sender VID and signature. | `#non-confidential-message` | Mapped |
+| MSG-NONC-002 | MUST | In non-confidential messages, the recipient VID field is optional; implementations MUST accept messages with no recipient VID. | `#non-confidential-message` | Mapped |
+| MSG-CTRL-001 | MUST | Control messages MUST be represented as protocol-defined payload types. | `#control-message-payload` | Mapped |
+| MSG-SIG-001 | MUST | The signature block MUST be a signature over the concatenation of the Envelope and the Payload. | `#messages` | Mapped |
+| CTL-TYPE-001 | MUST | Relationship request payload MUST carry nonce and optional hop list. | `#relationship-request-message` | Mapped |
+| CTL-TYPE-002 | MUST | Relationship accept payload MUST carry reply digest referencing original request. | `#relationship-accept-message` | Mapped |
+| CTL-TYPE-003 | MUST | Nested relationship request payload MUST carry nonce and nested message. | `#nested-relationship-request-message` | Mapped |
+| CTL-TYPE-004 | MUST | Nested relationship accept payload MUST carry nested message and reply digest. | `#nested-relationship-accept-message` | Mapped |
+| CTL-TYPE-005 | MUST | Relationship cancel payload MUST carry reply digest. | `#relationship-cancel-message` | Mapped |
+| CTL-TYPE-006 | MUST | Relationship referral payload MUST carry referred VID. | `#relationship-referral-message` | Mapped |
+| CTL-THRD-001 | MUST | Reply digest fields in control messages MUST reference the correct thread/request context. | `#control-message-payload` | Mapped |
+| CTL-HOPS-001 | MUST | Hop list, when present, MUST contain only VID entries. | `#relationship-request-message` | Mapped |
+| NEST-MODE-001 | MUST | Nested mode MUST encapsulate an inner TSP message as payload of an outer TSP message. | `#nested-mode-messages` | Mapped |
+| NEST-MODE-002 | MUST | Nested payload semantics MUST preserve inner message integrity across forwarding. | `#nested-mode-messages` | Mapped |
+| NEST-MODE-003 | MUST | Nested relationship setup MUST use control payload types defined for nested proposals/acceptance. | `#nested-relationship-request-message` | Mapped |
+| RTE-MODE-001 | MUST | Routed mode messages MUST include route information as ordered VID list. | `#routed-mode-messages` | Mapped |
+| RTE-MODE-002 | MUST | Routed payload MUST carry exactly one encrypted inner message plus route metadata. | `#routed-mode-messages` | Mapped |
+| RTE-MODE-003 | MUST | Intermediary-visible data in routed mode MUST be limited to route processing information. | `#routed-mode-messages` | Mapped |
+| RTE-MODE-004 | MUST | Intermediaries MUST forward routed/nested payloads without modifying protected inner content. | `#routed-mode-messages` | Mapped |
+| RTE-MODE-006 | MUST | Route construction MUST be compatible with corresponding relationship request semantics. | `#relationship-request-message` | Mapped |
+| CRY-HPKE-001 | MUST | Implementations MUST support HPKE in both Auth and Base modes (at least for the baseline profile). | `#message-crypto-type` | Mapped |
+| CRY-HPKE-002 | MUST | Baseline HPKE MUST use KEM `0x0020` (DHKEM(X25519, HKDF-SHA256)), KDF `0x0001` (HKDF-SHA256), AEAD `0x0003` (ChaCha20Poly1305). | `#message-crypto-type` | Mapped |
+| CRY-ALG-003 | MUST | Implementations MUST support Ed25519 signatures. | `#cryptography-requirements` | Mapped |
+| CRY-SIG-001 | MUST | Signature verification MUST validate the signature block against `Concat(Envelope, Payload)`. | `#messages` | Mapped |
+| ENC-CESR-001 | MUST | Protocol messages MUST be encoded using CESR as defined by the baseline encoding rules. | `#encoding` | Mapped |
+| ENC-CESR-002 | MUST | Conformant implementations MUST support CESR interleaving scheme for JSON, CBOR, and MsgPak payload encodings. | `#encoding` | Mapped |
+| ENC-PAY-001 | MUST | Generic payloads MUST use `XSCS` and include a CESR count field for the payload length. | `#encoding` | Mapped |
+| ENC-PAY-002 | MUST | An outer message of a nested message MUST be encoded with payload type `XHOP`. | `#nested-mode-messages` | Mapped |
+| ENC-PAY-003 | MUST | Control messages MUST be encoded with payload type `XRFI`, `XRFA`, or `XRFD` and follow the defined field order. | `#control-message-payload` | Mapped |
+| ENC-PARSE-001 | MUST | Unknown or malformed mandatory selectors MUST trigger message rejection. | `#encoding` | Mapped |
+| ENC-BOUND-001 | MUST | Length and group boundaries MUST be validated before semantic processing. | `#encoding` | Mapped |
+| TRN-INTF-001 | MUST | Transport bindings MUST provide `TSP_TRANSPORT_SEND` and `TSP_TRANSPORT_RECEIVE`. | `#transport-layer-bindings` | Mapped |
+| TRN-INTF-002 | MUST | Transport bindings MUST provide `TSP_TRANSPORT_SETUP`, `TSP_TRANSPORT_TEARDOWN`, and `TSP_TRANSPORT_EVENT`. | `#transport-layer-bindings` | Mapped |
+| TRN-INTF-003 | MUST | Each VID used for receiving MUST have a transport endpoint binding. | `#transport-layer-bindings` | Mapped |
+| TRN-INTF-004 | SHOULD | Implementations SHOULD support at least one standardized transport binding profile. | `#transport-layer-bindings` | Mapped |
+| ERR-UNSP-001 | SHOULD | Unsupported message types from unknown senders SHOULD be safely discarded. | `#transport-layer-bindings` | Mapped |
+| ERR-UNSP-002 | SHOULD | Unsupported message types from known senders SHOULD return an explicit error signal where feasible. | `#transport-layer-bindings` | Mapped |
+| ERR-VAL-001 | MUST | Parsing or validation failure in protected message structures MUST not result in partial acceptance. | `#messages` | Mapped |
+
+## Catalog Maintenance Rules
+
+1. If a baseline clause changes wording but not behavior, keep the same Clause ID and update notes.
+2. If behavior changes, create a new Clause ID and deprecate the old one in `06-versioning-and-diff-policy.md`.
+3. If a section is unclear, add `SPEC_GAP` annotation instead of inferring behavior.

--- a/docs/validation/02-conformance-matrix.md
+++ b/docs/validation/02-conformance-matrix.md
@@ -1,0 +1,78 @@
+# Conformance Matrix (Clause -> Assertion -> Tests)
+
+This matrix links every baseline clause to executable assertion design.
+
+Legend:
+
+- Positive case marker: `P`
+- Negative case marker: `N`
+- Boundary case marker: `B`
+- Priority: `P0` mandatory baseline, `P1` important, `P2` optional/capability
+
+Evidence profile keys come from `00-charter.md`.
+
+## Matrix
+
+| Clause ID | Assertion ID | Family | Priority | Positive Cases | Negative Cases | Boundary Cases | Required Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| VID-FORM-001 | AS-VID-FORM-001-001 | Identifier | P0 | `TC-VID-FORM-001-P-001` | `TC-VID-FORM-001-N-001` | `TC-VID-FORM-001-B-001` | `decoded_fields,error_code` |
+| VID-FORM-002 | AS-VID-FORM-002-001 | Identifier | P0 | `TC-VID-FORM-002-P-001` | `TC-VID-FORM-002-N-001` | `TC-VID-FORM-002-B-001` | `decoded_fields,error_code` |
+| VID-FORM-003 | AS-VID-FORM-003-001 | Identifier | P0 | `TC-VID-FORM-003-P-001` | `TC-VID-FORM-003-N-001` | `TC-VID-FORM-003-B-001` | `decoded_fields,error_code` |
+| VID-META-001 | AS-VID-META-001-001 | Identifier | P0 | `TC-VID-META-001-P-001` | `TC-VID-META-001-N-001` | `TC-VID-META-001-B-001` | `decoded_fields,error_code` |
+| VID-META-002 | AS-VID-META-002-001 | Identifier | P0 | `TC-VID-META-002-P-001` | `TC-VID-META-002-N-001` | `TC-VID-META-002-B-001` | `decoded_fields,error_code` |
+| VID-META-003 | AS-VID-META-003-001 | Identifier | P0 | `TC-VID-META-003-P-001` | `TC-VID-META-003-N-001` | `TC-VID-META-003-B-001` | `decoded_fields,error_code` |
+| VID-META-004 | AS-VID-META-004-001 | Identifier | P0 | `TC-VID-META-004-P-001` | `TC-VID-META-004-N-001` | `TC-VID-META-004-B-001` | `decoded_fields,error_code` |
+| VID-META-005 | AS-VID-META-005-001 | Identifier | P1 | `TC-VID-META-005-P-001` | `TC-VID-META-005-N-001` | `TC-VID-META-005-B-001` | `decoded_fields,error_code` |
+| VID-DISC-001 | AS-VID-DISC-001-001 | Identifier | P1 | `TC-VID-DISC-001-P-001` | `TC-VID-DISC-001-N-001` | `TC-VID-DISC-001-B-001` | `error_code,trace_ref` |
+| VID-INNER-001 | AS-VID-INNER-001-001 | Identifier | P0 | `TC-VID-INNER-001-P-001` | `TC-VID-INNER-001-N-001` | `TC-VID-INNER-001-B-001` | `decoded_fields,trace_ref` |
+| VID-INNER-002 | AS-VID-INNER-002-001 | Identifier | P1 | `TC-VID-INNER-002-P-001` | `TC-VID-INNER-002-N-001` | `TC-VID-INNER-002-B-001` | `decoded_fields,error_code` |
+| MSG-GEN-001 | AS-MSG-GEN-001-001 | MessageStructure | P0 | `TC-MSG-GEN-001-P-001` | `TC-MSG-GEN-001-N-001` | `TC-MSG-GEN-001-B-001` | `packet_hex,decoded_fields` |
+| MSG-GEN-002 | AS-MSG-GEN-002-001 | MessageStructure | P0 | `TC-MSG-GEN-002-P-001` | `TC-MSG-GEN-002-N-001` | `TC-MSG-GEN-002-B-001` | `packet_hex,decoded_fields,error_code` |
+| MSG-CONF-001 | AS-MSG-CONF-001-001 | MessageStructure | P0 | `TC-MSG-CONF-001-P-001` | `TC-MSG-CONF-001-N-001` | `TC-MSG-CONF-001-B-001` | `packet_hex,decoded_fields` |
+| MSG-CONF-002 | AS-MSG-CONF-002-001 | MessageStructure | P0 | `TC-MSG-CONF-002-P-001` | `TC-MSG-CONF-002-N-001` | `TC-MSG-CONF-002-B-001` | `packet_hex,decoded_fields,error_code` |
+| MSG-CONF-003 | AS-MSG-CONF-003-001 | MessageStructure | P0 | `TC-MSG-CONF-003-P-001` | `TC-MSG-CONF-003-N-001` | `TC-MSG-CONF-003-B-001` | `packet_hex,decoded_fields,error_code` |
+| MSG-NONC-001 | AS-MSG-NONC-001-001 | MessageStructure | P0 | `TC-MSG-NONC-001-P-001` | `TC-MSG-NONC-001-N-001` | `TC-MSG-NONC-001-B-001` | `packet_hex,decoded_fields` |
+| MSG-NONC-002 | AS-MSG-NONC-002-001 | MessageStructure | P0 | `TC-MSG-NONC-002-P-001` | `TC-MSG-NONC-002-N-001` | `TC-MSG-NONC-002-B-001` | `packet_hex,decoded_fields` |
+| MSG-CTRL-001 | AS-MSG-CTRL-001-001 | ControlState | P0 | `TC-MSG-CTRL-001-P-001` | `TC-MSG-CTRL-001-N-001` | `TC-MSG-CTRL-001-B-001` | `packet_hex,decoded_fields,error_code` |
+| MSG-SIG-001 | AS-MSG-SIG-001-001 | Crypto | P0 | `TC-MSG-SIG-001-P-001` | `TC-MSG-SIG-001-N-001` | `TC-MSG-SIG-001-B-001` | `packet_hex,decoded_fields,error_code` |
+| CTL-TYPE-001 | AS-CTL-TYPE-001-001 | ControlState | P0 | `TC-CTL-TYPE-001-P-001` | `TC-CTL-TYPE-001-N-001` | `TC-CTL-TYPE-001-B-001` | `decoded_fields,error_code` |
+| CTL-TYPE-002 | AS-CTL-TYPE-002-001 | ControlState | P0 | `TC-CTL-TYPE-002-P-001` | `TC-CTL-TYPE-002-N-001` | `TC-CTL-TYPE-002-B-001` | `decoded_fields,error_code` |
+| CTL-TYPE-003 | AS-CTL-TYPE-003-001 | ControlState | P0 | `TC-CTL-TYPE-003-P-001` | `TC-CTL-TYPE-003-N-001` | `TC-CTL-TYPE-003-B-001` | `decoded_fields,error_code` |
+| CTL-TYPE-004 | AS-CTL-TYPE-004-001 | ControlState | P0 | `TC-CTL-TYPE-004-P-001` | `TC-CTL-TYPE-004-N-001` | `TC-CTL-TYPE-004-B-001` | `decoded_fields,error_code` |
+| CTL-TYPE-005 | AS-CTL-TYPE-005-001 | ControlState | P0 | `TC-CTL-TYPE-005-P-001` | `TC-CTL-TYPE-005-N-001` | `TC-CTL-TYPE-005-B-001` | `decoded_fields,error_code` |
+| CTL-TYPE-006 | AS-CTL-TYPE-006-001 | ControlState | P0 | `TC-CTL-TYPE-006-P-001` | `TC-CTL-TYPE-006-N-001` | `TC-CTL-TYPE-006-B-001` | `decoded_fields,error_code` |
+| CTL-THRD-001 | AS-CTL-THRD-001-001 | ControlState | P0 | `TC-CTL-THRD-001-P-001` | `TC-CTL-THRD-001-N-001` | `TC-CTL-THRD-001-B-001` | `decoded_fields,error_code,trace_ref` |
+| CTL-HOPS-001 | AS-CTL-HOPS-001-001 | ControlState | P0 | `TC-CTL-HOPS-001-P-001` | `TC-CTL-HOPS-001-N-001` | `TC-CTL-HOPS-001-B-001` | `decoded_fields,error_code` |
+| NEST-MODE-001 | AS-NEST-MODE-001-001 | NestedRouted | P0 | `TC-NEST-MODE-001-P-001` | `TC-NEST-MODE-001-N-001` | `TC-NEST-MODE-001-B-001` | `packet_hex,decoded_fields` |
+| NEST-MODE-002 | AS-NEST-MODE-002-001 | NestedRouted | P0 | `TC-NEST-MODE-002-P-001` | `TC-NEST-MODE-002-N-001` | `TC-NEST-MODE-002-B-001` | `packet_hex,decoded_fields,error_code` |
+| NEST-MODE-003 | AS-NEST-MODE-003-001 | NestedRouted | P0 | `TC-NEST-MODE-003-P-001` | `TC-NEST-MODE-003-N-001` | `TC-NEST-MODE-003-B-001` | `decoded_fields,error_code` |
+| RTE-MODE-001 | AS-RTE-MODE-001-001 | NestedRouted | P0 | `TC-RTE-MODE-001-P-001` | `TC-RTE-MODE-001-N-001` | `TC-RTE-MODE-001-B-001` | `packet_hex,decoded_fields` |
+| RTE-MODE-002 | AS-RTE-MODE-002-001 | NestedRouted | P0 | `TC-RTE-MODE-002-P-001` | `TC-RTE-MODE-002-N-001` | `TC-RTE-MODE-002-B-001` | `packet_hex,decoded_fields,error_code` |
+| RTE-MODE-003 | AS-RTE-MODE-003-001 | NestedRouted | P0 | `TC-RTE-MODE-003-P-001` | `TC-RTE-MODE-003-N-001` | `TC-RTE-MODE-003-B-001` | `packet_hex,decoded_fields` |
+| RTE-MODE-004 | AS-RTE-MODE-004-001 | NestedRouted | P0 | `TC-RTE-MODE-004-P-001` | `TC-RTE-MODE-004-N-001` | `TC-RTE-MODE-004-B-001` | `packet_hex,decoded_fields,trace_ref` |
+| RTE-MODE-006 | AS-RTE-MODE-006-001 | NestedRouted | P0 | `TC-RTE-MODE-006-P-001` | `TC-RTE-MODE-006-N-001` | `TC-RTE-MODE-006-B-001` | `decoded_fields,error_code` |
+| CRY-ALG-003 | AS-CRY-ALG-003-001 | Crypto | P0 | `TC-CRY-ALG-003-P-001` | `TC-CRY-ALG-003-N-001` | `TC-CRY-ALG-003-B-001` | `decoded_fields,error_code,packet_hex` |
+| CRY-HPKE-001 | AS-CRY-HPKE-001-001 | Crypto | P0 | `TC-CRY-HPKE-001-P-001` | `TC-CRY-HPKE-001-N-001` | `TC-CRY-HPKE-001-B-001` | `decoded_fields,error_code,implementation_profile` |
+| CRY-HPKE-002 | AS-CRY-HPKE-002-001 | Crypto | P0 | `TC-CRY-HPKE-002-P-001` | `TC-CRY-HPKE-002-N-001` | `TC-CRY-HPKE-002-B-001` | `decoded_fields,error_code,packet_hex` |
+| CRY-SIG-001 | AS-CRY-SIG-001-001 | Crypto | P0 | `TC-CRY-SIG-001-P-001` | `TC-CRY-SIG-001-N-001` | `TC-CRY-SIG-001-B-001` | `packet_hex,decoded_fields,error_code` |
+| ENC-CESR-001 | AS-ENC-CESR-001-001 | Encoding | P0 | `TC-ENC-CESR-001-P-001` | `TC-ENC-CESR-001-N-001` | `TC-ENC-CESR-001-B-001` | `packet_hex,error_code` |
+| ENC-CESR-002 | AS-ENC-CESR-002-001 | Encoding | P0 | `TC-ENC-CESR-002-P-001` | `TC-ENC-CESR-002-N-001` | `TC-ENC-CESR-002-B-001` | `packet_hex,decoded_fields,error_code` |
+| ENC-PAY-001 | AS-ENC-PAY-001-001 | Encoding | P0 | `TC-ENC-PAY-001-P-001` | `TC-ENC-PAY-001-N-001` | `TC-ENC-PAY-001-B-001` | `packet_hex,decoded_fields,error_code` |
+| ENC-PAY-002 | AS-ENC-PAY-002-001 | Encoding | P0 | `TC-ENC-PAY-002-P-001` | `TC-ENC-PAY-002-N-001` | `TC-ENC-PAY-002-B-001` | `packet_hex,decoded_fields,error_code` |
+| ENC-PAY-003 | AS-ENC-PAY-003-001 | Encoding | P0 | `TC-ENC-PAY-003-P-001` | `TC-ENC-PAY-003-N-001` | `TC-ENC-PAY-003-B-001` | `packet_hex,decoded_fields,error_code` |
+| ENC-PARSE-001 | AS-ENC-PARSE-001-001 | Encoding | P0 | `TC-ENC-PARSE-001-P-001` | `TC-ENC-PARSE-001-N-001` | `TC-ENC-PARSE-001-B-001` | `packet_hex,error_code` |
+| ENC-BOUND-001 | AS-ENC-BOUND-001-001 | Encoding | P0 | `TC-ENC-BOUND-001-P-001` | `TC-ENC-BOUND-001-N-001` | `TC-ENC-BOUND-001-B-001` | `packet_hex,error_code` |
+| TRN-INTF-001 | AS-TRN-INTF-001-001 | Transport | P0 | `TC-TRN-INTF-001-P-001` | `TC-TRN-INTF-001-N-001` | `TC-TRN-INTF-001-B-001` | `trace_ref,error_code` |
+| TRN-INTF-002 | AS-TRN-INTF-002-001 | Transport | P0 | `TC-TRN-INTF-002-P-001` | `TC-TRN-INTF-002-N-001` | `TC-TRN-INTF-002-B-001` | `trace_ref,error_code` |
+| TRN-INTF-003 | AS-TRN-INTF-003-001 | Transport | P0 | `TC-TRN-INTF-003-P-001` | `TC-TRN-INTF-003-N-001` | `TC-TRN-INTF-003-B-001` | `trace_ref,error_code` |
+| TRN-INTF-004 | AS-TRN-INTF-004-001 | Transport | P1 | `TC-TRN-INTF-004-P-001` | `TC-TRN-INTF-004-N-001` | `TC-TRN-INTF-004-B-001` | `implementation_profile,trace_ref` |
+| ERR-UNSP-001 | AS-ERR-UNSP-001-001 | ErrorHandling | P1 | `TC-ERR-UNSP-001-P-001` | `TC-ERR-UNSP-001-N-001` | `TC-ERR-UNSP-001-B-001` | `error_code,trace_ref` |
+| ERR-UNSP-002 | AS-ERR-UNSP-002-001 | ErrorHandling | P1 | `TC-ERR-UNSP-002-P-001` | `TC-ERR-UNSP-002-N-001` | `TC-ERR-UNSP-002-B-001` | `error_code,trace_ref` |
+| ERR-VAL-001 | AS-ERR-VAL-001-001 | ErrorHandling | P0 | `TC-ERR-VAL-001-P-001` | `TC-ERR-VAL-001-N-001` | `TC-ERR-VAL-001-B-001` | `error_code,packet_hex` |
+
+## Matrix Completion Rules
+
+1. All `MUST` clauses require at least `P` and `N` cases before implementation starts.
+2. `B` cases are required for every parser, framing, and cryptography clause.
+3. A test cannot move to executable backlog without all required evidence keys defined.
+4. Clause rows marked `P0` are mandatory for baseline conformance profile `TSP-REV2-CORE`.

--- a/docs/validation/03-test-taxonomy.md
+++ b/docs/validation/03-test-taxonomy.md
@@ -1,0 +1,107 @@
+# Test Taxonomy and Coverage Levels
+
+This document defines the test family model for converting clause requirements into executable validation sets.
+
+## Family Definitions
+
+1. `Identifier`
+- VID format support (DID/URN)
+- Uniqueness and metadata obligations
+- Inner-identifier generation and correlation constraints
+
+2. `MessageStructure`
+- Envelope field presence and ordering
+- Confidential vs non-confidential message shape
+- Required signature and ciphertext groups
+
+3. `ControlState`
+- Control payload field validation
+- Thread/digest linkage checks
+- Relationship lifecycle transitions (request/accept/cancel/referral)
+
+4. `NestedRouted`
+- Nested message encapsulation invariants
+- Routed message hop/route semantics
+- Intermediary forwarding behavior and visibility boundaries
+
+5. `Crypto`
+- Algorithm profile support declarations
+- Crypto mode compatibility
+- Signature coverage and recipient binding
+
+6. `Encoding`
+- CESR framing, selectors, and length/group boundaries
+- Unknown selector and malformed payload rejection
+- Multi-signature parsing tolerance
+
+7. `Transport`
+- Send/receive contract behavior
+- Endpoint binding requirements for receiving identities
+- Binding-level error signaling behavior
+
+8. `ErrorHandling`
+- Unsupported message type behavior
+- Parsing and validation failure handling
+- Fail-closed guarantees on protected payload violations
+
+## Case Types
+
+- `P` (Positive): valid input and expected accept behavior
+- `N` (Negative): invalid input and expected reject behavior
+- `B` (Boundary): limits, empty values, repeated values, max-size, ordering
+
+## Coverage Profiles
+
+`TSP-REV2-CORE`:
+
+- Includes all `P0` rows in `02-conformance-matrix.md`
+- Mandatory for baseline conformance claim
+
+`TSP-REV2-EXTENDED`:
+
+- Includes all `P0` and `P1` rows
+- Adds optional/capability profile checks
+
+`TSP-REV2-FULL`:
+
+- Includes `P0`, `P1`, and `P2`
+- Includes stress and interop variants for each mandatory clause
+
+## Execution Layers
+
+Layer 1: Deterministic parser and structure validation
+
+- No network dependencies
+- Canonical encoded vectors only
+
+Layer 2: Cryptographic and control-message semantic validation
+
+- Requires key material and deterministic vector fixtures
+- Includes tampering and mismatch cases
+
+Layer 3: Transport and routing behavior validation
+
+- Requires endpoint setup and trace collection
+- Includes intermediary behavior checks
+
+Layer 4: Interoperability validation
+
+- Cross-language or cross-implementation vector replay
+- Strict evidence capture and result normalization
+
+## Priority Rules
+
+1. Start with Layer 1 and Layer 2 for `P0` clauses.
+2. Move to Layer 3 only after deterministic evidence formats are stable.
+3. Layer 4 requires frozen vectors and versioned expected outcomes.
+
+## Exit Criteria Per Family
+
+- `Identifier`: all VID-format and metadata clauses mapped with `P/N/B`
+- `MessageStructure`: all mandatory envelope/group rules have deterministic rejects
+- `ControlState`: all control payload types include mismatch and replay negatives
+- `NestedRouted`: all route and nested invariants include intermediary-focused negatives
+- `Crypto`: each required profile has a valid and invalid fixture set
+- `Encoding`: malformed CESR classes covered with fail-closed assertions
+- `Transport`: send/receive contracts have endpoint and callback failure tests
+- `ErrorHandling`: unsupported and malformed behavior never yields partial acceptance

--- a/docs/validation/04-test-case-template.md
+++ b/docs/validation/04-test-case-template.md
@@ -1,0 +1,124 @@
+# Test Case Template
+
+Use this template for every test in the validation set.
+
+## 1. Metadata
+
+- Test ID: `TC-<ClauseID>-<P|N|B>-<NNN>`
+- Clause ID: `<DOMAIN>-<SUBDOMAIN>-<NNN>`
+- Assertion ID: `AS-<ClauseID>-<NNN>`
+- Priority: `P0 | P1 | P2`
+- Family: `Identifier | MessageStructure | ControlState | NestedRouted | Crypto | Encoding | Transport | ErrorHandling`
+- Baseline: `TSP Rev 2`
+
+## 2. Objective
+
+State one sentence describing what this test proves or disproves.
+
+## 3. Inputs
+
+- Input vector ID:
+- Encoded payload source:
+- Key material profile:
+- Transport profile (if applicable):
+- Feature flags/profile assumptions:
+
+## 4. Preconditions
+
+- Required local identities:
+- Required verified identities:
+- Required relationship state:
+- Required transport bindings:
+
+## 5. Procedure
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+## 6. Expected Result
+
+- Accept/Reject expectation:
+- Expected decoded field invariants:
+- Expected control-state transitions:
+- Expected error category (if rejection expected):
+
+## 7. Evidence Requirements
+
+- `packet_hex`
+- `decoded_fields`
+- `error_code`
+- `trace_ref`
+- `timestamp_utc`
+- `implementation_profile`
+
+## 8. Verdict Rule
+
+- `PASS` when all expected invariants match and no forbidden behavior appears.
+- `FAIL` when any required invariant is violated.
+- `INCONCLUSIVE` when required evidence keys are missing.
+- `BLOCKED` when preconditions are unmet.
+
+## 9. Security Notes
+
+- Abuse case class:
+- Replay relevance:
+- Tampering relevance:
+- Downgrade relevance:
+
+## 10. Traceability
+
+- Spec anchor:
+- Related clause IDs:
+- Related gap register IDs:
+
+---
+
+## Canonical YAML Skeleton
+
+```yaml
+test_id: TC-CRY-SIG-001-N-001
+clause_id: CRY-SIG-001
+assertion_id: AS-CRY-SIG-001-001
+priority: P0
+family: Crypto
+baseline: tsp_rev2
+objective: Reject message when outer signature does not cover protected envelope+ciphertext section.
+inputs:
+  vector_id: VEC-CRY-SIG-NEG-001
+  encoded_payload_ref: vectors/cry_sig_neg_001.bin
+  key_profile: ed25519_x25519
+  transport_profile: none
+  implementation_profile: default
+preconditions:
+  local_identity: receiver_vid_a
+  verified_identity: sender_vid_b
+  relationship_state: established
+procedure:
+  - load payload bytes
+  - invoke open/verify path
+  - capture result and decoded fields
+expected:
+  action: reject
+  error_category: signature_verification_failed
+evidence_required:
+  - packet_hex
+  - decoded_fields
+  - error_code
+  - trace_ref
+  - timestamp_utc
+verdict_rule:
+  pass_if:
+    - result.action == reject
+    - result.error_category == signature_verification_failed
+  fail_if:
+    - result.action == accept
+security_notes:
+  abuse_class: forgery
+  replay_relevance: medium
+traceability:
+  spec_anchor: "#confidential-message"
+  related_clauses:
+    - MSG-CONF-003
+    - CRY-SIG-001
+```

--- a/docs/validation/05-known-gaps-vs-current-impl.md
+++ b/docs/validation/05-known-gaps-vs-current-impl.md
@@ -1,0 +1,41 @@
+# Observed Gaps: Protocol Baseline vs Current Repository
+
+This register captures observed differences and uncertainty points between the protocol baseline and current repository behavior.
+
+Important:
+
+- This is an observation log, not a conformance verdict.
+- Each item must be validated by protocol-derived tests before concluding pass/fail.
+
+## Gap Register
+
+| Gap ID | Observation | Protocol Impact | Evidence In Repo | Confidence | Planned Validation |
+| --- | --- | --- | --- | --- | --- |
+| GAP-001 | Current VID implementations appear focused on `did:web`, `did:peer`, and `did:webvh`; no obvious URN resolver path found. | Affects `VID-FORM-002` (MUST support URN syntax). | `tsp_sdk/src/vid/did/mod.rs`, `tsp_sdk/src/vid/resolve.rs`, `README.md` | Medium | Add positive URN parsing/resolution case and a capability profile check. |
+| GAP-002 | HPKE base/auth support appears feature-controlled (`essr`) rather than guaranteed in all build profiles. | Affects `CRY-HPKE-001` (MUST support both HPKE modes in baseline profile). | `tsp_sdk/src/cesr/packet.rs`, `tsp_sdk/src/crypto/tsp_hpke.rs` | Medium | Add build-profile conformance matrix by feature set and profile claim. |
+| GAP-003 | Optional NaCl/libsodium crypto support exists behind feature flags and may not be covered by the baseline spec profile. | Potentially affects extension claims; baseline should remain HPKE-focused (`CRY-HPKE-*`). | `tsp_sdk/src/crypto/tsp_nacl.rs`, `tsp_sdk/src/crypto/mod.rs` | Medium | Treat as capability-only until spec makes it normative; add profile metadata evidence. |
+| GAP-004 | Additional temporary payload selectors exist (`X3RR`, `XRNI`, `XRNA`) and may not align with baseline control payload set. | Affects `MSG-CTRL-001` and control payload strictness. | `tsp_sdk/src/cesr/packet.rs` | High | Add strict unknown/extension selector behavior tests. |
+| GAP-005 | Current parser/signature path appears centered on a single signature block in main verify/open flow. | Potentially impacts signature block parsing expectations (`MSG-SIG-001`) and any future multi-signature extensions (treat as `SPEC_GAP` until the spec is explicit). | `tsp_sdk/src/crypto/mod.rs`, `tsp_sdk/src/cesr/packet.rs` | Medium | Keep baseline tests single-signature; track multi-signature as future extension vectors if/when specified. |
+| GAP-006 | Local technical spec and implementation docs are SDK-oriented and may not reflect all protocol-level transport obligations. | Affects `TRN-INTF-*` clause coverage completeness. | `docs/src/TSP-technical-specification.md`, `docs/src/transport.md` | High | Build transport-interface tests directly from protocol clauses, not SDK docs. |
+| GAP-007 | Protocol baseline presents DID and URN as required VID formats, but CLI and examples emphasize DID-only workflows. | Affects end-to-end coverage of VID format MUSTs. | `examples/src/cli.rs`, `docs/src/cli/*.md` | Medium | Add explicit URN-path test fixtures at protocol layer (non-CLI if needed). |
+| GAP-008 | Current test suite is scenario-heavy and not clause-traceable to baseline normative requirements. | Affects auditability and regression precision for all clause domains. | `tsp_sdk/src/test.rs`, `examples/tests/cli_tests.rs` | High | Introduce clause-tagged test IDs and evidence schema before expansion. |
+| GAP-009 | Optional ML-DSA support exists, but conformance metadata for crypto capabilities is not formalized. | Affects how extension claims are expressed (baseline remains `CRY-ALG-003`, `CRY-HPKE-*`). | `tsp_sdk/src/definitions/mod.rs`, `tsp_sdk/src/cesr/packet.rs` | Medium | Require `implementation_profile` evidence to include declared capabilities and feature flags. |
+| GAP-010 | Version signaling is present in encoding constants but not yet tied to a documented conformance profile matrix. | Affects future compatibility and versioned clause mapping. | `tsp_sdk/src/cesr/packet.rs` (`TSP_VERSION`) | Medium | Add baseline/profile/version mapping in versioning policy tests. |
+
+## Risk Buckets
+
+- High risk:
+  - baseline clause omission due implementation-driven assumptions
+  - extension selectors accepted without policy controls
+  - non-traceable scenario tests masking normative gaps
+- Medium risk:
+  - feature-flag-dependent crypto mode conformance
+  - optional profile claims without declaration discipline
+  - DID-centric workflows under-covering URN requirements
+
+## Resolution Workflow
+
+1. Each gap maps to one or more clause IDs.
+2. Add test design entries in `02-conformance-matrix.md`.
+3. Create test vectors with `04-test-case-template.md`.
+4. Resolve only through protocol-derived evidence.

--- a/docs/validation/06-versioning-and-diff-policy.md
+++ b/docs/validation/06-versioning-and-diff-policy.md
@@ -1,0 +1,89 @@
+# Versioning and Spec Diff Policy
+
+This policy defines how the validation package tracks changes after the Rev 2 baseline.
+
+## 1. Baseline Lock
+
+- Baseline tag: `TSP-REV2`
+- Baseline source: `https://trustoverip.github.io/tswg-tsp-specification/`
+- Lock date: `2026-02-26`
+- Current catalog version: `v1`
+
+No clause renumbering is allowed within a locked baseline.
+
+## 2. Clause Lifecycle States
+
+- `Active`: required by current baseline
+- `Superseded`: replaced by newer clause behavior in a later baseline
+- `Deprecated`: retained for backward-reference only
+- `Removed`: no longer applicable and excluded from active profiles
+
+## 3. Change Types
+
+Type A: Editorial-only change
+
+- Wording clarification with no behavior change
+- Action: keep Clause ID, update notes only
+
+Type B: Behavioral change
+
+- Requirement semantics changed
+- Action: create new Clause ID and link predecessor as superseded
+
+Type C: New requirement
+
+- New normative clause appears
+- Action: add new Clause ID and add mandatory matrix row
+
+Type D: Requirement removal
+
+- Clause removed from spec
+- Action: mark old Clause ID deprecated or removed based on compatibility policy
+
+## 4. Baseline Upgrade Procedure
+
+1. Capture new spec snapshot and freeze source hash/reference.
+2. Run clause diff against previous catalog.
+3. Classify each change as Type A/B/C/D.
+4. Update:
+   - `01-spec-clause-catalog.md`
+   - `02-conformance-matrix.md`
+   - `05-known-gaps-vs-current-impl.md` (if impact changes)
+5. Publish profile migration note:
+   - from `TSP-REV2` to `TSP-REVX`
+   - mandatory test delta list
+
+## 5. Conformance Profiles and Claims
+
+Profiles:
+
+- `TSP-REV2-CORE`
+- `TSP-REV2-EXTENDED`
+- `TSP-REV2-FULL`
+
+A conformance claim must specify:
+
+- protocol baseline tag
+- profile name
+- implementation version/commit
+- enabled feature set
+- execution date and evidence bundle reference
+
+## 6. Compatibility Rules
+
+1. A profile claim for `TSP-REV2` cannot be reused for later baselines without rerun.
+2. Feature-flag changes require re-validation for impacted clauses.
+3. `SHOULD` and `MAY` capability claims must be explicit in implementation profile metadata.
+
+## 7. Governance and Review
+
+- Clause catalog changes require one protocol reviewer and one test-framework reviewer.
+- Gap register changes require direct evidence references.
+- Any unresolved ambiguity must be tagged `SPEC_GAP` and linked to an upstream issue discussion.
+
+## 8. Artifacts Required Per Upgrade
+
+- Updated clause catalog diff report
+- Updated conformance matrix diff report
+- Updated gap register
+- New/retired test-vector manifest

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -1,0 +1,39 @@
+# TSP Protocol Validation Design Package
+
+This directory defines the documentation-first validation design for TSP protocol conformance.
+
+The package is intentionally protocol-first:
+
+- The protocol specification is the authority.
+- Repository behavior is observational input only.
+- A passing implementation must satisfy protocol-derived assertions, not implementation-derived expectations.
+
+## Baseline
+
+- Baseline specification: `v1.0 Experimental Implementor's Draft Rev 2`
+- Baseline URL: `https://trustoverip.github.io/tswg-tsp-specification/`
+- Baseline lock date: `2026-02-25`
+
+## Contents
+
+- `00-charter.md`: scope, goals, conformance model, evidence model
+- `01-spec-clause-catalog.md`: clause IDs and normalized protocol requirements
+- `02-conformance-matrix.md`: clause-to-test mapping and required evidence
+- `03-test-taxonomy.md`: test families, coverage levels, and execution strategy
+- `04-test-case-template.md`: standard test-case and test-vector templates
+- `05-known-gaps-vs-current-impl.md`: observed protocol-vs-repo gap register
+- `06-versioning-and-diff-policy.md`: baseline maintenance and spec diff process
+
+## How To Use
+
+1. Start from `01-spec-clause-catalog.md` to identify the clause ID.
+2. Find its mapped test entry in `02-conformance-matrix.md`.
+3. Instantiate the test with `04-test-case-template.md`.
+4. Collect evidence as defined in `00-charter.md`.
+5. Track uncertain semantics using `SPEC_GAP` as defined in the charter.
+
+## Non-Goals For This Package
+
+- No SDK/API changes.
+- No executable test implementation.
+- No conformance verdict for any current implementation.


### PR DESCRIPTION
Closing #244

Add docs/validation/: clause catalog, conformance matrix, test taxonomy, test case template, versioning policy, and implementation gap register