### PR TITLE
Split network benchmark timings and gate tsp bench

### DIFF
--- a/docs/src/benchmark.md
+++ b/docs/src/benchmark.md
@@ -1,7 +1,7 @@
 TSP SDK Performance metrics
 ===========================
 
-For network traffic benchmark with `tsp bench`, see
+For network traffic benchmark with `tsp bench` built with the `examples` `bench` feature, see
 [Network Traffic Benchmark](./network-traffic-benchmark.md).
 
 To benchmark the TSP SDK on your machine, you can create a test executable. For the

--- a/docs/src/cli/base.md
+++ b/docs/src/cli/base.md
@@ -200,15 +200,20 @@ The TSP SDK also provides a couple more transport types and provides methods to 
 ### Transport benchmark traffic (`bench`)
 
 The CLI includes an `iperf`-like benchmark mode for sustained traffic tests.
+This subcommand is available only when the `examples` crate is built with the `bench` feature.
 
 Quick start:
 
 ```sh
-tsp --wallet bob bench server
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet bob \
+  bench server
 ```
 
 ```sh
-tsp --wallet alice bench client \
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet alice \
+  bench client \
   --profile local-tcp \
   --payload-size 1KiB \
   --duration 30s

--- a/docs/src/cli/installation.md
+++ b/docs/src/cli/installation.md
@@ -25,6 +25,12 @@ Installing the TSP CLI program:
 cargo install --git https://github.com/openwallet-foundation-labs/tsp.git examples --bin tsp
 ```
 
+To include the optional `bench` subcommand:
+
+```sh
+cargo install --git https://github.com/openwallet-foundation-labs/tsp.git examples --bin tsp --features bench
+```
+
 **Note:** If you clone the whole repository instead and want to build or test everything in there, you need a working Python
 installation on your system, because it includes language bindings for Python and JavaScript. Please refer to 
 the [Python Section](../python.md#tsp-python-bindings) for more information.
@@ -59,7 +65,6 @@ Commands:
   accept      accept a relationship
   cancel      break up a relationship
   secret      manage custom secret data
-  bench       run transport benchmark tests
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -72,4 +77,10 @@ Options:
   -h, --help                     Print help
   -V, --version                  Print version
 
+```
+
+If the CLI is installed or built with `--features bench`, the help output also includes:
+
+```text
+  bench       run transport benchmark traffic tests
 ```

--- a/docs/src/network-traffic-benchmark.md
+++ b/docs/src/network-traffic-benchmark.md
@@ -3,19 +3,25 @@ TSP Network Traffic Benchmark
 
 For local `seal` and `open` benchmark, see [Benchmark](./benchmark.md).
 Use `tsp bench` for sustained transport traffic tests.
+The `bench` subcommand is behind the optional `bench` feature in `examples`.
+The commands below use `cargo run` so the required feature is explicit.
 
 ## Quick start
 
 Server:
 
 ```sh
-tsp --wallet bob bench server
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet bob \
+  bench server
 ```
 
 Client:
 
 ```sh
-tsp --wallet alice bench client \
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet alice \
+  bench client \
   --profile local-tcp \
   --payload-size 1KiB \
   --duration 30s
@@ -35,11 +41,16 @@ tsp --wallet alice bench client \
 Hosted HTTP baseline:
 
 ```sh
-tsp --wallet bench-http-b bench server --profile hosted-http
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet bench-http-b \
+  bench server \
+  --profile hosted-http
 ```
 
 ```sh
-tsp --wallet bench-http-a bench client \
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet bench-http-a \
+  bench client \
   --profile hosted-http \
   --payload-size 1KiB \
   --duration 30s
@@ -50,7 +61,9 @@ tsp --wallet bench-http-a bench client \
 Latency mode:
 
 ```sh
-tsp --wallet alice bench client \
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet alice \
+  bench client \
   --payload-size 1KiB \
   --duration 30s \
   --mode latency
@@ -77,13 +90,15 @@ Server and client support `--json` for machine-readable summary output.
 Example:
 
 ```sh
-tsp --wallet alice bench client ... --json
+cargo run -p examples --bin tsp --features bench -- \
+  --wallet alice \
+  bench client ... --json
 ```
 
 ## Compare with `iperf3`
 
 1. Run `iperf3` with the same host, port, payload, and duration.
-2. Run `tsp bench` with the same settings.
+2. Run `tsp bench` with the same settings, using a binary built with `--features bench`.
 3. Compare bandwidth and latency distribution.
 
 For baseline tests, prefer HTTP(S) first because reqwest reuses pooled connections.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 
 [features]
 default = ["nacl"]
+bench = ["tsp_sdk/bench-network-timings"]
 nacl = ["tsp_sdk/nacl"]
 essr = ["tsp_sdk/essr"]
 use_local_certificate = ["tsp_sdk/use_local_certificate"]

--- a/examples/src/bench.rs
+++ b/examples/src/bench.rs
@@ -33,6 +33,16 @@ const BUILTIN_TLS_ALICE_PIV: &str = include_str!("../test/tls-alice/piv.json");
 const BUILTIN_TLS_BOB_PIV: &str = include_str!("../test/tls-bob/piv.json");
 const SERVER_SESSION_IDLE_GAP_MULTIPLIER: u32 = 2;
 
+fn run_measured<T, E>(
+    f: impl FnOnce() -> Result<T, E>,
+) -> Result<(T, tsp_sdk::BenchNetworkTimings), E> {
+    tsp_sdk::reset_bench_network_timings();
+    let result = f();
+    let timings = tsp_sdk::take_bench_network_timings();
+
+    result.map(|value| (value, timings))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FrameKind {
     ThroughputData = 1,
@@ -209,8 +219,10 @@ impl BenchMode {
 struct ThroughputStats {
     transfer_bytes: u64,
     messages: u64,
-    seal_us: Vec<f64>,
-    open_us: Vec<f64>,
+    signature_us: Vec<f64>,
+    seal_core_us: Vec<f64>,
+    verify_us: Vec<f64>,
+    open_core_us: Vec<f64>,
 }
 
 impl ThroughputStats {
@@ -218,16 +230,18 @@ impl ThroughputStats {
         self.messages == 0
     }
 
-    fn record_send(&mut self, bytes: u64, seal_us: f64) {
+    fn record_send(&mut self, bytes: u64, signature_us: f64, seal_core_us: f64) {
         self.transfer_bytes += bytes;
         self.messages += 1;
-        self.seal_us.push(seal_us);
+        self.signature_us.push(signature_us);
+        self.seal_core_us.push(seal_core_us);
     }
 
-    fn record_recv(&mut self, bytes: u64, open_us: f64) {
+    fn record_recv(&mut self, bytes: u64, verify_us: f64, open_core_us: f64) {
         self.transfer_bytes += bytes;
         self.messages += 1;
-        self.open_us.push(open_us);
+        self.verify_us.push(verify_us);
+        self.open_core_us.push(open_core_us);
     }
 
     fn reset(&mut self) {
@@ -239,7 +253,8 @@ impl ThroughputStats {
 struct LatencyStats {
     messages: u64,
     transfer_bytes: u64,
-    seal_us: Vec<f64>,
+    signature_us: Vec<f64>,
+    seal_core_us: Vec<f64>,
     rtt_us: Vec<f64>,
     jitter_us: Vec<f64>,
 }
@@ -249,10 +264,18 @@ impl LatencyStats {
         self.messages == 0
     }
 
-    fn record(&mut self, bytes: u64, seal_us: f64, rtt_us: f64, jitter_us: Option<f64>) {
+    fn record(
+        &mut self,
+        bytes: u64,
+        signature_us: f64,
+        seal_core_us: f64,
+        rtt_us: f64,
+        jitter_us: Option<f64>,
+    ) {
         self.transfer_bytes += bytes;
         self.messages += 1;
-        self.seal_us.push(seal_us);
+        self.signature_us.push(signature_us);
+        self.seal_core_us.push(seal_core_us);
         self.rtt_us.push(rtt_us);
         if let Some(v) = jitter_us {
             self.jitter_us.push(v);
@@ -293,8 +316,14 @@ struct ThroughputMetricsJson {
     messages: u64,
     msg_per_sec: f64,
     bandwidth_bps: f64,
-    seal_us: Percentiles,
-    open_us: Percentiles,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    signature_us: Option<Percentiles>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seal_core_us: Option<Percentiles>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verify_us: Option<Percentiles>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    open_core_us: Option<Percentiles>,
 }
 
 #[derive(Serialize)]
@@ -303,7 +332,8 @@ struct LatencyMetricsJson {
     transfer_bytes: u64,
     msg_per_sec: f64,
     bandwidth_bps: f64,
-    seal_us: Percentiles,
+    signature_us: Percentiles,
+    seal_core_us: Percentiles,
     rtt_us: PercentilesWithStddev,
     jitter_us: JitterMetrics,
 }
@@ -826,26 +856,42 @@ fn format_bits_per_sec(bps: f64) -> String {
     format!("{value:.2} {unit}")
 }
 
-fn print_throughput_header() {
-    println!(
-        "[ ID] {:>12}  {:>6}  {:>12}  {:>8}  {:>10}  {:>15}  {:>12}  {:>12}",
-        "Interval",
-        "Proto",
-        "Transfer",
-        "Messages",
-        "Msg/s",
-        "Bandwidth",
-        "Seal_us(p50)",
-        "Open_us(p50)"
-    );
+fn print_throughput_header(_server_side: bool) {
+    if _server_side {
+        println!(
+            "[ ID] {:>12}  {:>6}  {:>12}  {:>8}  {:>10}  {:>15}  {:>13}  {:>15}",
+            "Interval",
+            "Proto",
+            "Transfer",
+            "Messages",
+            "Msg/s",
+            "Bandwidth",
+            "Verify_us(p50)",
+            "OpenCore_us(p50)"
+        );
+    } else {
+        println!(
+            "[ ID] {:>12}  {:>6}  {:>12}  {:>8}  {:>10}  {:>15}  {:>11}  {:>12}",
+            "Interval",
+            "Proto",
+            "Transfer",
+            "Messages",
+            "Msg/s",
+            "Bandwidth",
+            "Sign_us(p50)",
+            "SealCore(p50)"
+        );
+    }
 }
 
 fn print_latency_header() {
     println!(
-        "[ ID] {:>12} {:>6} {:>8} {:>11} {:>7} {:>7} {:>7} {:>10} {:>10} {:>10}",
+        "[ ID] {:>12} {:>6} {:>8} {:>10} {:>10} {:>11} {:>7} {:>7} {:>7} {:>10} {:>10} {:>10}",
         "Interval",
         "Proto",
         "Messages",
+        "Sign_p50",
+        "SealCore",
         "RTT_avg(us)",
         "RTT_p50",
         "RTT_p95",
@@ -856,35 +902,62 @@ fn print_latency_header() {
     );
 }
 
-fn print_throughput_line(id: u32, interval: Duration, stats: &ThroughputStats, protocol: &str) {
+fn print_throughput_line(
+    id: u32,
+    interval: Duration,
+    stats: &ThroughputStats,
+    protocol: &str,
+    _server_side: bool,
+) {
     let elapsed = interval.as_secs_f64().max(f64::EPSILON);
     let msg_per_sec = stats.messages as f64 / elapsed;
     let bps = stats.transfer_bytes as f64 * 8.0 / elapsed;
-    let seal = summarize(&stats.seal_us);
-    let open = summarize(&stats.open_us);
+    let signature = summarize(&stats.signature_us);
+    let seal_core = summarize(&stats.seal_core_us);
+    let verify = summarize(&stats.verify_us);
+    let open_core = summarize(&stats.open_core_us);
 
-    println!(
-        "[{id:>3}] {:>8.1} sec  {:>6}  {:>12}  {:>8}  {:>10.2}  {:>15}  {:>12.1}  {:>12.1}",
-        interval.as_secs_f64(),
-        protocol,
-        format_bytes(stats.transfer_bytes),
-        stats.messages,
-        msg_per_sec,
-        format_bits_per_sec(bps),
-        seal.p50,
-        open.p50,
-    );
+    if _server_side {
+        println!(
+            "[{id:>3}] {:>8.1} sec  {:>6}  {:>12}  {:>8}  {:>10.2}  {:>15}  {:>13.1}  {:>15.1}",
+            interval.as_secs_f64(),
+            protocol,
+            format_bytes(stats.transfer_bytes),
+            stats.messages,
+            msg_per_sec,
+            format_bits_per_sec(bps),
+            verify.p50,
+            open_core.p50,
+        );
+    } else {
+        println!(
+            "[{id:>3}] {:>8.1} sec  {:>6}  {:>12}  {:>8}  {:>10.2}  {:>15}  {:>11.1}  {:>12.1}",
+            interval.as_secs_f64(),
+            protocol,
+            format_bytes(stats.transfer_bytes),
+            stats.messages,
+            msg_per_sec,
+            format_bits_per_sec(bps),
+            signature.p50,
+            seal_core.p50,
+        );
+    }
 }
 
 fn print_latency_line(id: u32, interval: Duration, stats: &LatencyStats, protocol: &str) {
     let rtt = summarize_with_stddev(&stats.rtt_us);
     let jitter = summarize_jitter(&stats.jitter_us);
 
+    let signature = summarize(&stats.signature_us);
+    let seal_core = summarize(&stats.seal_core_us);
+
     println!(
-        "[{id:>3}] {:>8.1} sec {:>6} {:>8} {:>11.1} {:>7.1} {:>7.1} {:>7.1} {:>10.1} {:>10.1} {:>10.1}",
+        "[{id:>3}] {:>8.1} sec {:>6} {:>8} {:>10.1} {:>10.1} {:>11.1} {:>7.1} {:>7.1} {:>7.1} {:>10.1} {:>10.1} {:>10.1}",
         interval.as_secs_f64(),
         protocol,
         stats.messages,
+        signature.p50,
+        seal_core.p50,
         rtt.avg,
         rtt.p50,
         rtt.p95,
@@ -981,7 +1054,7 @@ fn start_server_session(session: &mut ServerSession, started_at: Instant, protoc
 
     println!();
     println!("Session {} started ({protocol})", session.id);
-    print_throughput_header();
+    print_throughput_header(true);
 }
 
 fn maybe_emit_server_window(
@@ -998,7 +1071,7 @@ fn maybe_emit_server_window(
     let window_elapsed = elapsed.saturating_sub(session.last_report_elapsed);
 
     if should_emit_server_window(&session.window, window_elapsed, interval) {
-        print_throughput_line(0, window_elapsed, &session.window, protocol);
+        print_throughput_line(0, window_elapsed, &session.window, protocol, true);
         session.window.reset();
         session.last_report_elapsed = elapsed;
     }
@@ -1020,27 +1093,27 @@ fn finalize_server_session(
     let total_elapsed = measured_end_at.duration_since(started_at);
     if !session.window.is_empty() {
         let window_elapsed = total_elapsed.saturating_sub(session.last_report_elapsed);
-        print_throughput_line(0, window_elapsed, &session.window, protocol);
+        print_throughput_line(0, window_elapsed, &session.window, protocol, true);
         session.window.reset();
     }
 
-    let seal = summarize(&session.total.seal_us);
-    let open = summarize(&session.total.open_us);
+    let verify = summarize(&session.total.verify_us);
+    let open_core = summarize(&session.total.open_core_us);
     let elapsed = total_elapsed.as_secs_f64().max(f64::EPSILON);
     let msg_per_sec = session.total.messages as f64 / elapsed;
     let bandwidth_bps = session.total.transfer_bytes as f64 * 8.0 / elapsed;
 
     println!("Session {} summary:", session.id);
     println!(
-        "[SUM] {:>5.1} sec  {:>6}  {:>12}  {:>8}  {:>10.2}  {:>15}  {:>11.1}  {:>11.1}",
+        "[SUM] {:>5.1} sec  {:>6}  {:>12}  {:>8}  {:>10.2}  {:>15}  {:>13.1}  {:>15.1}",
         total_elapsed.as_secs_f64(),
         protocol,
         format_bytes(session.total.transfer_bytes),
         session.total.messages,
         msg_per_sec,
         format_bits_per_sec(bandwidth_bps),
-        seal.p50,
-        open.p50,
+        verify.p50,
+        open_core.p50,
     );
 
     if json {
@@ -1049,8 +1122,10 @@ fn finalize_server_session(
             messages: session.total.messages,
             msg_per_sec,
             bandwidth_bps,
-            seal_us: seal,
-            open_us: open,
+            signature_us: None,
+            seal_core_us: None,
+            verify_us: Some(verify),
+            open_core_us: Some(open_core),
         };
 
         let payload = BenchJson {
@@ -1127,15 +1202,15 @@ async fn run_server(
                 };
                 let raw_len = raw.len() as u64;
 
-                let open_started = Instant::now();
-                let opened = match store.open_message(&mut raw) {
+                let (opened, timings) = match run_measured(|| store.open_message(&mut raw)) {
                     Ok(v) => v,
                     Err(e) => {
                         eprintln!("bench server decode error: {e}");
                         continue;
                     }
                 };
-                let open_us = open_started.elapsed().as_secs_f64() * 1_000_000.0;
+                let verify_us = timings.verify_ns as f64 / 1_000.0;
+                let open_core_us = timings.open_core_ns as f64 / 1_000.0;
 
                 if let ReceivedTspMessage::GenericMessage { sender, message, .. } = opened
                     && let Some(frame) = parse_frame(message)
@@ -1167,15 +1242,18 @@ async fn run_server(
 
                     observed_any_message = true;
                     session.last_message_at = Some(now);
-                    session.total.record_recv(raw_len, open_us);
-                    session.window.record_recv(raw_len, open_us);
+                    session.total.record_recv(raw_len, verify_us, open_core_us);
+                    session.window.record_recv(raw_len, verify_us, open_core_us);
                     maybe_emit_server_window(&mut session, now, interval, &protocol);
 
                     if frame.kind == FrameKind::LatencyRequest {
-                        let ack_payload =
-                            build_frame(message.len().max(FRAME_HEADER_LEN), FrameKind::LatencyAck, frame.seq);
-                        let (ack_transport, ack_message) =
-                            store.seal_message(&vid, &sender, None, &ack_payload)?;
+                        let ack_payload = build_frame(
+                            message.len().max(FRAME_HEADER_LEN),
+                            FrameKind::LatencyAck,
+                            frame.seq,
+                        );
+                        let ((ack_transport, ack_message), _) =
+                            run_measured(|| store.seal_message(&vid, &sender, None, &ack_payload))?;
                         if let Err(e) = transport::send_message(&ack_transport, &ack_message).await {
                             eprintln!("bench server failed to send ack: {e}");
                         }
@@ -1198,8 +1276,10 @@ async fn run_server(
                 messages: 0,
                 msg_per_sec: 0.0,
                 bandwidth_bps: 0.0,
-                seal_us: summarize(&[]),
-                open_us: summarize(&[]),
+                signature_us: None,
+                seal_core_us: None,
+                verify_us: Some(summarize(&[])),
+                open_core_us: Some(summarize(&[])),
             };
 
             let payload = BenchJson {
@@ -1260,7 +1340,7 @@ async fn run_client_throughput(
     let transport_url = resolve_client_transport(store, &receiver, transport_override)?;
     let protocol = transport_url.scheme().to_ascii_uppercase();
 
-    print_throughput_header();
+    print_throughput_header(false);
 
     let started_at = Instant::now();
     let mut last_report_at = Duration::ZERO;
@@ -1272,21 +1352,22 @@ async fn run_client_throughput(
         seq = seq.wrapping_add(1);
         let payload = build_frame(payload_size, FrameKind::ThroughputData, seq);
 
-        let seal_started = Instant::now();
-        let (_, message) = store.seal_message(&sender, &receiver, None, &payload)?;
-        let seal_us = seal_started.elapsed().as_secs_f64() * 1_000_000.0;
+        let ((_, message), timings) =
+            run_measured(|| store.seal_message(&sender, &receiver, None, &payload))?;
+        let signature_us = timings.signature_ns as f64 / 1_000.0;
+        let seal_core_us = timings.seal_core_ns as f64 / 1_000.0;
 
         transport::send_message(&transport_url, &message).await?;
 
         let elapsed = started_at.elapsed();
         if elapsed > warmup {
-            total.record_send(message.len() as u64, seal_us);
-            window.record_send(message.len() as u64, seal_us);
+            total.record_send(message.len() as u64, signature_us, seal_core_us);
+            window.record_send(message.len() as u64, signature_us, seal_core_us);
 
             let measured_elapsed = elapsed.saturating_sub(warmup);
             if measured_elapsed.saturating_sub(last_report_at) >= interval && !window.is_empty() {
                 let window_elapsed = measured_elapsed.saturating_sub(last_report_at);
-                print_throughput_line(0, window_elapsed, &window, &protocol);
+                print_throughput_line(0, window_elapsed, &window, &protocol, false);
                 window.reset();
                 last_report_at = measured_elapsed;
             }
@@ -1297,26 +1378,26 @@ async fn run_client_throughput(
     if !window.is_empty() {
         let window_elapsed = measured_total_elapsed.saturating_sub(last_report_at);
         if !window_elapsed.is_zero() {
-            print_throughput_line(0, window_elapsed, &window, &protocol);
+            print_throughput_line(0, window_elapsed, &window, &protocol, false);
         }
     }
 
-    let seal = summarize(&total.seal_us);
-    let open = summarize(&total.open_us);
+    let signature = summarize(&total.signature_us);
+    let seal_core = summarize(&total.seal_core_us);
     let measured_elapsed_secs = measured_total_elapsed.as_secs_f64().max(f64::EPSILON);
     let msg_per_sec = total.messages as f64 / measured_elapsed_secs;
     let bandwidth_bps = total.transfer_bytes as f64 * 8.0 / measured_elapsed_secs;
 
     println!(
-        "[SUM] {:>5.1} sec  {:>6}  {:>12}  {:>8}  {:>10.2}  {:>15}  {:>11.1}  {:>11}",
+        "[SUM] {:>5.1} sec  {:>6}  {:>12}  {:>8}  {:>10.2}  {:>15}  {:>11.1}  {:>12.1}",
         measured_elapsed_secs,
         protocol,
         format_bytes(total.transfer_bytes),
         total.messages,
         msg_per_sec,
         format_bits_per_sec(bandwidth_bps),
-        seal.p50,
-        "-",
+        signature.p50,
+        seal_core.p50,
     );
 
     if json {
@@ -1325,8 +1406,10 @@ async fn run_client_throughput(
             messages: total.messages,
             msg_per_sec,
             bandwidth_bps,
-            seal_us: seal,
-            open_us: open,
+            signature_us: Some(signature),
+            seal_core_us: Some(seal_core),
+            verify_us: None,
+            open_core_us: None,
         };
 
         let payload = BenchJson {
@@ -1390,9 +1473,10 @@ async fn run_client_latency(
         seq = seq.wrapping_add(1);
 
         let payload = build_frame(payload_size, FrameKind::LatencyRequest, seq);
-        let seal_started = Instant::now();
-        let (_, message) = store.seal_message(&sender, &receiver, None, &payload)?;
-        let seal_us = seal_started.elapsed().as_secs_f64() * 1_000_000.0;
+        let ((_, message), timings) =
+            run_measured(|| store.seal_message(&sender, &receiver, None, &payload))?;
+        let signature_us = timings.signature_ns as f64 / 1_000.0;
+        let seal_core_us = timings.seal_core_ns as f64 / 1_000.0;
         let sent_bytes = message.len() as u64;
 
         let sent_at = Instant::now();
@@ -1414,7 +1498,7 @@ async fn run_client_latency(
         };
 
         let mut raw = ack?;
-        let opened = store.open_message(&mut raw)?;
+        let (opened, _timings) = run_measured(|| store.open_message(&mut raw))?;
 
         let mut accepted = false;
         if let ReceivedTspMessage::GenericMessage {
@@ -1440,8 +1524,8 @@ async fn run_client_latency(
 
         let elapsed = started_at.elapsed();
         if elapsed > warmup {
-            total.record(sent_bytes, seal_us, rtt_us, jitter);
-            window.record(sent_bytes, seal_us, rtt_us, jitter);
+            total.record(sent_bytes, signature_us, seal_core_us, rtt_us, jitter);
+            window.record(sent_bytes, signature_us, seal_core_us, rtt_us, jitter);
 
             let measured_elapsed = elapsed.saturating_sub(warmup);
             if measured_elapsed.saturating_sub(last_report_at) >= interval && !window.is_empty() {
@@ -1465,15 +1549,18 @@ async fn run_client_latency(
     let elapsed_s = measured_elapsed.as_secs_f64().max(f64::EPSILON);
     let msg_per_sec = total.messages as f64 / elapsed_s;
     let bandwidth_bps = total.transfer_bytes as f64 * 8.0 / elapsed_s;
-    let seal = summarize(&total.seal_us);
+    let signature = summarize(&total.signature_us);
+    let seal_core = summarize(&total.seal_core_us);
     let rtt = summarize_with_stddev(&total.rtt_us);
     let jitter = summarize_jitter(&total.jitter_us);
 
     println!(
-        "[SUM] {:>5.1} sec {:>6} {:>8} RTT avg/p95/p99 {:>7.1}/{:>7.1}/{:>7.1} us jitter p95 {:>7.1} us",
+        "[SUM] {:>5.1} sec {:>6} {:>8} sign/seal-core p50 {:>7.1}/{:>7.1} us RTT avg/p95/p99 {:>7.1}/{:>7.1}/{:>7.1} us jitter p95 {:>7.1} us",
         measured_elapsed.as_secs_f64(),
         protocol,
         total.messages,
+        signature.p50,
+        seal_core.p50,
         rtt.avg,
         rtt.p95,
         rtt.p99,
@@ -1486,7 +1573,8 @@ async fn run_client_latency(
             transfer_bytes: total.transfer_bytes,
             msg_per_sec,
             bandwidth_bps,
-            seal_us: seal,
+            signature_us: signature,
+            seal_core_us: seal_core,
             rtt_us: rtt,
             jitter_us: jitter,
         };
@@ -1702,7 +1790,7 @@ mod tests {
     fn server_window_emission_requires_full_interval() {
         let interval = Duration::from_secs(1);
         let mut non_empty = ThroughputStats::default();
-        non_empty.record_recv(1024, 10.0);
+        non_empty.record_recv(1024, 10.0, 20.0);
 
         assert!(!should_emit_server_window(
             &non_empty,
@@ -1740,8 +1828,10 @@ mod tests {
                 messages: 1,
                 msg_per_sec: 1.0,
                 bandwidth_bps: 8.0,
-                seal_us: summarize(&[]),
-                open_us: summarize(&[]),
+                signature_us: None,
+                seal_core_us: None,
+                verify_us: Some(summarize(&[])),
+                open_core_us: Some(summarize(&[])),
             },
         };
 

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -16,6 +16,7 @@ use tsp_sdk::{
 };
 use url::Url;
 
+#[cfg(feature = "bench")]
 mod bench;
 
 #[derive(Default, Debug, Clone)]
@@ -201,6 +202,7 @@ enum Commands {
         #[clap(subcommand)]
         sub: CustomSecretManagement,
     },
+    #[cfg(feature = "bench")]
     #[command(
         arg_required_else_help = true,
         about = "run transport benchmark traffic tests"
@@ -1150,6 +1152,7 @@ async fn run() -> Result<(), Error> {
                 println!("successfully removed secret '{}'", key);
             }
         },
+        #[cfg(feature = "bench")]
         Commands::Bench { sub } => {
             bench::run(sub, &vid_wallet, &args.wallet).await?;
         }

--- a/tsp_sdk/Cargo.toml
+++ b/tsp_sdk/Cargo.toml
@@ -23,6 +23,7 @@ nacl = ["essr"]
 pq = ["dep:hpke_pq", "dep:ml-dsa", "essr"]
 bench-callgrind = ["dep:gungraun"]
 bench-criterion = ["dep:criterion"]
+bench-network-timings = []
 async = [
   "resolve",
   "aries-askar",

--- a/tsp_sdk/src/bench.rs
+++ b/tsp_sdk/src/bench.rs
@@ -1,0 +1,89 @@
+use crate::BenchNetworkTimings;
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+    thread::ThreadId,
+    time::Instant,
+};
+
+struct BenchCollector {
+    per_thread: Mutex<HashMap<ThreadId, BenchNetworkTimings>>,
+}
+
+impl BenchCollector {
+    fn global() -> &'static Self {
+        static GLOBAL: OnceLock<BenchCollector> = OnceLock::new();
+        GLOBAL.get_or_init(|| BenchCollector {
+            per_thread: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<ThreadId, BenchNetworkTimings>> {
+        self.per_thread
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+
+    fn reset_current(&self) {
+        self.lock()
+            .insert(std::thread::current().id(), BenchNetworkTimings::default());
+    }
+
+    fn take_current(&self) -> BenchNetworkTimings {
+        self.lock()
+            .remove(&std::thread::current().id())
+            .unwrap_or_default()
+    }
+
+    fn with_current<R>(&self, f: impl FnOnce(&mut BenchNetworkTimings) -> R) -> R {
+        let thread_id = std::thread::current().id();
+        let mut guard = self.lock();
+        let current = guard.entry(thread_id).or_default();
+        f(current)
+    }
+}
+
+fn with_current(f: impl FnOnce(&mut BenchNetworkTimings)) {
+    BenchCollector::global().with_current(f);
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+pub(crate) fn signature_before() -> u64 {
+    BenchCollector::global().with_current(|timings| timings.signature_ns)
+}
+
+pub(crate) fn record_signature(started: Instant) {
+    let elapsed = elapsed_ns(started);
+    with_current(|timings| {
+        timings.signature_ns = timings.signature_ns.saturating_add(elapsed);
+    });
+}
+
+pub(crate) fn record_verify(started: Instant) {
+    let elapsed = elapsed_ns(started);
+    with_current(|timings| {
+        timings.verify_ns = timings.verify_ns.saturating_add(elapsed);
+    });
+}
+
+pub(crate) fn record_open_core(started: Instant) {
+    let elapsed = elapsed_ns(started);
+    with_current(|timings| {
+        timings.open_core_ns = timings.open_core_ns.saturating_add(elapsed);
+    });
+}
+
+pub(crate) fn record_seal_core(started: Instant, signature_before: u64) {
+    with_current(|timings| timings.record_seal_core(started, signature_before));
+}
+
+pub fn reset() {
+    BenchCollector::global().reset_current();
+}
+
+pub fn take() -> BenchNetworkTimings {
+    BenchCollector::global().take_current()
+}

--- a/tsp_sdk/src/cesr/error.rs
+++ b/tsp_sdk/src/cesr/error.rs
@@ -9,6 +9,7 @@ pub enum EncodeError {
     MissingReceiver,
     #[error("VID is not valid for CESR encoding")]
     InvalidVid,
+    #[error("invalid signature type")]
     InvalidSignatureType,
 }
 

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -13,6 +13,8 @@ use hpke_pq::kem;
 #[cfg(feature = "pq")]
 use ml_dsa::{EncodedVerifyingKey, KeyGen, MlDsa65, signature::Verifier};
 use rand_core::OsRng;
+#[cfg(feature = "bench-network-timings")]
+use std::time::Instant;
 
 pub use digest::{blake2b256, sha256};
 
@@ -343,7 +345,17 @@ pub fn seal(
     nonconfidential_data: Option<NonConfidentialData>,
     payload: Payload<&[u8]>,
 ) -> Result<TSPMessage, CryptoError> {
-    seal_and_hash(sender, receiver, nonconfidential_data, payload, None)
+    #[cfg(feature = "bench-network-timings")]
+    let signature_before = crate::bench::signature_before();
+    #[cfg(feature = "bench-network-timings")]
+    let started = Instant::now();
+
+    let result = seal_and_hash(sender, receiver, nonconfidential_data, payload, None);
+
+    #[cfg(feature = "bench-network-timings")]
+    crate::bench::record_seal_core(started, signature_before);
+
+    result
 }
 
 /// Encrypt, authenticate and sign and CESR encode a TSP message; also returns the hash value of the plaintext parts before encryption
@@ -430,10 +442,16 @@ pub(crate) fn open_with_signature_info<'a>(
     sender: &dyn VerifiedVid,
     tsp_message: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
+    #[cfg(feature = "bench-network-timings")]
+    let open_core_started = std::time::Instant::now();
     let view = crate::cesr::decode_envelope(tsp_message)?;
+    #[cfg(feature = "bench-network-timings")]
+    crate::bench::record_open_core(open_core_started);
 
     // verify outer signature
     let verification_challenge = view.as_challenge();
+    #[cfg(feature = "bench-network-timings")]
+    let verify_started = std::time::Instant::now();
     if !matches!(view.signature_type(), SignatureType::NoSignature) {
         verify_detached(
             sender,
@@ -441,8 +459,12 @@ pub(crate) fn open_with_signature_info<'a>(
             verification_challenge.signature,
         )?;
     }
+    #[cfg(feature = "bench-network-timings")]
+    crate::bench::record_verify(verify_started);
 
     // decode envelope
+    #[cfg(feature = "bench-network-timings")]
+    let open_core_started = std::time::Instant::now();
     let crate::cesr::DecodedEnvelope {
         raw_header,
         envelope,
@@ -459,7 +481,7 @@ pub(crate) fn open_with_signature_info<'a>(
         return Err(CryptoError::UnexpectedRecipient);
     }
 
-    match envelope.crypto_type {
+    let result = match envelope.crypto_type {
         #[cfg(feature = "pq")]
         CryptoType::X25519Kyber768Draft00 => {
             tsp_hpke::open::<Aead, Kdf, kem::X25519Kyber768Draft00>(
@@ -475,7 +497,11 @@ pub(crate) fn open_with_signature_info<'a>(
             tsp_nacl::open(receiver, sender, raw_header, envelope, ciphertext)
         }
         CryptoType::Plaintext => Err(CryptoError::MissingCiphertext),
-    }
+    };
+    #[cfg(feature = "bench-network-timings")]
+    crate::bench::record_open_core(open_core_started);
+
+    result
 }
 
 /// Construct and sign a non-confidential TSP message

--- a/tsp_sdk/src/crypto/nonconfidential.rs
+++ b/tsp_sdk/src/crypto/nonconfidential.rs
@@ -39,19 +39,27 @@ pub fn sign(
     // create and append signature
     match sender.signature_key_type() {
         VidSignatureKeyType::Ed25519 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
             let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
                 sender.signing_key().as_slice(),
             )?);
             let signature = sign_key.sign(&data).to_bytes();
             crate::cesr::encode_signature(&signature, &mut data, SignatureType::Ed25519);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
         }
         #[cfg(feature = "pq")]
         VidSignatureKeyType::MlDsa65 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
             let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
                 &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
             );
             let signature = sign_key.sign(&data).encode();
             crate::cesr::encode_signature(signature.as_slice(), &mut data, SignatureType::MlDsa65);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
         }
     }
 
@@ -63,10 +71,16 @@ pub fn verify<'a>(
     sender: &dyn VerifiedVid,
     tsp_message: &'a mut [u8],
 ) -> Result<(&'a [u8], MessageType), CryptoError> {
+    #[cfg(feature = "bench-network-timings")]
+    let open_core_started = std::time::Instant::now();
     let view = crate::cesr::decode_envelope(tsp_message)?;
+    #[cfg(feature = "bench-network-timings")]
+    crate::bench::record_open_core(open_core_started);
 
     // verify outer signature
     let verification_challenge = view.as_challenge();
+    #[cfg(feature = "bench-network-timings")]
+    let verify_started = std::time::Instant::now();
     match view.signature_type() {
         SignatureType::NoSignature => {}
         SignatureType::Ed25519 => {
@@ -92,8 +106,12 @@ pub fn verify<'a>(
                 .map_err(|err| Verify(sender.identifier().to_string(), err))?;
         }
     }
+    #[cfg(feature = "bench-network-timings")]
+    crate::bench::record_verify(verify_started);
 
     // decode envelope
+    #[cfg(feature = "bench-network-timings")]
+    let open_core_started = std::time::Instant::now();
     let DecodedEnvelope {
         raw_header: _,
         envelope:
@@ -111,6 +129,9 @@ pub fn verify<'a>(
     else {
         return Err(CryptoError::MissingCiphertext);
     };
+
+    #[cfg(feature = "bench-network-timings")]
+    crate::bench::record_open_core(open_core_started);
 
     Ok((
         nonconfidential_data,

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -178,19 +178,27 @@ where
     // create and append signature
     match sender.signature_key_type() {
         VidSignatureKeyType::Ed25519 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
             let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
                 sender.signing_key().as_slice(),
             )?);
             let signature = sign_key.sign(&data).to_bytes();
             crate::cesr::encode_signature(&signature, &mut data, SignatureType::Ed25519);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
         }
         #[cfg(feature = "pq")]
         VidSignatureKeyType::MlDsa65 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
             let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
                 &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
             );
             let signature = sign_key.sign(&data).encode();
             crate::cesr::encode_signature(signature.as_slice(), &mut data, SignatureType::MlDsa65);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
         }
     }
 

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -142,19 +142,27 @@ pub(crate) fn seal(
     // create and append signature
     match sender.signature_key_type() {
         VidSignatureKeyType::Ed25519 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
             let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
                 sender.signing_key().as_slice(),
             )?);
             let signature = sign_key.sign(&data).to_bytes();
             crate::cesr::encode_signature(&signature, &mut data, SignatureType::Ed25519);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
         }
         #[cfg(feature = "pq")]
         VidSignatureKeyType::MlDsa65 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
             let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
                 &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
             );
             let signature = sign_key.sign(&data).encode();
             crate::cesr::encode_signature(signature.as_slice(), &mut data, SignatureType::MlDsa65);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
         }
     }
 

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -91,6 +91,8 @@ pub mod cesr;
 ///     (more precisely "strong receiver-unforgeability under chosen
 pub mod crypto;
 
+#[cfg(feature = "bench-network-timings")]
+mod bench;
 /// Defines several common data structures, traits and error types that are used throughout the project.
 pub mod definitions;
 mod error;
@@ -137,6 +139,36 @@ pub use async_store::AsyncSecureStore;
 pub use secure_storage::AskarSecureStorage;
 #[cfg(feature = "async")]
 pub use secure_storage::SecureStorage;
+
+#[cfg(feature = "bench-network-timings")]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BenchNetworkTimings {
+    pub signature_ns: u64,
+    pub seal_core_ns: u64,
+    pub verify_ns: u64,
+    pub open_core_ns: u64,
+}
+
+#[cfg(feature = "bench-network-timings")]
+impl BenchNetworkTimings {
+    pub(crate) fn record_seal_core(&mut self, started: std::time::Instant, signature_before: u64) {
+        let elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        let signature_delta = self.signature_ns.saturating_sub(signature_before);
+        self.seal_core_ns = self
+            .seal_core_ns
+            .saturating_add(elapsed_ns.saturating_sub(signature_delta));
+    }
+}
+
+#[cfg(feature = "bench-network-timings")]
+pub fn reset_bench_network_timings() {
+    bench::reset();
+}
+
+#[cfg(feature = "bench-network-timings")]
+pub fn take_bench_network_timings() -> BenchNetworkTimings {
+    bench::take()
+}
 
 pub use definitions::{
     Payload, PendingIncomingParallelRelationship, PendingNestedRelationship,

--- a/tsp_sdk/src/secure_storage.rs
+++ b/tsp_sdk/src/secure_storage.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use crate::definitions::{VidEncryptionKeyType, VidSignatureKeyType};
+use crate::definitions::{
+    Digest, PendingNestedRelationship, VidEncryptionKeyType, VidSignatureKeyType,
+};
 use crate::{
     Error, ExportVid, PendingIncomingParallelRelationship, PendingParallelRelationship,
     RelationshipStatus,
@@ -57,6 +59,103 @@ pub(crate) struct Metadata {
     #[serde(default)]
     pending_incoming_parallel_requests: Vec<PendingIncomingParallelRelationship>,
     metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyMetadata {
+    id: String,
+    enc_key_type: VidEncryptionKeyType,
+    sig_key_type: VidSignatureKeyType,
+    transport: String,
+    relation_status: LegacyRelationshipStatus,
+    relation_vid: Option<String>,
+    parent_vid: Option<String>,
+    tunnel: Option<Box<[String]>>,
+    #[serde(default)]
+    pending_parallel_requests: Vec<PendingParallelRelationship>,
+    #[serde(default)]
+    pending_incoming_parallel_requests: Vec<PendingIncomingParallelRelationship>,
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+enum LegacyRelationshipStatus {
+    _Controlled,
+    Bidirectional {
+        thread_id: Digest,
+        #[serde(default)]
+        remote_thread_id: Option<Digest>,
+        #[serde(default)]
+        outstanding_nested_requests: Vec<PendingNestedRelationship>,
+        #[serde(default)]
+        outstanding_nested_thread_ids: Vec<Digest>,
+    },
+    Unidirectional {
+        thread_id: Digest,
+    },
+    ReverseUnidirectional {
+        thread_id: Digest,
+    },
+    Unrelated,
+}
+
+impl From<LegacyMetadata> for Metadata {
+    fn from(value: LegacyMetadata) -> Self {
+        Self {
+            id: value.id,
+            enc_key_type: value.enc_key_type,
+            sig_key_type: value.sig_key_type,
+            transport: value.transport,
+            relation_status: value.relation_status.into(),
+            relation_vid: value.relation_vid,
+            parent_vid: value.parent_vid,
+            tunnel: value.tunnel,
+            pending_parallel_requests: value.pending_parallel_requests,
+            pending_incoming_parallel_requests: value.pending_incoming_parallel_requests,
+            metadata: value.metadata,
+        }
+    }
+}
+
+impl From<LegacyRelationshipStatus> for RelationshipStatus {
+    fn from(value: LegacyRelationshipStatus) -> Self {
+        match value {
+            LegacyRelationshipStatus::_Controlled => RelationshipStatus::_Controlled,
+            LegacyRelationshipStatus::Bidirectional {
+                thread_id,
+                remote_thread_id,
+                outstanding_nested_requests,
+                outstanding_nested_thread_ids,
+            } => RelationshipStatus::Bidirectional {
+                thread_id,
+                remote_thread_id: remote_thread_id.unwrap_or(thread_id),
+                outstanding_nested_requests: if outstanding_nested_requests.is_empty() {
+                    outstanding_nested_thread_ids
+                        .into_iter()
+                        .map(|thread_id| PendingNestedRelationship {
+                            thread_id,
+                            local_nested_vid: String::new(),
+                        })
+                        .collect()
+                } else {
+                    outstanding_nested_requests
+                },
+            },
+            LegacyRelationshipStatus::Unidirectional { thread_id } => {
+                RelationshipStatus::Unidirectional { thread_id }
+            }
+            LegacyRelationshipStatus::ReverseUnidirectional { thread_id } => {
+                RelationshipStatus::ReverseUnidirectional { thread_id }
+            }
+            LegacyRelationshipStatus::Unrelated => RelationshipStatus::Unrelated,
+        }
+    }
+}
+
+fn decode_metadata(bytes: &[u8]) -> Result<Metadata, Error> {
+    serde_json::from_slice(bytes)
+        .or_else(|_| serde_json::from_slice::<LegacyMetadata>(bytes).map(Into::into))
+        .map_err(|_| Error::DecodeState("could not decode vid metadata"))
 }
 
 #[async_trait]
@@ -279,8 +378,7 @@ impl SecureStorage for AskarSecureStorage {
             .await?;
 
         for item in results.iter() {
-            let data: Metadata = serde_json::from_slice(&item.value)
-                .map_err(|_| Error::DecodeState("could not decode vid metadata"))?;
+            let data: Metadata = decode_metadata(&item.value)?;
 
             let id = data.id.clone();
 
@@ -406,7 +504,7 @@ impl AskarSecureStorage {
 #[cfg(not(feature = "pq"))]
 #[cfg(test)]
 mod test {
-    use crate::{OwnedVid, SecureStore, VerifiedVid};
+    use crate::{OwnedVid, RelationshipStatus, SecureStore, VerifiedVid};
 
     use super::*;
 
@@ -448,5 +546,42 @@ mod test {
 
             vault.destroy().await.unwrap();
         }
+    }
+
+    #[test]
+    fn decode_legacy_bidirectional_metadata() {
+        let raw = serde_json::json!({
+            "id": "did:test:alice",
+            "enc_key_type": "X25519",
+            "sig_key_type": "Ed25519",
+            "transport": "tcp://127.0.0.1:13371",
+            "relation_status": {
+                "Bidirectional": {
+                    "thread_id": vec![1; 32],
+                    "outstanding_nested_thread_ids": [vec![2; 32]]
+                }
+            },
+            "relation_vid": "did:test:bob",
+            "parent_vid": null,
+            "tunnel": null,
+            "metadata": null
+        });
+
+        let decoded = decode_metadata(raw.to_string().as_bytes()).unwrap();
+
+        let RelationshipStatus::Bidirectional {
+            thread_id,
+            remote_thread_id,
+            outstanding_nested_requests,
+        } = decoded.relation_status
+        else {
+            panic!()
+        };
+
+        assert_eq!(thread_id, [1; 32]);
+        assert_eq!(remote_thread_id, [1; 32]);
+        assert_eq!(outstanding_nested_requests.len(), 1);
+        assert_eq!(outstanding_nested_requests[0].thread_id, [2; 32]);
+        assert!(outstanding_nested_requests[0].local_nested_vid.is_empty());
     }
 }

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -590,14 +590,25 @@ impl SecureStore {
         nonconfidential_data: Option<&[u8]>,
         message: &[u8],
     ) -> Result<(Url, Vec<u8>), Error> {
-        // ANCHOR_END: seal_message-mbBook
-        self.seal_message_payload(
+        #[cfg(feature = "bench-network-timings")]
+        let signature_before = crate::bench::signature_before();
+        #[cfg(feature = "bench-network-timings")]
+        let started = std::time::Instant::now();
+
+        let result = self.seal_message_payload(
             sender,
             receiver,
             nonconfidential_data,
             Payload::Content(message),
-        )
+        );
+
+        #[cfg(feature = "bench-network-timings")]
+        crate::bench::record_seal_core(started, signature_before);
+
+        result
     }
+
+    // ANCHOR_END: seal_message-mbBook
 
     /// Seal a TSP message.
     pub(crate) fn seal_message_payload(
@@ -1887,7 +1898,8 @@ impl SecureStore {
                 "cannot find thread_id for parent vid {parent_vid}"
             )));
         };
-        if outstanding_nested_requests[index].local_nested_vid != expected_local_nested_vid {
+        let local_nested_vid = &outstanding_nested_requests[index].local_nested_vid;
+        if !local_nested_vid.is_empty() && local_nested_vid != expected_local_nested_vid {
             return Err(Error::Relationship(format!(
                 "nested relationship accept receiver mismatch for parent vid {parent_vid}"
             )));


### PR DESCRIPTION
## Summary

***tsp bench is no longer included in the default examples build and now requires an explicit feature flag.***

Split the key network benchmark timings and make `tsp bench` available only with`bench`.

## Changes

- client: split `seal` into `signature_us` and `seal_core_us`
- server: split `open` into `verify_us` and `open_core_us`
- gate the `tsp bench` command in `examples` behind `bench`

## Example Output

### Server

```shell
cargo run -p examples --bin tsp --features bench -- bench server --profile local-tcp
   Compiling examples v0.9.0-alpha2 (/Users/qians/Workspace/openwallet-foundation-labs/tsp-improve-bench-report/examples)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.70s
     Running `target/debug/tsp bench server --profile local-tcp`

Session 1 started (TCP)
[ ID]     Interval   Proto      Transfer  Messages       Msg/s        Bandwidth  Verify_us(p50)  OpenCore_us(p50)
[  0]      1.0 sec     TCP     174.4 KiB       124      123.93     1.43 Mbits/s         7096.3            724.5
[  0]      1.0 sec     TCP     178.6 KiB       127      126.14     1.45 Mbits/s         6967.3            703.2
[  0]      1.0 sec     TCP     180.0 KiB       128      127.29     1.47 Mbits/s         6963.0            693.7
[  0]      1.0 sec     TCP     182.8 KiB       130      129.52     1.49 Mbits/s         6880.8            691.8
[  0]      1.0 sec     TCP     181.4 KiB       129      128.51     1.48 Mbits/s         6882.0            692.2
[  0]      1.0 sec     TCP     178.6 KiB       127      126.89     1.46 Mbits/s         7001.9            694.0
[  0]      1.0 sec     TCP     182.8 KiB       130      129.82     1.50 Mbits/s         6812.0            693.2
[  0]      1.0 sec     TCP     181.4 KiB       129      128.53     1.48 Mbits/s         6904.8            701.6
[  0]      1.0 sec     TCP     168.8 KiB       120      119.76     1.38 Mbits/s         6943.8            720.0
[  0]      1.0 sec     TCP     182.8 KiB       130      129.53     1.49 Mbits/s         6847.9            691.2
[  0]      1.0 sec     TCP     182.8 KiB       130      129.00     1.49 Mbits/s         6916.8            691.0
[  0]      1.0 sec     TCP     180.0 KiB       128      127.57     1.47 Mbits/s         6920.4            691.3
[  0]      1.0 sec     TCP     175.8 KiB       125      124.49     1.43 Mbits/s         7085.1            719.5
[  0]      1.0 sec     TCP     181.4 KiB       129      128.89     1.48 Mbits/s         6838.0            694.5
[  0]      1.0 sec     TCP     178.6 KiB       127      126.46     1.46 Mbits/s         6956.8            693.2
[  0]      1.0 sec     TCP     167.3 KiB       119      118.79     1.37 Mbits/s         7219.4            755.7
[  0]      1.0 sec     TCP     171.6 KiB       122      121.21     1.40 Mbits/s         7196.9            726.3
[  0]      1.0 sec     TCP     174.4 KiB       124      123.21     1.42 Mbits/s         7066.7            759.1
[  0]      1.0 sec     TCP     174.4 KiB       124      123.57     1.42 Mbits/s         7145.8            726.6
[  0]      1.6 sec     TCP     153.3 KiB       109       69.20   797.18 Kbits/s         7522.9            737.4
^CSession 1 summary:
[SUM]  20.0 sec     TCP       3.4 MiB      2511      125.51     1.45 Mbits/s         6984.0            713.1
```

### Client

```shell
cargo run -p examples --bin tsp --features bench -- bench client --profile local-tcp --payload-size 1KiB --duration 15s --interval 1s
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.85s
     Running `target/debug/tsp bench client --profile local-tcp --payload-size 1KiB --duration 15s --interval 1s`
[ ID]     Interval   Proto      Transfer  Messages       Msg/s        Bandwidth  Sign_us(p50)  SealCore(p50)
[  0]      1.4 sec     TCP     791.7 KiB       563      399.02     4.60 Mbits/s        547.6         686.9
[  0]      1.4 sec     TCP     278.4 KiB       198      137.15     1.58 Mbits/s        524.7         686.4
[  0]      1.4 sec     TCP     282.7 KiB       201      142.80     1.65 Mbits/s        576.9         694.1
[  0]      1.4 sec     TCP     279.8 KiB       199      139.07     1.60 Mbits/s        537.3         650.9
[  0]      1.4 sec     TCP     292.5 KiB       208      147.27     1.70 Mbits/s        539.9         700.2
[  0]      1.4 sec     TCP     293.9 KiB       209      149.26     1.72 Mbits/s        526.2         687.3
[  0]      1.5 sec     TCP     293.9 KiB       209      143.75     1.66 Mbits/s        564.4         712.7
[  0]      1.4 sec     TCP     254.5 KiB       181      125.33     1.44 Mbits/s        546.9         688.4
[  0]      1.4 sec     TCP     254.5 KiB       181      127.32     1.47 Mbits/s        539.3         660.1
[  0]      1.4 sec     TCP     254.5 KiB       181      127.95     1.47 Mbits/s        572.8         700.3
[  0]      1.4 sec     TCP     254.5 KiB       181      127.23     1.47 Mbits/s        565.3         688.0
[SUM]  15.7 sec     TCP       3.4 MiB      2511      160.31     1.85 Mbits/s        549.9         687.4            -
```
