### PR TITLE
Accept parallel relationships

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["tsp_sdk", "examples", "fuzz", "tsp_python", "tsp_javascript"]
 exclude = ["demo"]
 
 [workspace.package]
-version = "0.9.0-alpha2"
+version = "0.9.1-rev2"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/openwallet-foundation-labs/tsp"
@@ -107,4 +107,4 @@ clap = { version = "4.5", features = ["derive"] }
 axum = { version = "0.8.1", features = ["ws", "macros"] }
 tower-http = { version = "0.6.2", features = ["cors"] }
 
-tsp_sdk = { path = "./tsp_sdk", version = "0.9.0-alpha" }
+tsp_sdk = { path = "./tsp_sdk", version = "0.9.1-rev2" }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Command line interface](./cli/index.md)
   - [Installation](./cli/installation.md)
   - [Base mode](./cli/base.md)
+  - [Parallel relationships](./cli/parallel.md)
   - [Nested mode](./cli/nested.md)
   - [Routed mode](./cli/routed.md)
 - [Intermediary server](./intermediary.md)

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -6,6 +6,13 @@ It also provides a `bench` command for sustained transport traffic tests.
 
 Read the next sections on how to get started.
 
+The CLI walkthroughs are split by relationship style:
+
+- [Base mode](./base.md) for direct relationships and ordinary message exchange
+- [Parallel relationships](./parallel.md) for referral-based relationship formation with a new VID pair
+- [Nested mode](./nested.md) for inner relationships coupled to an outer relationship
+- [Routed mode](./routed.md) for multi-hop delivery
+
 A short demo of the CLI (made using the TSP SDK development version of May 2024):
 
 <iframe width="754" height="380" frameborder="0" src="https://www.youtube.com/embed/WRwZ_rug4E4?si=638gVed4fGxTJTV7" allowfullscreen></iframe>

--- a/docs/src/cli/installation.md
+++ b/docs/src/cli/installation.md
@@ -58,8 +58,6 @@ Commands:
   request     propose a relationship
   accept      accept a relationship
   cancel      break up a relationship
-  refer       send an identity referral
-  publish     publish a new own identity
   secret      manage custom secret data
   bench       run transport benchmark tests
   help        Print this message or the help of the given subcommand(s)

--- a/docs/src/cli/nested.md
+++ b/docs/src/cli/nested.md
@@ -8,6 +8,8 @@ exchanging relationship messages (the preferred way), but it can also be tested 
 setting up identifiers, having both sides explicitly verify each other’s identities
 and establishing a relationship between those identifiers.
 
+If you want to create a second independent relationship via referral instead of a private inner relationship, see [Parallel relationships](./parallel.md).
+
 ## Nested mode (using relationship control messages)
 
 ### Establishing an outer relationship

--- a/docs/src/cli/parallel.md
+++ b/docs/src/cli/parallel.md
@@ -1,0 +1,89 @@
+# Parallel relationships
+
+Parallel relationship forming uses an existing bidirectional relationship as a referral to create a second relationship with a new VID pair.
+This follows the "Parallel Relationship Forming" flow in the
+[Trust Spanning Protocol specification](https://trustoverip.github.io/tswg-tsp-specification/).
+
+Compared with [nested mode](./nested.md), the new VIDs are not coupled as inner VIDs of the outer relationship.
+Use a parallel relationship when you want a second, separately addressable relationship, typically with a new directly reachable VID.
+
+## Current CLI scope
+
+The Rust SDK can both send and receive parallel relationship control messages.
+The CLI currently supports:
+
+- initiating a parallel relationship request with `tsp request --parallel --new-vid ...`
+- receiving a parallel relationship request
+- verifying the referred `new_vid`
+- accepting the request with `tsp accept --parallel`
+
+## Initiating a parallel relationship request
+
+Assume **alice** and **bob** already have an outer bidirectional relationship, for example with the aliases `alice` and `bob`.
+Before sending the request, **alice** creates or imports the local VID she wants to use for the new parallel relationship.
+For example:
+
+```sh
+> tsp -w alice create --type web alice-alt --alias alice-alt
+ INFO tsp: created identity did:web:did.teaspoon.world:endpoint:alice-alt
+```
+
+Now **alice** can initiate the referral:
+
+```sh
+> tsp -w alice request --parallel --sender-vid alice --receiver-vid bob --new-vid alice-alt --wait
+ INFO tsp: sent a parallel relationship request from did:web:did.teaspoon.world:endpoint:alice to did:web:did.teaspoon.world:endpoint:bob with new identity 'alice-alt'
+ INFO tsp: sent relationship request from did:web:did.teaspoon.world:endpoint:alice to did:web:did.teaspoon.world:endpoint:bob
+ INFO tsp: waiting for response...
+```
+
+When `--wait` is present, the CLI listens on the proposed `new_vid`, because the corresponding `TSP_RFA` is returned over the new relationship.
+
+## Accepting a parallel relationship request
+
+Assume **alice** sent the request above and introduced the new VID `alice-alt`.
+
+On **bob**'s side, listen on the outer relationship:
+
+```sh
+> tsp -w bob receive --one bob
+ INFO tsp: listening for messages...
+ INFO tsp: received parallel relationship request for 'did:web:did.teaspoon.world:endpoint:alice-alt' from did:web:did.teaspoon.world:endpoint:alice
+ did:web:did.teaspoon.world:endpoint:alice-alt    JZla6+N6FP/In7ywOp8yQD2GfXemCn1e4b6tFVWaLxg
+ INFO tsp: did:web:did.teaspoon.world:endpoint:alice-alt is verified and added to the wallet bob
+```
+
+The CLI prints two fields separated by a tab:
+
+- the referred `new_vid`
+- the `thread_id` that must be echoed in the accept message
+
+Before accepting, **bob** needs a local VID for the new parallel relationship.
+In practice this should usually be a directly reachable VID, such as a `did:web` or `did:webvh` identity:
+
+```sh
+> tsp -w bob create --type web bob-alt --alias bob-alt
+ INFO tsp: created identity did:web:did.teaspoon.world:endpoint:bob-alt
+```
+
+Now **bob** can accept the referred relationship:
+
+```sh
+> tsp -w bob accept --parallel --sender-vid bob-alt --receiver-vid did:web:did.teaspoon.world:endpoint:alice-alt --thread-id 'JZla6+N6FP/In7ywOp8yQD2GfXemCn1e4b6tFVWaLxg'
+ INFO tsp: sent control message from did:web:did.teaspoon.world:endpoint:bob-alt to did:web:did.teaspoon.world:endpoint:alice-alt
+```
+
+When **alice** receives the acceptance, the CLI will report the new remote VID:
+
+```sh
+ INFO tsp: received accept relationship from did:web:did.teaspoon.world:endpoint:bob (nested_vid: none, parallel_vid: did:web:did.teaspoon.world:endpoint:bob-alt)
+ did:web:did.teaspoon.world:endpoint:bob-alt
+```
+
+At that point the new VID pair forms its own bidirectional relationship, separate from the outer one that was used as the referral.
+
+## Notes
+
+- The outer relationship must already be bidirectional before a parallel relationship can be formed.
+- `tsp accept --parallel` uses the new local VID as the sender and the referred remote VID as the receiver.
+- The original outer relationship remains in place after the new parallel relationship is established.

--- a/docs/src/start.md
+++ b/docs/src/start.md
@@ -18,5 +18,5 @@ the [Composable Event Streaming Representation]() (CESR) encoding of messages an
 See the [command line interface](./cli/index.md) guide to get started
 with the _test_ CLI for TSP.
 The TSP CLI is an example application of Rust TSP that helps to test
-the direct, nested, and routed mode of TSP.
+the direct, parallel relationship, nested, and routed flows of TSP.
 There is some support infrastructure deployed on <https://did.teaspoon.world/>, <https://p.teaspoon.world/> and <https://q.teaspoon.world/> to get started quickly.

--- a/examples/src/bench.rs
+++ b/examples/src/bench.rs
@@ -478,7 +478,8 @@ fn ensure_bidirectional_relation(
                 remote_vid,
                 RelationshipStatus::Bidirectional {
                     thread_id: [0; 32],
-                    outstanding_nested_thread_ids: vec![],
+                    remote_thread_id: [0; 32],
+                    outstanding_nested_requests: vec![],
                 },
                 local_vid,
             )?;

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -150,11 +150,21 @@ enum Commands {
         sender_vid: String,
         #[arg(short, long, required = true)]
         receiver_vid: String,
-        #[arg(long)]
+        #[arg(long, conflicts_with = "parallel")]
         nested: bool,
+        #[arg(long, conflicts_with = "nested", requires = "new_vid")]
+        parallel: bool,
+        #[arg(
+            long,
+            conflicts_with = "nested",
+            requires = "parallel",
+            help = "existing local VID to propose for a parallel relationship"
+        )]
+        new_vid: Option<String>,
         #[arg(
             short,
             long,
+            conflicts_with = "parallel",
             help = "parent VID of the sender, used to listen for a response"
         )]
         parent_vid: Option<String>,
@@ -174,8 +184,10 @@ enum Commands {
         receiver_vid: String,
         #[arg(long, required = true)]
         thread_id: String,
-        #[arg(long)]
+        #[arg(long, conflicts_with = "parallel")]
         nested: bool,
+        #[arg(long, conflicts_with = "nested")]
+        parallel: bool,
     },
     #[command(arg_required_else_help = true, about = "break up a relationship")]
     Cancel {
@@ -775,7 +787,7 @@ async fn run() -> Result<(), Error> {
                                     info!(
                                         "received parallel relationship request for '{new_vid}' from {sender}"
                                     );
-                                    println!("{new_vid}");
+                                    println!("{new_vid}\t{thread_id_string}");
                                     return Action::Verify(new_vid);
                                 }
                                 (
@@ -785,7 +797,7 @@ async fn run() -> Result<(), Error> {
                                     info!(
                                         "received nested parallel relationship request from '{nested_vid}' for '{new_vid}' from {sender}"
                                     );
-                                    println!("{new_vid}");
+                                    println!("{new_vid}\t{thread_id_string}");
                                     return Action::Verify(new_vid);
                                 }
                                 (ReceivedRelationshipDelivery::Routed, _) => {
@@ -947,6 +959,8 @@ async fn run() -> Result<(), Error> {
             sender_vid,
             receiver_vid,
             nested,
+            parallel,
+            new_vid,
             parent_vid,
             ask,
             wait,
@@ -954,7 +968,13 @@ async fn run() -> Result<(), Error> {
             ensure_vid_verified(&vid_wallet, &receiver_vid, &args.wallet, ask).await?;
 
             // Setup receive stream before sending the request
-            let listener_vid = parent_vid.unwrap_or(sender_vid.clone());
+            let listener_vid = if parallel {
+                new_vid
+                    .clone()
+                    .expect("clap should require --new-vid for --parallel")
+            } else {
+                parent_vid.unwrap_or(sender_vid.clone())
+            };
             let mut messages = vid_wallet.receive(&listener_vid).await?;
 
             tracing::debug!("sending request...");
@@ -975,6 +995,24 @@ async fn run() -> Result<(), Error> {
                         return Ok(());
                     }
                 }
+            } else if parallel {
+                let new_vid = new_vid
+                    .as_deref()
+                    .expect("clap should require --new-vid for --parallel");
+
+                if let Err(e) = vid_wallet
+                    .send_parallel_relationship_request(&sender_vid, &receiver_vid, new_vid)
+                    .await
+                {
+                    tracing::error!(
+                        "error sending message from {sender_vid} to {receiver_vid}: {e}"
+                    );
+                    return Ok(());
+                }
+
+                info!(
+                    "sent a parallel relationship request from {sender_vid} to {receiver_vid} with new identity '{new_vid}'"
+                );
             } else if let Err(e) = vid_wallet
                 .send_relationship_request(&sender_vid, &receiver_vid, None)
                 .await
@@ -999,7 +1037,10 @@ async fn run() -> Result<(), Error> {
                             info!("received relationship request from {sender}")
                         }
                         ReceivedTspMessage::AcceptRelationship {
-                            sender, delivery, ..
+                            sender,
+                            delivery,
+                            form,
+                            ..
                         } => {
                             let nested_vid = match delivery {
                                 ReceivedRelationshipDelivery::Nested { nested_vid } => {
@@ -1007,12 +1048,20 @@ async fn run() -> Result<(), Error> {
                                 }
                                 _ => None,
                             };
+                            let parallel_vid = match form {
+                                ReceivedRelationshipForm::Parallel { new_vid, .. } => Some(new_vid),
+                                ReceivedRelationshipForm::Direct => None,
+                            };
                             info!(
-                                "received accept relationship from {sender} (nested_vid: {})",
-                                nested_vid.clone().unwrap_or("none".to_string())
+                                "received accept relationship from {sender} (nested_vid: {}, parallel_vid: {})",
+                                nested_vid.clone().unwrap_or("none".to_string()),
+                                parallel_vid.clone().unwrap_or("none".to_string())
                             );
                             if let Some(nested_vid) = nested_vid {
                                 println!("{nested_vid}");
+                            }
+                            if let Some(parallel_vid) = parallel_vid {
+                                println!("{parallel_vid}");
                             }
                             break;
                         }
@@ -1035,6 +1084,7 @@ async fn run() -> Result<(), Error> {
             receiver_vid,
             thread_id,
             nested,
+            parallel,
         } => {
             let mut digest: [u8; 32] = Default::default();
             Base64Unpadded::decode(&thread_id, &mut digest).unwrap();
@@ -1057,6 +1107,17 @@ async fn run() -> Result<(), Error> {
 
                         return Ok(());
                     }
+                }
+            } else if parallel {
+                if let Err(e) = vid_wallet
+                    .send_parallel_relationship_accept(&sender_vid, &receiver_vid, digest)
+                    .await
+                {
+                    tracing::error!(
+                        "error sending message from {sender_vid} to {receiver_vid}: {e}"
+                    );
+
+                    return Ok(());
                 }
             } else if let Err(e) = vid_wallet
                 .send_relationship_accept(&sender_vid, &receiver_vid, digest, None)

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -8,8 +8,9 @@ use tokio::io::AsyncReadExt;
 use tracing::{debug, error, info, trace};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tsp_sdk::{
-    Aliases, AskarSecureStorage, AsyncSecureStore, Error, ExportVid, OwnedVid, ReceivedTspMessage,
-    RelationshipStatus, SecureStorage, VerifiedVid, Vid, cesr,
+    Aliases, AskarSecureStorage, AsyncSecureStore, Error, ExportVid, OwnedVid,
+    ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage, RelationshipStatus,
+    SecureStorage, VerifiedVid, Vid, cesr,
     definitions::Digest,
     vid::{VidError, did::webvh::WebvhMetadata, verify_vid, vid_to_did_document},
 };
@@ -182,24 +183,6 @@ enum Commands {
         sender_vid: String,
         #[arg(short, long, required = true)]
         receiver_vid: String,
-    },
-    #[command(arg_required_else_help = true, about = "send an identity referral")]
-    Refer {
-        #[arg(short, long, required = true)]
-        sender_vid: String,
-        #[arg(short, long, required = true)]
-        receiver_vid: String,
-        #[arg(long, required = true)]
-        referred_vid: String,
-    },
-    #[command(arg_required_else_help = true, about = "publish a new own identity")]
-    Publish {
-        #[arg(short, long, required = true)]
-        sender_vid: String,
-        #[arg(short, long, required = true)]
-        receiver_vid: String,
-        #[arg(short, long, required = true)]
-        new_vid: String,
     },
     #[command(arg_required_else_help = true, about = "manage custom secret data")]
     Secret {
@@ -760,44 +743,104 @@ async fn run() -> Result<(), Error> {
                             sender,
                             receiver: _,
                             thread_id,
-                            route: _,
-                            nested_vid,
+                            form,
+                            delivery,
                         } => {
                             let thread_id_string = Base64Unpadded::encode_string(&thread_id);
-                            match nested_vid {
-                                Some(vid) => {
-                                    info!(
-                                        "received nested relationship request from '{vid}' (new identity for {sender}), thread-id '{thread_id_string}'"
-                                    );
-                                    println!("{vid}\t{thread_id_string}");
-                                }
-                                None => {
+                            match (delivery, form) {
+                                (
+                                    ReceivedRelationshipDelivery::Direct,
+                                    ReceivedRelationshipForm::Direct,
+                                ) => {
                                     info!(
                                         "received relationship request from {sender}, thread-id '{thread_id_string}'"
                                     );
                                     println!("{sender}\t{thread_id_string}");
+                                    return Action::AssignDefaultRelation(sender, thread_id);
+                                }
+                                (
+                                    ReceivedRelationshipDelivery::Nested { nested_vid: vid },
+                                    ReceivedRelationshipForm::Direct,
+                                ) => {
+                                    info!(
+                                        "received nested relationship request from '{vid}' (new identity for {sender}), thread-id '{thread_id_string}'"
+                                    );
+                                    println!("{vid}\t{thread_id_string}");
+                                    return Action::AssignDefaultRelation(sender, thread_id);
+                                }
+                                (
+                                    ReceivedRelationshipDelivery::Direct,
+                                    ReceivedRelationshipForm::Parallel { new_vid, .. },
+                                ) => {
+                                    info!(
+                                        "received parallel relationship request for '{new_vid}' from {sender}"
+                                    );
+                                    println!("{new_vid}");
+                                    return Action::Verify(new_vid);
+                                }
+                                (
+                                    ReceivedRelationshipDelivery::Nested { nested_vid },
+                                    ReceivedRelationshipForm::Parallel { new_vid, .. },
+                                ) => {
+                                    info!(
+                                        "received nested parallel relationship request from '{nested_vid}' for '{new_vid}' from {sender}"
+                                    );
+                                    println!("{new_vid}");
+                                    return Action::Verify(new_vid);
+                                }
+                                (ReceivedRelationshipDelivery::Routed, _) => {
+                                    error!(
+                                        "received routed relationship request from {sender}, but routed relationship-forming is not implemented"
+                                    );
                                 }
                             }
-
-                            return Action::AssignDefaultRelation(sender, thread_id);
                         }
                         ReceivedTspMessage::AcceptRelationship {
                             sender,
                             receiver: _,
-                            nested_vid: None,
-                        } => {
-                            info!("received accept relationship from {}", sender);
-                        }
-                        ReceivedTspMessage::AcceptRelationship {
-                            sender,
-                            receiver: _,
-                            nested_vid: Some(vid),
-                        } => {
-                            info!(
-                                "received accept nested relationship from '{vid}' (new identity for {sender})"
-                            );
-                            println!("{vid}");
-                        }
+                            form,
+                            delivery,
+                            ..
+                        } => match (delivery, form) {
+                            (
+                                ReceivedRelationshipDelivery::Direct,
+                                ReceivedRelationshipForm::Direct,
+                            ) => {
+                                info!("received accept relationship from {}", sender);
+                            }
+                            (
+                                ReceivedRelationshipDelivery::Nested { nested_vid: vid },
+                                ReceivedRelationshipForm::Direct,
+                            ) => {
+                                info!(
+                                    "received accept nested relationship from '{vid}' (new identity for {sender})"
+                                );
+                                println!("{vid}");
+                            }
+                            (
+                                ReceivedRelationshipDelivery::Direct,
+                                ReceivedRelationshipForm::Parallel { new_vid, .. },
+                            ) => {
+                                info!(
+                                    "received parallel relationship accept for '{new_vid}' from {sender}"
+                                );
+                                println!("{new_vid}");
+                            }
+                            (
+                                ReceivedRelationshipDelivery::Nested { nested_vid },
+                                ReceivedRelationshipForm::Parallel { new_vid, .. },
+                            ) => {
+                                info!(
+                                    "received accept nested parallel relationship from '{nested_vid}' for '{new_vid}' from {sender}"
+                                );
+                                println!("{new_vid}");
+                            }
+                            (ReceivedRelationshipDelivery::Routed, _) => {
+                                error!(
+                                    "received routed relationship accept from {sender}, but routed relationship-forming is not implemented"
+                                );
+                            }
+                        },
                         ReceivedTspMessage::CancelRelationship {
                             sender,
                             receiver: _,
@@ -820,26 +863,6 @@ async fn run() -> Result<(), Error> {
                             {
                                 return Action::Forward(next_hop, route, opaque_payload);
                             }
-                        }
-                        ReceivedTspMessage::NewIdentifier {
-                            sender,
-                            receiver: _,
-                            new_vid,
-                        } => {
-                            info!("received request for new identifier '{new_vid}' from {sender}");
-                            println!("{new_vid}");
-                            return Action::Verify(new_vid);
-                        }
-                        ReceivedTspMessage::Referral {
-                            sender,
-                            receiver: _,
-                            referred_vid,
-                        } => {
-                            info!(
-                                "received relationship referral for '{referred_vid}' from {sender}"
-                            );
-                            println!("{referred_vid}");
-                            return Action::Verify(referred_vid);
                         }
                         ReceivedTspMessage::PendingMessage {
                             unknown_vid,
@@ -976,8 +999,14 @@ async fn run() -> Result<(), Error> {
                             info!("received relationship request from {sender}")
                         }
                         ReceivedTspMessage::AcceptRelationship {
-                            sender, nested_vid, ..
+                            sender, delivery, ..
                         } => {
+                            let nested_vid = match delivery {
+                                ReceivedRelationshipDelivery::Nested { nested_vid } => {
+                                    Some(nested_vid)
+                                }
+                                _ => None,
+                            };
                             info!(
                                 "received accept relationship from {sender} (nested_vid: {})",
                                 nested_vid.clone().unwrap_or("none".to_string())
@@ -994,16 +1023,6 @@ async fn run() -> Result<(), Error> {
                         ReceivedTspMessage::ForwardRequest { sender, .. } => {
                             info!("received forward request from {sender}")
                         }
-                        ReceivedTspMessage::NewIdentifier {
-                            sender, new_vid, ..
-                        } => {
-                            info!("received new identifier for {sender}: {new_vid}")
-                        }
-                        ReceivedTspMessage::Referral {
-                            sender,
-                            referred_vid,
-                            ..
-                        } => info!("received referral from {sender} for {referred_vid}"),
                         ReceivedTspMessage::PendingMessage { unknown_vid, .. } => {
                             info!("received pending message from {unknown_vid}")
                         }
@@ -1041,38 +1060,6 @@ async fn run() -> Result<(), Error> {
                 }
             } else if let Err(e) = vid_wallet
                 .send_relationship_accept(&sender_vid, &receiver_vid, digest, None)
-                .await
-            {
-                tracing::error!("error sending message from {sender_vid} to {receiver_vid}: {e}");
-
-                return Ok(());
-            }
-
-            info!("sent control message from {sender_vid} to {receiver_vid}",);
-        }
-        Commands::Refer {
-            sender_vid,
-            receiver_vid,
-            referred_vid,
-        } => {
-            if let Err(e) = vid_wallet
-                .send_relationship_referral(&sender_vid, &receiver_vid, &referred_vid)
-                .await
-            {
-                tracing::error!("error sending message from {sender_vid} to {receiver_vid}: {e}");
-
-                return Ok(());
-            }
-
-            info!("sent control message from {sender_vid} to {receiver_vid}",);
-        }
-        Commands::Publish {
-            sender_vid,
-            receiver_vid,
-            new_vid,
-        } => {
-            if let Err(e) = vid_wallet
-                .send_new_identifier_notice(&sender_vid, &receiver_vid, &new_vid)
                 .await
             {
                 tracing::error!("error sending message from {sender_vid} to {receiver_vid}: {e}");

--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -15,8 +15,9 @@ use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{Notify, RwLock, RwLockWriteGuard, broadcast};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tsp_sdk::{
-    AsyncSecureStore, OwnedVid, ReceivedTspMessage, VerifiedVid, cesr, definitions::Digest,
-    transport, vid::vid_to_did_document,
+    AsyncSecureStore, OwnedVid, ReceivedRelationshipDelivery, ReceivedRelationshipForm,
+    ReceivedTspMessage, VerifiedVid, cesr, definitions::Digest, transport,
+    vid::vid_to_did_document,
 };
 use url::Url;
 use uuid::Uuid;
@@ -253,47 +254,57 @@ async fn new_message(
         return (StatusCode::BAD_REQUEST, "error verifying VID").into_response();
     }
 
-    let handle_relationship_request = async |sender: String,
-                                             route: Option<Vec<Vec<u8>>>,
-                                             nested_vid: Option<String>,
-                                             thread_id: Digest|
-           -> Result<(), tsp_sdk::Error> {
-        if let Some(nested_vid) = nested_vid {
-            tracing::trace!("Requested new nested relationship");
-            let ((endpoint, message), my_new_nested_vid) = state
-                .db
-                .read()
-                .await
-                .make_nested_relationship_accept(&receiver, &nested_vid, thread_id)?;
+    let handle_relationship_request =
+        async |sender: String, form, delivery, thread_id: Digest| -> Result<(), tsp_sdk::Error> {
+            match (delivery, form) {
+                (ReceivedRelationshipDelivery::Direct, ReceivedRelationshipForm::Direct) => {
+                    tracing::trace!("Received relationship request from {}", sender);
+                    let (endpoint, message) = state
+                        .db
+                        .read()
+                        .await
+                        .make_relationship_accept(&receiver, &sender, thread_id, None)?;
 
-            transport::send_message(&endpoint, &message).await?;
+                    transport::send_message(&endpoint, &message).await?;
+                    Ok(())
+                }
+                (
+                    ReceivedRelationshipDelivery::Nested { nested_vid },
+                    ReceivedRelationshipForm::Direct,
+                ) => {
+                    tracing::trace!("Requested new nested relationship");
+                    let ((endpoint, message), my_new_nested_vid) = state
+                        .db
+                        .read()
+                        .await
+                        .make_nested_relationship_accept(&receiver, &nested_vid, thread_id)?;
 
-            tracing::debug!(
-                "Created nested {} for {nested_vid}",
-                my_new_nested_vid.vid().identifier()
-            );
+                    transport::send_message(&endpoint, &message).await?;
 
-            Ok(())
-        } else {
-            tracing::trace!("Received relationship request from {}", sender);
-            let route: Option<Vec<&str>> = route.as_ref().map(|vec| {
-                vec.iter()
-                    .map(|vid| std::str::from_utf8(vid).unwrap())
-                    .collect()
-            });
+                    tracing::debug!(
+                        "Created nested {} for {nested_vid}",
+                        my_new_nested_vid.vid().identifier()
+                    );
 
-            let (endpoint, message) = state.db.read().await.make_relationship_accept(
-                &receiver,
-                &sender,
-                thread_id,
-                route.as_deref(),
-            )?;
-
-            transport::send_message(&endpoint, &message).await?;
-
-            Ok(())
-        }
-    };
+                    Ok(())
+                }
+                (
+                    ReceivedRelationshipDelivery::Direct,
+                    ReceivedRelationshipForm::Parallel { new_vid, .. },
+                )
+                | (
+                    ReceivedRelationshipDelivery::Nested { .. },
+                    ReceivedRelationshipForm::Parallel { new_vid, .. },
+                ) => {
+                    tracing::error!("parallel relationship request from {sender}: {new_vid}");
+                    Ok(())
+                }
+                (ReceivedRelationshipDelivery::Routed, _) => {
+                    tracing::error!("routed relationship request from {sender}");
+                    Ok(())
+                }
+            }
+        };
 
     // yes, this must be a separate variable https://github.com/rust-lang/rust/issues/37612
     let res = state.db.read().await.open_message(message.as_mut());
@@ -307,13 +318,17 @@ async fn new_message(
         Ok(ReceivedTspMessage::RequestRelationship {
             sender,
             receiver: _,
-            route,
-            nested_vid,
             thread_id,
+            form,
+            delivery,
         }) => {
+            let nested_vid = match &delivery {
+                ReceivedRelationshipDelivery::Nested { nested_vid } => Some(nested_vid.clone()),
+                _ => None,
+            };
+
             if let Err(e) =
-                handle_relationship_request(sender.clone(), route, nested_vid.clone(), thread_id)
-                    .await
+                handle_relationship_request(sender.clone(), form, delivery, thread_id).await
             {
                 state.log_error(e.to_string()).await;
                 return (StatusCode::BAD_REQUEST, "error accepting relationship").into_response();
@@ -327,9 +342,14 @@ async fn new_message(
                     format!("Accepted relationship request from {sender}")
                 }).await;
         }
-        Ok(ReceivedTspMessage::AcceptRelationship { sender, .. }) => {
-            tracing::error!("accept relationship message from {sender}")
-        }
+        Ok(ReceivedTspMessage::AcceptRelationship { sender, form, .. }) => match form {
+            ReceivedRelationshipForm::Parallel { new_vid, .. } => {
+                tracing::error!("parallel relationship accept from {sender}: {new_vid}")
+            }
+            ReceivedRelationshipForm::Direct => {
+                tracing::error!("accept relationship message from {sender}")
+            }
+        },
         Ok(ReceivedTspMessage::CancelRelationship { sender, .. }) => {
             tracing::error!("cancel relationship message from {sender}")
         }
@@ -396,16 +416,6 @@ async fn new_message(
                     .await;
             }
         }
-        Ok(ReceivedTspMessage::NewIdentifier {
-            sender, new_vid, ..
-        }) => {
-            tracing::error!("new identifier message from {sender}: {new_vid}")
-        }
-        Ok(ReceivedTspMessage::Referral {
-            sender,
-            referred_vid,
-            ..
-        }) => tracing::error!("referral from {sender}: {referred_vid}"),
         Ok(ReceivedTspMessage::PendingMessage { unknown_vid, .. }) => {
             tracing::error!("pending message message from unknown VID {unknown_vid}")
         }

--- a/examples/tests/cli_tests.rs
+++ b/examples/tests/cli_tests.rs
@@ -2,10 +2,11 @@ use assert_cmd::{Command, cargo_bin};
 use predicates::prelude::*;
 use rand::distributions::Alphanumeric;
 use rand::{Rng, thread_rng};
+use std::net::{TcpListener, TcpStream};
 use std::process::Command as StdCommand;
 use std::thread;
 use std::time::Duration;
-use tsp_sdk::{AskarSecureStorage, AsyncSecureStore, SecureStorage};
+use tsp_sdk::{AskarSecureStorage, AsyncSecureStore, RelationshipStatus, SecureStorage};
 
 struct WalletCleanupGuard;
 
@@ -42,6 +43,61 @@ fn create_wallet(alias: &str, did_type: &str) -> String {
     random_name
 }
 
+fn create_peer_wallet(alias: &str, tcp_addr: &str) -> String {
+    let mut cmd: Command = Command::new(cargo_bin!("tsp"));
+    let wallet_name = format!("test_wallet_{}", random_string(8));
+    cmd.args([
+        "--wallet",
+        wallet_name.as_str(),
+        "create",
+        "--type",
+        "peer",
+        "--tcp",
+        tcp_addr,
+        alias,
+    ])
+    .assert()
+    .success();
+
+    wallet_name
+}
+
+fn create_peer_identity(wallet_name: &str, alias: &str, tcp_addr: &str) {
+    let mut cmd: Command = Command::new(cargo_bin!("tsp"));
+    cmd.args([
+        "--wallet",
+        wallet_name,
+        "create",
+        "--type",
+        "peer",
+        "--tcp",
+        tcp_addr,
+        alias,
+    ])
+    .assert()
+    .success();
+}
+
+fn allocate_tcp_addr() -> String {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("failed to allocate test port");
+    let addr = listener
+        .local_addr()
+        .expect("failed to read test listener address");
+    drop(listener);
+    format!("127.0.0.1:{}", addr.port())
+}
+
+fn can_use_loopback_transport() -> bool {
+    let Ok(listener) = TcpListener::bind(("127.0.0.1", 0)) else {
+        return false;
+    };
+    let Ok(addr) = listener.local_addr() else {
+        return false;
+    };
+
+    TcpStream::connect(addr).is_ok()
+}
+
 fn print_did(wallet_name: &str, alias: &str) -> String {
     let mut cmd: Command = Command::new(cargo_bin!("tsp"));
     let output = cmd
@@ -52,6 +108,18 @@ fn print_did(wallet_name: &str, alias: &str) -> String {
         .expect("invalid utf-8")
         .trim()
         .to_string()
+}
+
+fn parse_relationship_stdout(stdout: &[u8]) -> (String, String) {
+    let stdout = std::str::from_utf8(stdout).expect("invalid utf-8");
+    let line = stdout
+        .lines()
+        .find(|line| line.contains('\t'))
+        .expect("expected tab-separated relationship output");
+    let (left, right) = line
+        .split_once('\t')
+        .expect("relationship output should contain a tab");
+    (left.trim().to_string(), right.trim().to_string())
 }
 
 fn verify_did(wallet_name: &str, alias: &str, did: &str) {
@@ -93,6 +161,23 @@ fn remove_next_update_alias(wallet_name: &str, did: &str) {
             .expect("Failed to persist modified wallet state");
         vault.close().await.expect("Failed to close wallet storage");
     });
+}
+
+fn load_wallet(wallet_name: &str) -> AsyncSecureStore {
+    let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+    runtime.block_on(async {
+        let url = format!("sqlite://{wallet_name}.sqlite");
+        let vault = AskarSecureStorage::open(&url, b"unsecure")
+            .await
+            .expect("Failed to open wallet storage");
+        let (vids, aliases, keys) = vault.read().await.expect("Failed to read wallet");
+
+        let db = AsyncSecureStore::new();
+        db.import(vids, aliases, keys)
+            .expect("Failed to import wallet state");
+        vault.close().await.expect("Failed to close wallet storage");
+        db
+    })
 }
 
 fn clean_wallet() {
@@ -356,6 +441,247 @@ fn test_webvh_update_reports_out_of_sync_when_precommit_alias_is_missing() {
             "Server has precommit active but wallet has no matching key. Wallet may be out of sync.",
         ))
         .failure();
+}
+
+#[test]
+#[serial_test::serial(clean_wallet)]
+fn test_request_help_lists_parallel_options() {
+    let _cleanup = wallet_cleanup_guard();
+
+    let mut cmd: Command = Command::new(cargo_bin!("tsp"));
+    cmd.args(["request", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--parallel"))
+        .stdout(predicate::str::contains("--new-vid"));
+}
+
+#[test]
+#[serial_test::serial(clean_wallet)]
+fn test_parallel_request_requires_new_vid() {
+    let _cleanup = wallet_cleanup_guard();
+
+    let mut cmd: Command = Command::new(cargo_bin!("tsp"));
+    cmd.args(["request", "--parallel", "-s", "alice", "-r", "bob"])
+        .assert()
+        .stderr(predicate::str::contains("--new-vid"))
+        .failure();
+}
+
+#[test]
+#[serial_test::serial(clean_wallet)]
+fn test_parallel_request_and_accept_roundtrip_over_cli() {
+    let _cleanup = wallet_cleanup_guard();
+
+    if !can_use_loopback_transport() {
+        eprintln!("skipping loopback CLI test: local TCP transport is unavailable");
+        return;
+    }
+
+    let alice_wallet = create_peer_wallet("alice", &allocate_tcp_addr());
+    let bob_wallet = create_peer_wallet("bob", &allocate_tcp_addr());
+    create_peer_identity(&alice_wallet, "alice-alt", &allocate_tcp_addr());
+    create_peer_identity(&bob_wallet, "bob-alt", &allocate_tcp_addr());
+
+    let alice_did = print_did(&alice_wallet, "alice");
+    let bob_did = print_did(&bob_wallet, "bob");
+    let alice_alt_did = print_did(&alice_wallet, "alice-alt");
+    let bob_alt_did = print_did(&bob_wallet, "bob-alt");
+
+    verify_did(&alice_wallet, "bob", &bob_did);
+    verify_did(&bob_wallet, "alice", &alice_did);
+
+    let tsp_bin = cargo_bin!("tsp");
+
+    let outer_receive = {
+        let tsp_bin = tsp_bin;
+        let bob_wallet = bob_wallet.clone();
+        thread::spawn(move || {
+            StdCommand::new(&tsp_bin)
+                .args(["--wallet", bob_wallet.as_str(), "receive", "--one", "bob"])
+                .output()
+                .expect("failed to receive outer relationship request")
+        })
+    };
+
+    thread::sleep(Duration::from_millis(300));
+
+    let outer_request = StdCommand::new(&tsp_bin)
+        .args([
+            "--wallet",
+            alice_wallet.as_str(),
+            "request",
+            "-s",
+            "alice",
+            "-r",
+            "bob",
+        ])
+        .output()
+        .expect("failed to send outer relationship request");
+    assert!(
+        outer_request.status.success(),
+        "outer request failed: {}",
+        String::from_utf8_lossy(&outer_request.stderr)
+    );
+
+    let outer_receive = outer_receive.join().expect("outer receive thread panicked");
+    assert!(
+        outer_receive.status.success(),
+        "outer receive failed: {}",
+        String::from_utf8_lossy(&outer_receive.stderr)
+    );
+    let (outer_sender, outer_thread_id) = parse_relationship_stdout(&outer_receive.stdout);
+    assert_eq!(outer_sender, alice_did);
+
+    let outer_accept_receive = {
+        let tsp_bin = tsp_bin;
+        let alice_wallet = alice_wallet.clone();
+        thread::spawn(move || {
+            StdCommand::new(&tsp_bin)
+                .args([
+                    "--wallet",
+                    alice_wallet.as_str(),
+                    "receive",
+                    "--one",
+                    "alice",
+                ])
+                .output()
+                .expect("failed to receive outer relationship accept")
+        })
+    };
+
+    thread::sleep(Duration::from_millis(300));
+
+    let outer_accept = StdCommand::new(&tsp_bin)
+        .args([
+            "--wallet",
+            bob_wallet.as_str(),
+            "accept",
+            "-s",
+            "bob",
+            "-r",
+            &alice_did,
+            "--thread-id",
+            outer_thread_id.as_str(),
+        ])
+        .output()
+        .expect("failed to send outer relationship accept");
+    assert!(
+        outer_accept.status.success(),
+        "outer accept failed: {}",
+        String::from_utf8_lossy(&outer_accept.stderr)
+    );
+
+    let outer_accept_receive = outer_accept_receive
+        .join()
+        .expect("outer accept receive thread panicked");
+    assert!(
+        outer_accept_receive.status.success(),
+        "outer accept receive failed: {}",
+        String::from_utf8_lossy(&outer_accept_receive.stderr)
+    );
+
+    verify_did(&alice_wallet, "alice-alt", &alice_alt_did);
+
+    let parallel_receive = {
+        let tsp_bin = tsp_bin;
+        let bob_wallet = bob_wallet.clone();
+        thread::spawn(move || {
+            StdCommand::new(&tsp_bin)
+                .args(["--wallet", bob_wallet.as_str(), "receive", "--one", "bob"])
+                .output()
+                .expect("failed to receive parallel relationship request")
+        })
+    };
+
+    thread::sleep(Duration::from_millis(300));
+
+    let parallel_request = {
+        let tsp_bin = tsp_bin;
+        let alice_wallet = alice_wallet.clone();
+        thread::spawn(move || {
+            StdCommand::new(&tsp_bin)
+                .args([
+                    "--wallet",
+                    alice_wallet.as_str(),
+                    "request",
+                    "--parallel",
+                    "-s",
+                    "alice",
+                    "-r",
+                    "bob",
+                    "--new-vid",
+                    "alice-alt",
+                    "--wait",
+                ])
+                .output()
+                .expect("failed to send parallel relationship request")
+        })
+    };
+
+    let parallel_receive = parallel_receive
+        .join()
+        .expect("parallel receive thread panicked");
+    assert!(
+        parallel_receive.status.success(),
+        "parallel receive failed: {}",
+        String::from_utf8_lossy(&parallel_receive.stderr)
+    );
+    let (received_new_vid, parallel_thread_id) =
+        parse_relationship_stdout(&parallel_receive.stdout);
+    assert_eq!(received_new_vid, alice_alt_did);
+
+    let parallel_accept = StdCommand::new(&tsp_bin)
+        .args([
+            "--wallet",
+            bob_wallet.as_str(),
+            "accept",
+            "--parallel",
+            "-s",
+            "bob-alt",
+            "-r",
+            &alice_alt_did,
+            "--thread-id",
+            parallel_thread_id.as_str(),
+        ])
+        .output()
+        .expect("failed to send parallel relationship accept");
+    assert!(
+        parallel_accept.status.success(),
+        "parallel accept failed: {}",
+        String::from_utf8_lossy(&parallel_accept.stderr)
+    );
+
+    let parallel_request = parallel_request
+        .join()
+        .expect("parallel request thread panicked");
+    assert!(
+        parallel_request.status.success(),
+        "parallel request failed: {}",
+        String::from_utf8_lossy(&parallel_request.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&parallel_request.stdout).contains(&bob_alt_did),
+        "parallel request output did not include bob-alt did: stdout={}, stderr={}",
+        String::from_utf8_lossy(&parallel_request.stdout),
+        String::from_utf8_lossy(&parallel_request.stderr)
+    );
+
+    let alice_store = load_wallet(&alice_wallet);
+    assert!(matches!(
+        alice_store
+            .get_relation_status_for_vid_pair("alice-alt", &bob_alt_did)
+            .unwrap(),
+        RelationshipStatus::Bidirectional { .. }
+    ));
+
+    let bob_store = load_wallet(&bob_wallet);
+    assert!(matches!(
+        bob_store
+            .get_relation_status_for_vid_pair("bob-alt", &alice_alt_did)
+            .unwrap(),
+        RelationshipStatus::Bidirectional { .. }
+    ));
 }
 
 /// Stress test: Create DID, send message, rotate 100 times, send message again

--- a/examples/tests/cli_tests.rs
+++ b/examples/tests/cli_tests.rs
@@ -494,10 +494,10 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
     let tsp_bin = cargo_bin!("tsp");
 
     let outer_receive = {
-        let tsp_bin = tsp_bin;
+        let tsp_bin = tsp_bin.to_path_buf();
         let bob_wallet = bob_wallet.clone();
         thread::spawn(move || {
-            StdCommand::new(&tsp_bin)
+            StdCommand::new(tsp_bin)
                 .args(["--wallet", bob_wallet.as_str(), "receive", "--one", "bob"])
                 .output()
                 .expect("failed to receive outer relationship request")
@@ -506,7 +506,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
 
     thread::sleep(Duration::from_millis(300));
 
-    let outer_request = StdCommand::new(&tsp_bin)
+    let outer_request = StdCommand::new(tsp_bin)
         .args([
             "--wallet",
             alice_wallet.as_str(),
@@ -534,10 +534,10 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
     assert_eq!(outer_sender, alice_did);
 
     let outer_accept_receive = {
-        let tsp_bin = tsp_bin;
+        let tsp_bin = tsp_bin.to_path_buf();
         let alice_wallet = alice_wallet.clone();
         thread::spawn(move || {
-            StdCommand::new(&tsp_bin)
+            StdCommand::new(tsp_bin)
                 .args([
                     "--wallet",
                     alice_wallet.as_str(),
@@ -552,7 +552,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
 
     thread::sleep(Duration::from_millis(300));
 
-    let outer_accept = StdCommand::new(&tsp_bin)
+    let outer_accept = StdCommand::new(tsp_bin)
         .args([
             "--wallet",
             bob_wallet.as_str(),
@@ -584,10 +584,10 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
     verify_did(&alice_wallet, "alice-alt", &alice_alt_did);
 
     let parallel_receive = {
-        let tsp_bin = tsp_bin;
+        let tsp_bin = tsp_bin.to_path_buf();
         let bob_wallet = bob_wallet.clone();
         thread::spawn(move || {
-            StdCommand::new(&tsp_bin)
+            StdCommand::new(tsp_bin)
                 .args(["--wallet", bob_wallet.as_str(), "receive", "--one", "bob"])
                 .output()
                 .expect("failed to receive parallel relationship request")
@@ -597,10 +597,10 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
     thread::sleep(Duration::from_millis(300));
 
     let parallel_request = {
-        let tsp_bin = tsp_bin;
+        let tsp_bin = tsp_bin.to_path_buf();
         let alice_wallet = alice_wallet.clone();
         thread::spawn(move || {
-            StdCommand::new(&tsp_bin)
+            StdCommand::new(tsp_bin)
                 .args([
                     "--wallet",
                     alice_wallet.as_str(),
@@ -631,7 +631,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
         parse_relationship_stdout(&parallel_receive.stdout);
     assert_eq!(received_new_vid, alice_alt_did);
 
-    let parallel_accept = StdCommand::new(&tsp_bin)
+    let parallel_accept = StdCommand::new(tsp_bin)
         .args([
             "--wallet",
             bob_wallet.as_str(),

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -11,6 +11,15 @@ impl From<Error> for JsValue {
     }
 }
 
+fn parse_thread_id(thread_id: &[u8]) -> Result<[u8; 32], tsp_sdk::Error> {
+    thread_id.try_into().map_err(|_| {
+        tsp_sdk::Error::Relationship(format!(
+            "thread_id must be exactly 32 bytes, got {}",
+            thread_id.len()
+        ))
+    })
+}
+
 #[derive(Default, Clone)]
 #[wasm_bindgen]
 pub struct Store(tsp_sdk::SecureStore);
@@ -134,13 +143,14 @@ impl Store {
         route: Option<Vec<String>>,
     ) -> Result<SealedMessage, Error> {
         let route_items: Vec<&str> = route.iter().flatten().map(|s| s.as_str()).collect();
+        let thread_id = parse_thread_id(&thread_id).map_err(Error)?;
 
         let (url, sealed) = self
             .0
             .make_relationship_accept(
                 &sender,
                 &receiver,
-                thread_id.try_into().unwrap(),
+                thread_id,
                 route.as_ref().map(|_| route_items.as_slice()),
             )
             .map_err(Error)?;
@@ -176,13 +186,10 @@ impl Store {
         receiver_new_vid: String,
         thread_id: Vec<u8>,
     ) -> Result<SealedMessage, Error> {
+        let thread_id = parse_thread_id(&thread_id).map_err(Error)?;
         let (url, sealed) = self
             .0
-            .make_parallel_relationship_accept(
-                &sender_new_vid,
-                &receiver_new_vid,
-                thread_id.try_into().unwrap(),
-            )
+            .make_parallel_relationship_accept(&sender_new_vid, &receiver_new_vid, thread_id)
             .map_err(Error)?;
 
         Ok(SealedMessage {
@@ -233,9 +240,10 @@ impl Store {
         receiver: String,
         thread_id: Vec<u8>,
     ) -> Result<NestedSealedMessage, Error> {
+        let thread_id = parse_thread_id(&thread_id).map_err(Error)?;
         let ((url, sealed), vid) = self
             .0
-            .make_nested_relationship_accept(&sender, &receiver, thread_id.try_into().unwrap())
+            .make_nested_relationship_accept(&sender, &receiver, thread_id)
             .map_err(Error)?;
 
         Ok(NestedSealedMessage {
@@ -754,5 +762,26 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
         };
 
         this
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_thread_id;
+
+    #[test]
+    fn parse_thread_id_accepts_32_bytes() {
+        let thread_id = [7_u8; 32];
+        assert_eq!(parse_thread_id(&thread_id).unwrap(), thread_id);
+    }
+
+    #[test]
+    fn parse_thread_id_rejects_wrong_length() {
+        let error = parse_thread_id(&[7_u8; 31]).unwrap_err();
+        assert!(matches!(error, tsp_sdk::Error::Relationship(_)));
+        assert_eq!(
+            error.to_string(),
+            "Relationship Error: thread_id must be exactly 32 bytes, got 31"
+        );
     }
 }

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -422,16 +422,23 @@ pub enum ReceivedTspMessageVariant {
     AcceptRelationship = 2,
     CancelRelationship = 3,
     ForwardRequest = 4,
+    PendingMessage = 5,
 }
 
 impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
     fn from(value: &tsp_sdk::ReceivedTspMessage) -> Self {
+        if value.pending_message_parts().is_some() {
+            return Self::PendingMessage;
+        }
+
+        #[allow(unreachable_patterns)]
         match value {
             tsp_sdk::ReceivedTspMessage::GenericMessage { .. } => Self::GenericMessage,
             tsp_sdk::ReceivedTspMessage::RequestRelationship { .. } => Self::RequestRelationship,
             tsp_sdk::ReceivedTspMessage::AcceptRelationship { .. } => Self::AcceptRelationship,
             tsp_sdk::ReceivedTspMessage::CancelRelationship { .. } => Self::CancelRelationship,
             tsp_sdk::ReceivedTspMessage::ForwardRequest { .. } => Self::ForwardRequest,
+            _ => unreachable!("pending messages are handled before variant flattening"),
         }
     }
 }
@@ -653,6 +660,13 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             new_vid: None,
         };
 
+        if let Some((unknown_vid, payload)) = value.pending_message_parts() {
+            this.unknown_vid = Some(unknown_vid.to_string());
+            this.payload = Some(payload.to_vec());
+            return this;
+        }
+
+        #[allow(unreachable_patterns)]
         match value {
             tsp_sdk::ReceivedTspMessage::GenericMessage {
                 sender,
@@ -736,6 +750,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.route = Some(route.into_iter().map(Into::into).collect());
                 this.opaque_payload = Some(opaque_payload.into());
             }
+            _ => unreachable!("pending messages are handled before flattening"),
         };
 
         this

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -169,42 +169,6 @@ impl Store {
     }
 
     #[wasm_bindgen]
-    pub fn make_new_identifier_notice(
-        &self,
-        sender: String,
-        receiver: String,
-        sender_new_vid: String,
-    ) -> Result<SealedMessage, Error> {
-        let (url, sealed) = self
-            .0
-            .make_new_identifier_notice(&sender, &receiver, &sender_new_vid)
-            .map_err(Error)?;
-
-        Ok(SealedMessage {
-            url: url.to_string(),
-            sealed,
-        })
-    }
-
-    #[wasm_bindgen]
-    pub fn make_relationship_referral(
-        &self,
-        sender: String,
-        receiver: String,
-        referred_vid: String,
-    ) -> Result<SealedMessage, Error> {
-        let (url, sealed) = self
-            .0
-            .make_relationship_referral(&sender, &receiver, &referred_vid)
-            .map_err(Error)?;
-
-        Ok(SealedMessage {
-            url: url.to_string(),
-            sealed,
-        })
-    }
-
-    #[wasm_bindgen]
     pub fn make_nested_relationship_request(
         &self,
         parent_sender: String,
@@ -418,8 +382,6 @@ pub enum ReceivedTspMessageVariant {
     AcceptRelationship = 2,
     CancelRelationship = 3,
     ForwardRequest = 4,
-    NewIdentifier = 5,
-    Referral = 6,
 }
 
 impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
@@ -430,12 +392,23 @@ impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
             tsp_sdk::ReceivedTspMessage::AcceptRelationship { .. } => Self::AcceptRelationship,
             tsp_sdk::ReceivedTspMessage::CancelRelationship { .. } => Self::CancelRelationship,
             tsp_sdk::ReceivedTspMessage::ForwardRequest { .. } => Self::ForwardRequest,
-            tsp_sdk::ReceivedTspMessage::NewIdentifier { .. } => Self::NewIdentifier,
-            tsp_sdk::ReceivedTspMessage::Referral { .. } => Self::Referral,
-            #[cfg(not(target_arch = "wasm32"))]
-            tsp_sdk::ReceivedTspMessage::PendingMessage { .. } => unreachable!(),
         }
     }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum RelationshipForm {
+    Direct = 0,
+    Parallel = 1,
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum RelationshipDelivery {
+    Direct = 0,
+    Nested = 1,
+    Routed = 2,
 }
 
 #[wasm_bindgen]
@@ -478,14 +451,16 @@ pub struct FlatReceivedTspMessage {
     message: Option<Vec<u8>>,
     pub crypto_type: Option<CryptoType>,
     pub signature_type: Option<SignatureType>,
-    route: Option<Option<Vec<Vec<u8>>>>,
-    nested_vid: Option<Option<String>>,
+    pub form: Option<RelationshipForm>,
+    pub delivery: Option<RelationshipDelivery>,
+    route: Option<Vec<Vec<u8>>>,
+    nested_vid: Option<String>,
     thread_id: Option<Vec<u8>>,
+    reply_thread_id: Option<Vec<u8>>,
     next_hop: Option<String>,
     payload: Option<Vec<u8>>,
     opaque_payload: Option<Vec<u8>>,
     unknown_vid: Option<String>,
-    referred_vid: Option<String>,
     new_vid: Option<String>,
 }
 
@@ -494,6 +469,11 @@ impl FlatReceivedTspMessage {
     #[wasm_bindgen(getter)]
     pub fn sender(&self) -> Option<String> {
         self.sender.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn receiver(&self) -> Option<String> {
+        self.receiver.clone()
     }
 
     #[wasm_bindgen(getter)]
@@ -514,23 +494,31 @@ impl FlatReceivedTspMessage {
 
     #[wasm_bindgen(getter)]
     pub fn route(&self) -> JsValue {
-        match &self.route {
-            Some(Some(routes)) => serde_wasm_bindgen::to_value(routes).unwrap(),
-            _ => JsValue::NULL,
-        }
+        self.route
+            .as_ref()
+            .map(|routes| serde_wasm_bindgen::to_value(routes).unwrap())
+            .unwrap_or(JsValue::NULL)
     }
 
     #[wasm_bindgen(getter)]
     pub fn nested_vid(&self) -> JsValue {
-        match &self.nested_vid {
-            Some(Some(vid)) => JsValue::from_str(vid),
-            _ => JsValue::NULL,
-        }
+        self.nested_vid
+            .as_ref()
+            .map(|vid| JsValue::from_str(vid))
+            .unwrap_or(JsValue::NULL)
     }
 
     #[wasm_bindgen(getter)]
     pub fn thread_id(&self) -> JsValue {
         match &self.thread_id {
+            Some(data) => serde_wasm_bindgen::to_value(data).unwrap(),
+            None => JsValue::NULL,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn reply_thread_id(&self) -> JsValue {
+        match &self.reply_thread_id {
             Some(data) => serde_wasm_bindgen::to_value(data).unwrap(),
             None => JsValue::NULL,
         }
@@ -567,6 +555,37 @@ impl FlatReceivedTspMessage {
             None => JsValue::NULL,
         }
     }
+
+    #[wasm_bindgen(getter)]
+    pub fn new_vid(&self) -> JsValue {
+        self.new_vid
+            .as_ref()
+            .map(|new_vid| JsValue::from_str(new_vid))
+            .unwrap_or(JsValue::NULL)
+    }
+}
+
+fn flatten_relationship_form<Data: AsRef<[u8]>>(
+    form: tsp_sdk::ReceivedRelationshipForm<Data>,
+) -> (RelationshipForm, Option<String>) {
+    match form {
+        tsp_sdk::ReceivedRelationshipForm::Direct => (RelationshipForm::Direct, None),
+        tsp_sdk::ReceivedRelationshipForm::Parallel { new_vid, .. } => {
+            (RelationshipForm::Parallel, Some(new_vid))
+        }
+    }
+}
+
+fn flatten_relationship_delivery(
+    delivery: tsp_sdk::ReceivedRelationshipDelivery,
+) -> (RelationshipDelivery, Option<String>) {
+    match delivery {
+        tsp_sdk::ReceivedRelationshipDelivery::Direct => (RelationshipDelivery::Direct, None),
+        tsp_sdk::ReceivedRelationshipDelivery::Nested { nested_vid } => {
+            (RelationshipDelivery::Nested, Some(nested_vid))
+        }
+        tsp_sdk::ReceivedRelationshipDelivery::Routed => (RelationshipDelivery::Routed, None),
+    }
 }
 
 impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
@@ -581,14 +600,16 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             message: None,
             crypto_type: None,
             signature_type: None,
+            form: None,
+            delivery: None,
             route: None,
             nested_vid: None,
             thread_id: None,
+            reply_thread_id: None,
             next_hop: None,
             payload: None,
             opaque_payload: None,
             unknown_vid: None,
-            referred_vid: None,
             new_vid: None,
         };
 
@@ -625,46 +646,42 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             tsp_sdk::ReceivedTspMessage::RequestRelationship {
                 sender,
                 receiver,
-                route,
-                nested_vid,
                 thread_id,
+                form,
+                delivery,
             } => {
+                let (form, new_vid) = flatten_relationship_form(form);
+                let (delivery, nested_vid) = flatten_relationship_delivery(delivery);
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
-                this.route = Some(route);
-                this.nested_vid = Some(nested_vid);
+                this.form = Some(form);
+                this.delivery = Some(delivery);
+                this.nested_vid = nested_vid;
                 this.thread_id = Some(thread_id.to_vec());
+                this.new_vid = new_vid;
             }
             tsp_sdk::ReceivedTspMessage::AcceptRelationship {
                 sender,
                 receiver,
-                nested_vid,
+                thread_id,
+                reply_thread_id,
+                form,
+                delivery,
             } => {
+                let (form, new_vid) = flatten_relationship_form(form);
+                let (delivery, nested_vid) = flatten_relationship_delivery(delivery);
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
-                this.nested_vid = Some(nested_vid);
+                this.form = Some(form);
+                this.delivery = Some(delivery);
+                this.nested_vid = nested_vid;
+                this.thread_id = Some(thread_id.to_vec());
+                this.reply_thread_id = Some(reply_thread_id.to_vec());
+                this.new_vid = new_vid;
             }
             tsp_sdk::ReceivedTspMessage::CancelRelationship { sender, receiver } => {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
-            }
-            tsp_sdk::ReceivedTspMessage::NewIdentifier {
-                sender,
-                receiver,
-                new_vid,
-            } => {
-                this.sender = Some(sender);
-                this.receiver = Some(receiver);
-                this.new_vid = Some(new_vid);
-            }
-            tsp_sdk::ReceivedTspMessage::Referral {
-                sender,
-                receiver,
-                referred_vid,
-            } => {
-                this.sender = Some(sender);
-                this.receiver = Some(receiver);
-                this.referred_vid = Some(referred_vid);
             }
             tsp_sdk::ReceivedTspMessage::ForwardRequest {
                 sender,
@@ -676,12 +693,8 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
                 this.next_hop = Some(next_hop);
-                this.route = Some(Some(route.into_iter().map(Into::into).collect()));
+                this.route = Some(route.into_iter().map(Into::into).collect());
                 this.opaque_payload = Some(opaque_payload.into());
-            }
-            #[cfg(not(target_arch = "wasm32"))]
-            tsp_sdk::ReceivedTspMessage::PendingMessage { .. } => {
-                unreachable!()
             }
         };
 

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -152,6 +152,46 @@ impl Store {
     }
 
     #[wasm_bindgen]
+    pub fn make_parallel_relationship_request(
+        &self,
+        sender: String,
+        receiver: String,
+        sender_new_vid: String,
+    ) -> Result<SealedMessage, Error> {
+        let (url, sealed) = self
+            .0
+            .make_parallel_relationship_request(&sender, &receiver, &sender_new_vid)
+            .map_err(Error)?;
+
+        Ok(SealedMessage {
+            url: url.to_string(),
+            sealed,
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn make_parallel_relationship_accept(
+        &self,
+        sender_new_vid: String,
+        receiver_new_vid: String,
+        thread_id: Vec<u8>,
+    ) -> Result<SealedMessage, Error> {
+        let (url, sealed) = self
+            .0
+            .make_parallel_relationship_accept(
+                &sender_new_vid,
+                &receiver_new_vid,
+                thread_id.try_into().unwrap(),
+            )
+            .map_err(Error)?;
+
+        Ok(SealedMessage {
+            url: url.to_string(),
+            sealed,
+        })
+    }
+
+    #[wasm_bindgen]
     pub fn make_relationship_cancel(
         &self,
         sender: String,

--- a/tsp_node/package-lock.json
+++ b/tsp_node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../tsp_javascript/pkg": {
       "name": "tsp_javascript",
-      "version": "0.9.0-alpha",
+      "version": "0.9.1-rev2",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/tsp_node/test.js
+++ b/tsp_node/test.js
@@ -1,10 +1,44 @@
 const assert = require('assert');
 
 const tsp = require('./tsp');
-const { Store, OwnedVid, CryptoType, SignatureType, GenericMessage, RequestRelationship, AcceptRelationship, CancelRelationship, ForwardRequest} = tsp;
+const {
+    Store,
+    OwnedVid,
+    CryptoType,
+    SignatureType,
+    RelationshipForm,
+    RelationshipDelivery,
+    GenericMessage,
+    RequestRelationship,
+    AcceptRelationship,
+    CancelRelationship,
+    ForwardRequest,
+} = tsp;
 
 function new_vid() {
     return OwnedVid.new_did_peer("tcp://127.0.0.1:1337");
+}
+
+function establishOuterRelationship(store, alice, bob) {
+    let { sealed } = store.make_relationship_request(alice.identifier(), bob.identifier(), null);
+    let received = store.open_message(sealed);
+
+    if (received instanceof RequestRelationship) {
+        assert.strictEqual(received.sender, alice.identifier());
+        assert.strictEqual(received.receiver, bob.identifier());
+    } else {
+        assert.fail(`Unexpected message type: ${received}`);
+    }
+
+    ({ sealed } = store.make_relationship_accept(bob.identifier(), alice.identifier(), received.thread_id, null));
+    received = store.open_message(sealed);
+
+    if (received instanceof AcceptRelationship) {
+        assert.strictEqual(received.sender, bob.identifier());
+        assert.strictEqual(received.receiver, alice.identifier());
+    } else {
+        assert.fail(`Unexpected message type: ${received}`);
+    }
 }
 
 describe('tsp node tests', function() {
@@ -72,6 +106,65 @@ describe('tsp node tests', function() {
         if (received instanceof AcceptRelationship) {
             const { sender } = received;
             assert.strictEqual(sender, bob.identifier());
+        } else {
+            assert.fail(`Unexpected message type: ${received}`);
+        }
+    });
+
+    it("parallel relationship accept", function() {
+        let store = new Store();
+        let alice = new_vid();
+        let bob = new_vid();
+        let aliceParallel = new_vid();
+        let bobParallel = new_vid();
+
+        store.add_private_vid(alice);
+        store.add_private_vid(bob);
+        store.add_private_vid(aliceParallel);
+        store.add_private_vid(bobParallel);
+        establishOuterRelationship(store, alice, bob);
+
+        let { url, sealed } = store.make_parallel_relationship_request(
+            alice.identifier(),
+            bob.identifier(),
+            aliceParallel.identifier(),
+        );
+
+        assert.strictEqual(url, "tcp://127.0.0.1:1337");
+
+        let received = store.open_message(sealed);
+
+        if (received instanceof RequestRelationship) {
+            assert.strictEqual(received.sender, alice.identifier());
+            assert.strictEqual(received.receiver, bob.identifier());
+            assert.strictEqual(received.form, RelationshipForm.Parallel);
+            assert.strictEqual(received.delivery, RelationshipDelivery.Direct);
+            assert.strictEqual(received.nested_vid, null);
+            assert.strictEqual(received.new_vid, aliceParallel.identifier());
+        } else {
+            assert.fail(`Unexpected message type: ${received}`);
+        }
+
+        const requestThreadId = received.thread_id;
+
+        ({ url, sealed } = store.make_parallel_relationship_accept(
+            bobParallel.identifier(),
+            aliceParallel.identifier(),
+            requestThreadId,
+        ));
+
+        assert.strictEqual(url, "tcp://127.0.0.1:1337");
+
+        received = store.open_message(sealed);
+
+        if (received instanceof AcceptRelationship) {
+            assert.strictEqual(received.sender, bob.identifier());
+            assert.strictEqual(received.receiver, aliceParallel.identifier());
+            assert.deepStrictEqual(received.thread_id, requestThreadId);
+            assert.strictEqual(received.form, RelationshipForm.Parallel);
+            assert.strictEqual(received.delivery, RelationshipDelivery.Direct);
+            assert.strictEqual(received.nested_vid, null);
+            assert.strictEqual(received.new_vid, bobParallel.identifier());
         } else {
             assert.fail(`Unexpected message type: ${received}`);
         }

--- a/tsp_node/tsp.js
+++ b/tsp_node/tsp.js
@@ -1,5 +1,10 @@
 const wasm = require('tsp-javascript');
-const { OwnedVid } = wasm;
+const {
+    OwnedVid,
+    Vid,
+    RelationshipForm,
+    RelationshipDelivery,
+} = wasm;
 
 const CryptoType = {
     Plaintext: 0,
@@ -58,6 +63,14 @@ class Store {
         return this.inner.make_relationship_accept(...args);
     }
 
+    make_parallel_relationship_request(...args) {
+        return this.inner.make_parallel_relationship_request(...args);
+    }
+
+    make_parallel_relationship_accept(...args) {
+        return this.inner.make_parallel_relationship_accept(...args);
+    }
+
     make_relationship_cancel(...args) {
         return this.inner.make_relationship_cancel(...args);
     }
@@ -89,28 +102,37 @@ class ReceivedTspMessage {
                     msg.receiver,
                     msg.nonconfidential_data,
                     new Uint8Array(msg.message),
-                    msg.message_type
+                    msg.crypto_type,
+                    msg.signature_type
                 );
 
             case 1: 
                 return new RequestRelationship(
                     msg.sender,
                     msg.receiver,
-                    msg.route,
-                    msg.nested_vid,
                     msg.thread_id,
+                    msg.form,
+                    msg.delivery,
+                    msg.nested_vid,
+                    msg.new_vid,
                 );
 
             case 2: 
                 return new AcceptRelationship(
                     msg.sender,
                     msg.receiver,
-                    msg.nested_vid
+                    msg.thread_id,
+                    msg.reply_thread_id,
+                    msg.form,
+                    msg.delivery,
+                    msg.nested_vid,
+                    msg.new_vid,
                 );
 
             case 3: 
                 return new CancelRelationship(
-                    msg.sender
+                    msg.sender,
+                    msg.receiver,
                 );
 
             case 4: 
@@ -132,33 +154,41 @@ class ReceivedTspMessage {
 }
 
 class GenericMessage extends ReceivedTspMessage {
-    constructor(sender, receiver, nonconfidential_data, message, message_type) {
+    constructor(sender, receiver, nonconfidential_data, message, crypto_type, signature_type) {
         super();
         this.sender = sender;
         this.receiver = receiver;
         this.nonconfidential_data = nonconfidential_data;
         this.message = message;
-        this.message_type = message_type;
+        this.crypto_type = crypto_type;
+        this.signature_type = signature_type;
     }
 }
 
 class RequestRelationship extends ReceivedTspMessage {
-    constructor(sender, receiver, route, nested_vid, thread_id) {
+    constructor(sender, receiver, thread_id, form, delivery, nested_vid, new_vid) {
         super();
         this.sender = sender;
         this.receiver = receiver;
-        this.route = route;
-        this.nested_vid = nested_vid;
         this.thread_id = thread_id;
+        this.form = form;
+        this.delivery = delivery;
+        this.nested_vid = nested_vid;
+        this.new_vid = new_vid;
     }
 }
 
 class AcceptRelationship extends ReceivedTspMessage {
-    constructor(sender, receiver, nested_vid) {
+    constructor(sender, receiver, thread_id, reply_thread_id, form, delivery, nested_vid, new_vid) {
         super();
         this.sender = sender;
         this.receiver = receiver;
+        this.thread_id = thread_id;
+        this.reply_thread_id = reply_thread_id;
+        this.form = form;
+        this.delivery = delivery;
         this.nested_vid = nested_vid;
+        this.new_vid = new_vid;
     }
 }
 
@@ -184,8 +214,11 @@ class ForwardRequest extends ReceivedTspMessage {
 module.exports = {
     CryptoType,
     SignatureType,
+    RelationshipForm,
+    RelationshipDelivery,
     Store,
     OwnedVid,
+    Vid,
     ReceivedTspMessage,
     GenericMessage,
     AcceptRelationship,

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -273,6 +273,34 @@ impl Store {
         Ok((url.to_string(), bytes))
     }
 
+    fn make_parallel_relationship_request(
+        &self,
+        sender: String,
+        receiver: String,
+        sender_new_vid: String,
+    ) -> PyResult<(String, Vec<u8>)> {
+        let (url, bytes) = self
+            .inner
+            .make_parallel_relationship_request(&sender, &receiver, &sender_new_vid)
+            .map_err(py_exception)?;
+
+        Ok((url.to_string(), bytes))
+    }
+
+    fn make_parallel_relationship_accept(
+        &self,
+        sender_new_vid: String,
+        receiver_new_vid: String,
+        thread_id: [u8; 32],
+    ) -> PyResult<(String, Vec<u8>)> {
+        let (url, bytes) = self
+            .inner
+            .make_parallel_relationship_accept(&sender_new_vid, &receiver_new_vid, thread_id)
+            .map_err(py_exception)?;
+
+        Ok((url.to_string(), bytes))
+    }
+
     #[pyo3(signature = (sender, receiver))]
     fn make_relationship_cancel(
         &self,

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -9,6 +9,8 @@ fn tsp_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_class::<CryptoType>()?;
     m.add_class::<SignatureType>()?;
+    m.add_class::<RelationshipForm>()?;
+    m.add_class::<RelationshipDelivery>()?;
     m.add_class::<ReceivedTspMessageVariant>()?;
     m.add_class::<FlatReceivedTspMessage>()?;
 
@@ -285,36 +287,6 @@ impl Store {
         Ok((url.to_string(), bytes))
     }
 
-    #[pyo3(signature = (sender, receiver, sender_new_vid))]
-    fn make_new_identifier_notice(
-        &self,
-        sender: String,
-        receiver: String,
-        sender_new_vid: String,
-    ) -> PyResult<(String, Vec<u8>)> {
-        let (url, bytes) = self
-            .inner
-            .make_new_identifier_notice(&sender, &receiver, &sender_new_vid)
-            .map_err(py_exception)?;
-
-        Ok((url.to_string(), bytes))
-    }
-
-    #[pyo3(signature = (sender, receiver, referred_vid))]
-    fn make_relationship_referral(
-        &self,
-        sender: String,
-        receiver: String,
-        referred_vid: String,
-    ) -> PyResult<(String, Vec<u8>)> {
-        let (url, bytes) = self
-            .inner
-            .make_relationship_referral(&sender, &receiver, &referred_vid)
-            .map_err(py_exception)?;
-
-        Ok((url.to_string(), bytes))
-    }
-
     fn make_nested_relationship_request(
         &self,
         parent_sender: String,
@@ -391,8 +363,6 @@ enum ReceivedTspMessageVariant {
     CancelRelationship,
     ForwardRequest,
     PendingMessage,
-    NewIdentifier,
-    Referral,
 }
 
 impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
@@ -404,10 +374,23 @@ impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
             tsp_sdk::ReceivedTspMessage::CancelRelationship { .. } => Self::CancelRelationship,
             tsp_sdk::ReceivedTspMessage::ForwardRequest { .. } => Self::ForwardRequest,
             tsp_sdk::ReceivedTspMessage::PendingMessage { .. } => Self::PendingMessage,
-            tsp_sdk::ReceivedTspMessage::NewIdentifier { .. } => Self::NewIdentifier,
-            tsp_sdk::ReceivedTspMessage::Referral { .. } => Self::Referral,
         }
     }
+}
+
+#[pyclass(eq, eq_int)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RelationshipForm {
+    Direct = 0,
+    Parallel = 1,
+}
+
+#[pyclass(eq, eq_int)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RelationshipDelivery {
+    Direct = 0,
+    Nested = 1,
+    Routed = 2,
 }
 
 #[pyclass(eq, eq_int)]
@@ -448,11 +431,17 @@ struct FlatReceivedTspMessage {
     #[pyo3(get, set)]
     signature_type: Option<SignatureType>,
     #[pyo3(get, set)]
-    route: Option<Option<Vec<Vec<u8>>>>,
+    form: Option<RelationshipForm>,
     #[pyo3(get, set)]
-    nested_vid: Option<Option<String>>,
+    delivery: Option<RelationshipDelivery>,
+    #[pyo3(get, set)]
+    route: Option<Vec<Vec<u8>>>,
+    #[pyo3(get, set)]
+    nested_vid: Option<String>,
     #[pyo3(get, set)]
     thread_id: Option<[u8; 32]>,
+    #[pyo3(get, set)]
+    reply_thread_id: Option<[u8; 32]>,
     #[pyo3(get, set)]
     next_hop: Option<String>,
     #[pyo3(get, set)]
@@ -463,14 +452,35 @@ struct FlatReceivedTspMessage {
     unknown_vid: Option<String>,
     #[pyo3(get, set)]
     new_vid: Option<String>,
-    #[pyo3(get, set)]
-    referred_vid: Option<String>,
 }
 
 #[pymethods]
 impl FlatReceivedTspMessage {
     fn __repr__(&self) -> String {
         format!("{self:?}")
+    }
+}
+
+fn flatten_relationship_form<Data: AsRef<[u8]>>(
+    form: tsp_sdk::ReceivedRelationshipForm<Data>,
+) -> (RelationshipForm, Option<String>) {
+    match form {
+        tsp_sdk::ReceivedRelationshipForm::Direct => (RelationshipForm::Direct, None),
+        tsp_sdk::ReceivedRelationshipForm::Parallel { new_vid, .. } => {
+            (RelationshipForm::Parallel, Some(new_vid))
+        }
+    }
+}
+
+fn flatten_relationship_delivery(
+    delivery: tsp_sdk::ReceivedRelationshipDelivery,
+) -> (RelationshipDelivery, Option<String>) {
+    match delivery {
+        tsp_sdk::ReceivedRelationshipDelivery::Direct => (RelationshipDelivery::Direct, None),
+        tsp_sdk::ReceivedRelationshipDelivery::Nested { nested_vid } => {
+            (RelationshipDelivery::Nested, Some(nested_vid))
+        }
+        tsp_sdk::ReceivedRelationshipDelivery::Routed => (RelationshipDelivery::Routed, None),
     }
 }
 
@@ -486,15 +496,17 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             message: None,
             crypto_type: None,
             signature_type: None,
+            form: None,
+            delivery: None,
             route: None,
             nested_vid: None,
             thread_id: None,
+            reply_thread_id: None,
             next_hop: None,
             payload: None,
             opaque_payload: None,
             unknown_vid: None,
             new_vid: None,
-            referred_vid: None,
         };
 
         match value {
@@ -530,46 +542,42 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             tsp_sdk::ReceivedTspMessage::RequestRelationship {
                 sender,
                 receiver,
-                route,
-                nested_vid,
                 thread_id,
+                form,
+                delivery,
             } => {
+                let (form, new_vid) = flatten_relationship_form(form);
+                let (delivery, nested_vid) = flatten_relationship_delivery(delivery);
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
-                this.route = Some(route);
-                this.nested_vid = Some(nested_vid);
+                this.form = Some(form);
+                this.delivery = Some(delivery);
+                this.nested_vid = nested_vid;
                 this.thread_id = Some(thread_id);
+                this.new_vid = new_vid;
             }
             tsp_sdk::ReceivedTspMessage::AcceptRelationship {
                 sender,
                 receiver,
-                nested_vid,
+                thread_id,
+                reply_thread_id,
+                form,
+                delivery,
             } => {
+                let (form, new_vid) = flatten_relationship_form(form);
+                let (delivery, nested_vid) = flatten_relationship_delivery(delivery);
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
-                this.nested_vid = Some(nested_vid);
+                this.form = Some(form);
+                this.delivery = Some(delivery);
+                this.nested_vid = nested_vid;
+                this.thread_id = Some(thread_id);
+                this.reply_thread_id = Some(reply_thread_id);
+                this.new_vid = new_vid;
             }
             tsp_sdk::ReceivedTspMessage::CancelRelationship { sender, receiver } => {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
-            }
-            tsp_sdk::ReceivedTspMessage::NewIdentifier {
-                sender,
-                receiver,
-                new_vid,
-            } => {
-                this.sender = Some(sender);
-                this.receiver = Some(receiver);
-                this.new_vid = Some(new_vid);
-            }
-            tsp_sdk::ReceivedTspMessage::Referral {
-                sender,
-                receiver,
-                referred_vid,
-            } => {
-                this.sender = Some(sender);
-                this.receiver = Some(receiver);
-                this.referred_vid = Some(referred_vid);
             }
             tsp_sdk::ReceivedTspMessage::ForwardRequest {
                 sender,
@@ -581,7 +589,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
                 this.next_hop = Some(next_hop);
-                this.route = Some(Some(route.into_iter().map(Into::into).collect()));
+                this.route = Some(route.into_iter().map(Into::into).collect());
                 this.opaque_payload = Some(opaque_payload.into());
             }
             tsp_sdk::ReceivedTspMessage::PendingMessage {

--- a/tsp_python/test.py
+++ b/tsp_python/test.py
@@ -54,9 +54,7 @@ class AliceBob(unittest.TestCase):
         received = self.store.open_message(sealed)
 
         match received:
-            case tsp.RequestRelationship(
-                sender, receiver, _route, _nested_vid, _thread_id
-            ):
+            case tsp.RequestRelationship(sender, receiver, _thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, self.alice.identifier())
                 self.assertEqual(receiver, self.bob.identifier())
 
@@ -71,9 +69,7 @@ class AliceBob(unittest.TestCase):
 
         received = self.store.open_message(sealed)
         match received:
-            case tsp.RequestRelationship(
-                sender, receiver, _route, _nested_vid, thread_id
-            ):
+            case tsp.RequestRelationship(sender, receiver, thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, self.alice.identifier())
                 self.assertEqual(receiver, self.bob.identifier())
 
@@ -87,7 +83,7 @@ class AliceBob(unittest.TestCase):
 
         received = self.store.open_message(sealed)
         match received:
-            case tsp.AcceptRelationship(sender, receiver, _nested_vid):
+            case tsp.AcceptRelationship(sender, receiver, _thread_id, _reply_thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, self.bob.identifier())
                 self.assertEqual(receiver, self.alice.identifier())
 
@@ -102,9 +98,7 @@ class AliceBob(unittest.TestCase):
 
         received = self.store.open_message(sealed)
         match received:
-            case tsp.RequestRelationship(
-                sender, receiver, _route, _nested_vid, thread_id
-            ):
+            case tsp.RequestRelationship(sender, receiver, thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, self.alice.identifier())
                 self.assertEqual(receiver, self.bob.identifier())
 
@@ -118,7 +112,7 @@ class AliceBob(unittest.TestCase):
 
         received = self.store.open_message(sealed)
         match received:
-            case tsp.AcceptRelationship(sender, receiver, _nested_vid):
+            case tsp.AcceptRelationship(sender, receiver, _thread_id, _reply_thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, self.bob.identifier())
                 self.assertEqual(receiver, self.alice.identifier())
 
@@ -270,9 +264,7 @@ class AliceBob(unittest.TestCase):
 
         received = b_store.open_message(sealed)
         match received:
-            case tsp.RequestRelationship(
-                sender, receiver, _route, _nested_vid, thread_id
-            ):
+            case tsp.RequestRelationship(sender, receiver, thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, a.identifier())
                 self.assertEqual(receiver, b.identifier())
 
@@ -286,7 +278,7 @@ class AliceBob(unittest.TestCase):
 
         received = a_store.open_message(sealed)
         match received:
-            case tsp.AcceptRelationship(sender, receiver, _nested_vid):
+            case tsp.AcceptRelationship(sender, receiver, _thread_id, _reply_thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, b.identifier())
                 self.assertEqual(receiver, a.identifier())
 
@@ -298,9 +290,7 @@ class AliceBob(unittest.TestCase):
         )
 
         match b_store.open_message(sealed):
-            case tsp.RequestRelationship(
-                sender, receiver, _route, nested_vid_1, thread_id
-            ):
+            case tsp.RequestRelationship(sender, receiver, thread_id, _form, _delivery, nested_vid_1, _new_vid):
                 self.assertEqual(sender, a.identifier())
                 self.assertEqual(receiver, b.identifier())
 
@@ -312,7 +302,7 @@ class AliceBob(unittest.TestCase):
         )
 
         match a_store.open_message(sealed):
-            case tsp.AcceptRelationship(sender, receiver, nested_vid_2):
+            case tsp.AcceptRelationship(sender, receiver, _thread_id, _reply_thread_id, _form, _delivery, nested_vid_2, _new_vid):
                 self.assertEqual(sender, b.identifier())
 
             case other:

--- a/tsp_python/test.py
+++ b/tsp_python/test.py
@@ -20,6 +20,31 @@ class AliceBob(unittest.TestCase):
     def tearDown(self):
         os.remove("test_wallet.sqlite")
 
+    def establish_outer_relationship(self):
+        _url, sealed = self.store.make_relationship_request(
+            self.alice.identifier(), self.bob.identifier(), None
+        )
+
+        received = self.store.open_message(sealed)
+        match received:
+            case tsp.RequestRelationship(sender, receiver, thread_id, _form, _delivery, _nested_vid, _new_vid):
+                self.assertEqual(sender, self.alice.identifier())
+                self.assertEqual(receiver, self.bob.identifier())
+            case other:
+                self.fail(f"unexpected message type {other}")
+
+        _url, sealed = self.store.make_relationship_accept(
+            self.bob.identifier(), self.alice.identifier(), thread_id, None
+        )
+
+        received = self.store.open_message(sealed)
+        match received:
+            case tsp.AcceptRelationship(sender, receiver, _thread_id, _reply_thread_id, _form, _delivery, _nested_vid, _new_vid):
+                self.assertEqual(sender, self.bob.identifier())
+                self.assertEqual(receiver, self.alice.identifier())
+            case other:
+                self.fail(f"unexpected message type {other}")
+
     def test_open_seal(self):
         message = b"hello world"
 
@@ -57,6 +82,78 @@ class AliceBob(unittest.TestCase):
             case tsp.RequestRelationship(sender, receiver, _thread_id, _form, _delivery, _nested_vid, _new_vid):
                 self.assertEqual(sender, self.alice.identifier())
                 self.assertEqual(receiver, self.bob.identifier())
+
+            case other:
+                self.fail(f"unexpected message type {other}")
+
+    def test_make_parallel_relationship_request(self):
+        alice_parallel = new_vid()
+        self.store.add_private_vid(alice_parallel)
+        self.establish_outer_relationship()
+
+        url, sealed = self.store.make_parallel_relationship_request(
+            self.alice.identifier(),
+            self.bob.identifier(),
+            alice_parallel.identifier(),
+        )
+
+        self.assertEqual(url, "tcp://127.0.0.1:1337")
+
+        received = self.store.open_message(sealed)
+
+        match received:
+            case tsp.RequestRelationship(sender, receiver, _thread_id, form, delivery, nested_vid, parallel_vid):
+                self.assertEqual(sender, self.alice.identifier())
+                self.assertEqual(receiver, self.bob.identifier())
+                self.assertEqual(form, tsp.RelationshipForm.Parallel)
+                self.assertEqual(delivery, tsp.RelationshipDelivery.Direct)
+                self.assertIsNone(nested_vid)
+                self.assertEqual(parallel_vid, alice_parallel.identifier())
+
+            case other:
+                self.fail(f"unexpected message type {other}")
+
+    def test_make_parallel_relationship_accept(self):
+        alice_parallel = new_vid()
+        bob_parallel = new_vid()
+        self.store.add_private_vid(alice_parallel)
+        self.store.add_private_vid(bob_parallel)
+        self.establish_outer_relationship()
+
+        _url, sealed = self.store.make_parallel_relationship_request(
+            self.alice.identifier(),
+            self.bob.identifier(),
+            alice_parallel.identifier(),
+        )
+
+        received = self.store.open_message(sealed)
+        match received:
+            case tsp.RequestRelationship(sender, receiver, thread_id, form, delivery, nested_vid, parallel_vid):
+                self.assertEqual(sender, self.alice.identifier())
+                self.assertEqual(receiver, self.bob.identifier())
+                self.assertEqual(form, tsp.RelationshipForm.Parallel)
+                self.assertEqual(delivery, tsp.RelationshipDelivery.Direct)
+                self.assertIsNone(nested_vid)
+                self.assertEqual(parallel_vid, alice_parallel.identifier())
+
+            case other:
+                self.fail(f"unexpected message type {other}")
+
+        url, sealed = self.store.make_parallel_relationship_accept(
+            bob_parallel.identifier(), alice_parallel.identifier(), thread_id
+        )
+        self.assertEqual(url, "tcp://127.0.0.1:1337")
+
+        received = self.store.open_message(sealed)
+        match received:
+            case tsp.AcceptRelationship(sender, receiver, received_thread_id, _reply_thread_id, form, delivery, nested_vid, parallel_vid):
+                self.assertEqual(sender, self.bob.identifier())
+                self.assertEqual(receiver, alice_parallel.identifier())
+                self.assertEqual(received_thread_id, thread_id)
+                self.assertEqual(form, tsp.RelationshipForm.Parallel)
+                self.assertEqual(delivery, tsp.RelationshipDelivery.Direct)
+                self.assertIsNone(nested_vid)
+                self.assertEqual(parallel_vid, bob_parallel.identifier())
 
             case other:
                 self.fail(f"unexpected message type {other}")

--- a/tsp_python/tsp_python/tsp.py
+++ b/tsp_python/tsp_python/tsp.py
@@ -8,6 +8,8 @@ ReceivedTspMessageVariant = tsp_python.ReceivedTspMessageVariant
 FlatReceivedTspMessage = tsp_python.FlatReceivedTspMessage
 CryptoType = tsp_python.CryptoType
 SignatureType = tsp_python.SignatureType
+RelationshipForm = tsp_python.RelationshipForm
+RelationshipDelivery = tsp_python.RelationshipDelivery
 
 
 def color_print(message: bytes) -> str:
@@ -200,11 +202,26 @@ class ReceivedTspMessage:
 
             case ReceivedTspMessageVariant.RequestRelationship:
                 return RequestRelationship(
-                    msg.sender, msg.receiver, msg.route, msg.nested_vid, msg.thread_id
+                    msg.sender,
+                    msg.receiver,
+                    bytes(msg.thread_id),
+                    msg.form,
+                    msg.delivery,
+                    msg.nested_vid,
+                    msg.new_vid,
                 )
 
             case ReceivedTspMessageVariant.AcceptRelationship:
-                return AcceptRelationship(msg.sender, msg.receiver, msg.nested_vid)
+                return AcceptRelationship(
+                    msg.sender,
+                    msg.receiver,
+                    bytes(msg.thread_id),
+                    bytes(msg.reply_thread_id),
+                    msg.form,
+                    msg.delivery,
+                    msg.nested_vid,
+                    msg.new_vid,
+                )
 
             case ReceivedTspMessageVariant.CancelRelationship:
                 return CancelRelationship(msg.sender, msg.receiver)
@@ -214,8 +231,8 @@ class ReceivedTspMessage:
                     msg.sender,
                     msg.receiver,
                     msg.next_hop,
-                    msg.route,
-                    msg.opaque_payload,
+                    [bytes(hop) for hop in msg.route],
+                    bytes(msg.opaque_payload),
                 )
 
             case ReceivedTspMessageVariant.PendingMessage:
@@ -239,7 +256,12 @@ class GenericMessage(ReceivedTspMessage):
 class AcceptRelationship(ReceivedTspMessage):
     sender: str
     receiver: str
-    nested_vid: str
+    thread_id: bytes
+    reply_thread_id: bytes
+    form: RelationshipForm
+    delivery: RelationshipDelivery
+    nested_vid: str | None
+    new_vid: str | None
 
 
 @dataclass
@@ -252,9 +274,11 @@ class CancelRelationship(ReceivedTspMessage):
 class RequestRelationship(ReceivedTspMessage):
     sender: str
     receiver: str
-    route: str
-    nested_vid: str
-    thread_id: str
+    thread_id: bytes
+    form: RelationshipForm
+    delivery: RelationshipDelivery
+    nested_vid: str | None
+    new_vid: str | None
 
 
 @dataclass
@@ -262,5 +286,5 @@ class ForwardRequest(ReceivedTspMessage):
     sender: str
     receiver: str
     next_hop: str
-    route: str
-    opaque_payload: str
+    route: list[bytes]
+    opaque_payload: bytes

--- a/tsp_python/tsp_python/tsp.py
+++ b/tsp_python/tsp_python/tsp.py
@@ -161,6 +161,22 @@ class SecureStore:
                 sender, receiver, thread_id, route
             )
 
+    def make_parallel_relationship_request(
+            self, sender: str, receiver: str, sender_new_vid: str
+    ) -> tuple[str, bytes]:
+        with Wallet(self):
+            return self.inner.make_parallel_relationship_request(
+                sender, receiver, sender_new_vid
+            )
+
+    def make_parallel_relationship_accept(
+            self, sender_new_vid: str, receiver_new_vid: str, thread_id: bytes
+    ) -> tuple[str, bytes]:
+        with Wallet(self):
+            return self.inner.make_parallel_relationship_accept(
+                sender_new_vid, receiver_new_vid, thread_id
+            )
+
     def make_relationship_cancel(self, sender: str, receiver: str) -> tuple[str, bytes]:
         with Wallet(self):
             return self.inner.make_relationship_cancel(sender, receiver)

--- a/tsp_sdk/benches/throughput_cli.rs
+++ b/tsp_sdk/benches/throughput_cli.rs
@@ -67,7 +67,8 @@ fn fixture_owned_vid_with_transport(which: &str, transport: &Url) -> OwnedVid {
 fn relationship_bi_default() -> RelationshipStatus {
     RelationshipStatus::Bidirectional {
         thread_id: [0u8; 32],
-        outstanding_nested_thread_ids: vec![],
+        remote_thread_id: [0u8; 32],
+        outstanding_nested_requests: vec![],
     }
 }
 

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -368,62 +368,6 @@ impl AsyncSecureStore {
         Ok(())
     }
 
-    pub fn make_new_identifier_notice(
-        &self,
-        sender: &str,
-        receiver: &str,
-        sender_new_vid: &str,
-    ) -> Result<(Url, Vec<u8>), Error> {
-        self.inner
-            .make_new_identifier_notice(sender, receiver, sender_new_vid)
-    }
-
-    /// Send a new identifier introduction notice
-    pub async fn send_new_identifier_notice(
-        &self,
-        sender: &str,
-        receiver: &str,
-        sender_new_vid: &str,
-    ) -> Result<(), Error> {
-        let (endpoint, message) =
-            self.inner
-                .make_new_identifier_notice(sender, receiver, sender_new_vid)?;
-
-        tracing::info!("sending message to {endpoint}");
-
-        crate::transport::send_message(&endpoint, &message).await?;
-
-        Ok(())
-    }
-
-    pub fn make_relationship_referral(
-        &self,
-        sender: &str,
-        receiver: &str,
-        referred_vid: &str,
-    ) -> Result<(Url, Vec<u8>), Error> {
-        self.inner
-            .make_relationship_referral(sender, receiver, referred_vid)
-    }
-
-    /// Send a relationship referral message to `receiver`
-    pub async fn send_relationship_referral(
-        &self,
-        sender: &str,
-        receiver: &str,
-        referred_vid: &str,
-    ) -> Result<(), Error> {
-        let (endpoint, message) =
-            self.inner
-                .make_relationship_referral(sender, receiver, referred_vid)?;
-
-        tracing::info!("sending message to {endpoint}");
-
-        crate::transport::send_message(&endpoint, &message).await?;
-
-        Ok(())
-    }
-
     pub fn make_nested_relationship_request(
         &self,
         parent_sender: &str,

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -313,6 +313,33 @@ impl AsyncSecureStore {
         Ok(())
     }
 
+    pub fn make_parallel_relationship_request(
+        &self,
+        sender: &str,
+        receiver: &str,
+        sender_new_vid: &str,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.inner
+            .make_parallel_relationship_request(sender, receiver, sender_new_vid)
+    }
+
+    pub async fn send_parallel_relationship_request(
+        &self,
+        sender: &str,
+        receiver: &str,
+        sender_new_vid: &str,
+    ) -> Result<(), Error> {
+        let (endpoint, message) =
+            self.inner
+                .make_parallel_relationship_request(sender, receiver, sender_new_vid)?;
+
+        tracing::info!("sending message to {endpoint}");
+
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
     pub fn make_relationship_accept(
         &self,
         sender: &str,
@@ -336,6 +363,35 @@ impl AsyncSecureStore {
     ) -> Result<(), Error> {
         let (endpoint, message) =
             self.make_relationship_accept(sender, receiver, thread_id, route)?;
+
+        tracing::info!("sending message to {endpoint}");
+
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
+    pub fn make_parallel_relationship_accept(
+        &self,
+        sender_new_vid: &str,
+        receiver_new_vid: &str,
+        thread_id: Digest,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.inner
+            .make_parallel_relationship_accept(sender_new_vid, receiver_new_vid, thread_id)
+    }
+
+    pub async fn send_parallel_relationship_accept(
+        &self,
+        sender_new_vid: &str,
+        receiver_new_vid: &str,
+        thread_id: Digest,
+    ) -> Result<(), Error> {
+        let (endpoint, message) = self.inner.make_parallel_relationship_accept(
+            sender_new_vid,
+            receiver_new_vid,
+            thread_id,
+        )?;
 
         tracing::info!("sending message to {endpoint}");
 
@@ -494,6 +550,11 @@ impl AsyncSecureStore {
 
                 match db_inner.open_message(&mut message) {
                     Err(Error::UnverifiedSource(unknown_vid, _)) => {
+                        debug!("Verifying VID: {}", unknown_vid);
+                        self_inner.verify_vid(&unknown_vid, None).await?;
+                        db_inner.open_message(&mut message)
+                    }
+                    Err(Error::UnverifiedVid(unknown_vid)) => {
                         debug!("Verifying VID: {}", unknown_vid);
                         self_inner.verify_vid(&unknown_vid, None).await?;
                         db_inner.open_message(&mut message)

--- a/tsp_sdk/src/cesr/error.rs
+++ b/tsp_sdk/src/cesr/error.rs
@@ -5,6 +5,7 @@ pub enum EncodeError {
     MissingHops,
     MissingReceiver,
     InvalidVid,
+    InvalidSignatureType,
 }
 
 /// An error type to indicate something went wrong with decoding

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -46,13 +46,6 @@ const XRFA: [u8; 3] = cesr_data("XRFA");
 const XRFD: [u8; 3] = cesr_data("XRFD");
 const YTSP: [u8; 3] = cesr_data("YTSP");
 
-// FIXME: a temporary code for third party referrals
-const X3RR: [u8; 3] = cesr_data("X3RR");
-
-// FIXME: a temporary code for nested relationships
-const XRNI: [u8; 3] = cesr_data("XRNI");
-const XRNA: [u8; 3] = cesr_data("XRNA");
-
 use super::{
     decode::{
         decode_count, decode_count_mut, decode_fixed_data, decode_fixed_data_mut,
@@ -109,21 +102,29 @@ pub enum Payload<'a, Bytes, Vid> {
     /// A routed payload; same as above but with routing information attached
     RoutedMessage(Vec<Vid>, Bytes),
     /// A TSP message requesting a relationship
-    DirectRelationProposal { nonce: Nonce, hops: Vec<Vid> },
+    DirectRelationProposal {
+        nonce: Nonce,
+        request_digest: Digest<'a>,
+    },
     /// A TSP message confirming a relationship
-    DirectRelationAffirm { reply: Digest<'a> },
-    /// A TSP message requesting a nested relationship
-    NestedRelationProposal { nonce: Nonce, message: Bytes },
-    /// A TSP message confirming a relationship
-    NestedRelationAffirm { message: Bytes, reply: Digest<'a> },
-    /// A TSP Message establishing a secondary relationship (parallel relationship forming)
-    NewIdentifierProposal {
-        thread_id: Digest<'a>,
-        sig_thread_id: &'a Signature,
+    DirectRelationAffirm {
+        request_digest: Digest<'a>,
+        reply_digest: Digest<'a>,
+    },
+    /// A TSP message requesting a secondary relationship alongside an existing one.
+    ParallelRelationProposal {
+        nonce: Nonce,
+        request_digest: Digest<'a>,
+        sig_new_vid: &'a Signature,
         new_vid: Vid,
     },
-    /// A TSP Message revealing a third party
-    RelationshipReferral { referred_vid: Vid },
+    /// A TSP message accepting a secondary relationship request.
+    ParallelRelationAffirm {
+        request_digest: Digest<'a>,
+        reply_digest: Digest<'a>,
+        sig_new_vid: &'a Signature,
+        new_vid: Vid,
+    },
     /// A TSP cancellation message
     RelationshipCancel { reply: Digest<'a> },
 }
@@ -290,51 +291,52 @@ pub fn encode_payload(
             encode_hops(hops, &mut temp)?;
             checked_encode_variable_data(TSP_PLAINTEXT, data.as_ref(), &mut temp)?;
         }
-        Payload::DirectRelationProposal { nonce, hops } => {
+        Payload::DirectRelationProposal {
+            nonce,
+            request_digest,
+        } => {
             temp.extend(&XRFI);
-            encode_hops(hops, &mut temp)?;
+            encode_digest(request_digest, &mut temp);
             encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
             checked_encode_variable_data(TSP_VID, &[], &mut temp)?;
         }
-        Payload::DirectRelationAffirm { reply } => {
+        Payload::DirectRelationAffirm {
+            request_digest,
+            reply_digest,
+        } => {
             temp.extend(&XRFA);
-            encode_digest(reply, &mut temp);
+            encode_digest(request_digest, &mut temp);
+            encode_digest(reply_digest, &mut temp);
         }
-        Payload::NestedRelationProposal {
-            message: data,
+        Payload::ParallelRelationProposal {
             nonce,
-        } => {
-            temp.extend(&XRNI);
-            checked_encode_variable_data(TSP_PLAINTEXT, data.as_ref(), &mut temp)?;
-            encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
-        }
-        Payload::NestedRelationAffirm {
-            message: data,
-            reply,
-        } => {
-            temp.extend(&XRNA);
-            checked_encode_variable_data(TSP_PLAINTEXT, data.as_ref(), &mut temp)?;
-            encode_digest(reply, &mut temp);
-        }
-        Payload::NewIdentifierProposal {
-            thread_id,
-            sig_thread_id,
+            request_digest,
+            sig_new_vid,
             new_vid,
         } => {
             if new_vid.as_ref().is_empty() {
                 return Err(EncodeError::InvalidVid);
             }
             temp.extend(&XRFI);
-            let no_hops: [&[u8]; 0] = [];
-            encode_hops(&no_hops, &mut temp)?;
-            encode_fixed_data(TSP_NONCE, &[0; 32], &mut temp); // this does not need to be a secure nonce
+            encode_digest(request_digest, &mut temp);
+            encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
             checked_encode_variable_data(TSP_VID, new_vid.as_ref(), &mut temp)?;
-            encode_digest(thread_id, &mut temp);
-            encode_fixed_data(ED25519_SIGNATURE, sig_thread_id, &mut temp);
+            encode_fixed_data(ED25519_SIGNATURE, sig_new_vid, &mut temp);
         }
-        Payload::RelationshipReferral { referred_vid } => {
-            temp.extend(&X3RR);
-            checked_encode_variable_data(TSP_VID, referred_vid.as_ref(), &mut temp)?;
+        Payload::ParallelRelationAffirm {
+            request_digest,
+            reply_digest,
+            sig_new_vid,
+            new_vid,
+        } => {
+            if new_vid.as_ref().is_empty() {
+                return Err(EncodeError::InvalidVid);
+            }
+            temp.extend(&XRFA);
+            encode_digest(request_digest, &mut temp);
+            encode_digest(reply_digest, &mut temp);
+            checked_encode_variable_data(TSP_VID, new_vid.as_ref(), &mut temp)?;
+            encode_fixed_data(ED25519_SIGNATURE, sig_new_vid, &mut temp);
         }
         Payload::RelationshipCancel { reply } => {
             temp.extend(&XRFD);
@@ -446,8 +448,8 @@ pub fn decode_payload(mut stream: &mut [u8]) -> Result<DecodedPayload<'_>, Decod
             }
         }
         XRFI => {
-            let hop_list;
-            (hop_list, stream) = decode_hops(stream)?;
+            let request_digest;
+            (request_digest, stream) = decode_digest(stream)?;
 
             let nonce;
             (nonce, stream) =
@@ -460,59 +462,49 @@ pub fn decode_payload(mut stream: &mut [u8]) -> Result<DecodedPayload<'_>, Decod
             if new_vid.is_empty() {
                 Payload::DirectRelationProposal {
                     nonce: Nonce(*nonce),
-                    hops: hop_list,
+                    request_digest,
                 }
             } else {
-                let (thread_id, sig_thread_id);
-                (thread_id, stream) = decode_digest(stream)?;
-                (sig_thread_id, stream) = decode_fixed_data_mut::<64>(ED25519_SIGNATURE, stream)
+                let sig_new_vid;
+                (sig_new_vid, stream) = decode_fixed_data_mut::<64>(ED25519_SIGNATURE, stream)
                     .ok_or(DecodeError::UnexpectedData)?;
 
-                Payload::NewIdentifierProposal {
-                    thread_id,
-                    sig_thread_id,
+                Payload::ParallelRelationProposal {
+                    nonce: Nonce(*nonce),
+                    request_digest,
+                    sig_new_vid,
                     new_vid,
                 }
             }
         }
         XRFA => {
-            let reply;
-            (reply, stream) = decode_digest(stream)?;
+            let request_digest;
+            (request_digest, stream) = decode_digest(stream)?;
 
-            Payload::DirectRelationAffirm { reply }
-        }
-        XRNI => {
-            let data: &mut [u8];
-            (data, stream) = decode_variable_data_mut(TSP_PLAINTEXT, stream)
-                .ok_or(DecodeError::UnexpectedData)?;
+            let reply_digest;
+            (reply_digest, stream) = decode_digest(stream)?;
 
-            let nonce;
-            (nonce, stream) =
-                decode_fixed_data_mut(TSP_NONCE, stream).ok_or(DecodeError::UnexpectedData)?;
+            if stream.is_empty() {
+                Payload::DirectRelationAffirm {
+                    request_digest,
+                    reply_digest,
+                }
+            } else {
+                let new_vid: &[u8];
+                let sig_new_vid;
 
-            Payload::NestedRelationProposal {
-                message: data,
-                nonce: Nonce(*nonce),
+                (new_vid, stream) =
+                    decode_variable_data_mut(TSP_VID, stream).ok_or(DecodeError::UnexpectedData)?;
+                (sig_new_vid, stream) = decode_fixed_data_mut::<64>(ED25519_SIGNATURE, stream)
+                    .ok_or(DecodeError::UnexpectedData)?;
+
+                Payload::ParallelRelationAffirm {
+                    request_digest,
+                    reply_digest,
+                    sig_new_vid,
+                    new_vid,
+                }
             }
-        }
-        XRNA => {
-            let data: &mut [u8];
-            let reply;
-            (data, stream) = decode_variable_data_mut(TSP_PLAINTEXT, stream)
-                .ok_or(DecodeError::UnexpectedData)?;
-            (reply, stream) = decode_digest(stream)?;
-
-            Payload::NestedRelationAffirm {
-                message: data,
-                reply,
-            }
-        }
-        X3RR => {
-            let referred_vid: &[u8];
-            (referred_vid, stream) =
-                decode_variable_data_mut(TSP_VID, stream).ok_or(DecodeError::UnexpectedData)?;
-
-            Payload::RelationshipReferral { referred_vid }
         }
         XRFD => {
             let reply;
@@ -1451,18 +1443,22 @@ mod test {
     #[test]
     #[wasm_bindgen_test]
     fn test_par_refer_rel() {
-        test_turn_around(Payload::NewIdentifierProposal {
-            thread_id: Digest::Sha2_256(&Default::default()),
-            sig_thread_id: &[5; 64],
+        test_turn_around(Payload::ParallelRelationProposal {
+            nonce: Nonce([7; 32]),
+            request_digest: Digest::Sha2_256(&Default::default()),
+            sig_new_vid: &[5; 64],
             new_vid: b"Charlie",
         });
     }
 
     #[test]
     #[wasm_bindgen_test]
-    fn test_3p_refer_rel() {
-        test_turn_around(Payload::RelationshipReferral {
-            referred_vid: b"Charlie",
+    fn test_parallel_relation_accept_round_trip() {
+        test_turn_around(Payload::ParallelRelationAffirm {
+            request_digest: Digest::Sha2_256(&[3; 32]),
+            reply_digest: Digest::Blake2b256(&[4; 32]),
+            sig_new_vid: &[9; 64],
+            new_vid: b"Delta",
         });
     }
 
@@ -1516,27 +1512,16 @@ mod test {
         let nonce: &[u8; 32] = temp.as_slice().try_into().unwrap();
         test_turn_around(Payload::DirectRelationProposal {
             nonce: Nonce(*nonce),
-            hops: vec![],
+            request_digest: Digest::Sha2_256(nonce),
         });
         test_turn_around(Payload::DirectRelationAffirm {
-            reply: Digest::Sha2_256(nonce),
+            request_digest: Digest::Sha2_256(nonce),
+            reply_digest: Digest::Sha2_256(nonce),
         });
         test_turn_around(Payload::DirectRelationAffirm {
-            reply: Digest::Blake2b256(nonce),
+            request_digest: Digest::Blake2b256(nonce),
+            reply_digest: Digest::Blake2b256(nonce),
         });
-        test_turn_around(Payload::NestedRelationProposal {
-            message: &mut temp.clone(),
-            nonce: Nonce(*nonce),
-        });
-        test_turn_around(Payload::NestedRelationAffirm {
-            message: &mut temp.clone(),
-            reply: Digest::Sha2_256(nonce),
-        });
-        test_turn_around(Payload::NestedRelationAffirm {
-            message: &mut temp.clone(),
-            reply: Digest::Blake2b256(nonce),
-        });
-
         test_turn_around(Payload::RelationshipCancel {
             reply: Digest::Sha2_256(nonce),
         });

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -222,6 +222,82 @@ pub struct DecodedEnvelope<'a, Vid, Bytes> {
 
 type Signature = [u8];
 
+fn encoded_signature_from_raw<'a>(
+    signature: &'a Signature,
+) -> Result<EncodedSignature<'a>, EncodeError> {
+    if let Ok(signature) = <&[u8; 64]>::try_from(signature) {
+        return Ok(EncodedSignature::Ed25519(signature));
+    }
+
+    #[cfg(feature = "pq")]
+    if let Ok(signature) = <&[u8; 3309]>::try_from(signature) {
+        return Ok(EncodedSignature::MlDsa65(signature));
+    }
+
+    Err(EncodeError::InvalidSignatureType)
+}
+
+fn encode_embedded_signature(
+    signature: &Signature,
+    output: &mut impl for<'a> Extend<&'a u8>,
+) -> Result<(), EncodeError> {
+    encoded_signature_from_raw(signature)?.encode(output);
+    Ok(())
+}
+
+fn decoded_signature_from_stream(
+    stream: &mut [u8],
+) -> Result<(&Signature, &mut [u8]), DecodeError> {
+    let mut immutable_stream: &[u8] = stream;
+    let original_len = immutable_stream.len();
+    let signature_len = match EncodedSignature::decode(&mut immutable_stream)? {
+        EncodedSignature::NoSignature => return Err(DecodeError::InvalidSignatureType),
+        EncodedSignature::Ed25519(signature) => signature.len(),
+        #[cfg(feature = "pq")]
+        EncodedSignature::MlDsa65(signature) => signature.len(),
+    };
+
+    let consumed = original_len - immutable_stream.len();
+    let (prefix, remaining) = stream.split_at_mut(consumed);
+    let signature = &prefix[prefix.len() - signature_len..];
+
+    Ok((signature, remaining))
+}
+
+pub(crate) fn encode_parallel_relation_proposal_challenge(
+    sender_identity: Option<&[u8]>,
+    nonce: &Nonce,
+    request_digest: Digest<'_>,
+    new_vid: &[u8],
+) -> Result<Vec<u8>, EncodeError> {
+    let mut temp = Vec::new();
+    if let Some(sender_identity) = sender_identity {
+        checked_encode_variable_data(TSP_VID, sender_identity, &mut temp)?;
+    }
+    temp.extend(&XRFI);
+    encode_digest(&request_digest, &mut temp);
+    encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
+    checked_encode_variable_data(TSP_VID, new_vid, &mut temp)?;
+    Ok(temp)
+}
+
+pub(crate) fn encode_parallel_relation_affirm_challenge(
+    sender_identity: Option<&[u8]>,
+    request_digest: Digest<'_>,
+    reply_digest: Digest<'_>,
+    new_vid: &[u8],
+) -> Result<Vec<u8>, EncodeError> {
+    let mut temp = Vec::new();
+    if let Some(sender_identity) = sender_identity {
+        checked_encode_variable_data(TSP_VID, sender_identity, &mut temp)?;
+    }
+    temp.extend(&XRFA);
+    encode_digest(&request_digest, &mut temp);
+    encode_digest(&reply_digest, &mut temp);
+    checked_encode_variable_data(TSP_VID, new_vid, &mut temp)?;
+    Ok(temp)
+}
+
 /// Safely encode variable data, returning a soft error in case the size limit is exceeded
 fn checked_encode_variable_data(
     identifier: u32,
@@ -321,7 +397,7 @@ pub fn encode_payload(
             encode_digest(request_digest, &mut temp);
             encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
             checked_encode_variable_data(TSP_VID, new_vid.as_ref(), &mut temp)?;
-            encode_fixed_data(ED25519_SIGNATURE, sig_new_vid, &mut temp);
+            encode_embedded_signature(sig_new_vid, &mut temp)?;
         }
         Payload::ParallelRelationAffirm {
             request_digest,
@@ -336,7 +412,7 @@ pub fn encode_payload(
             encode_digest(request_digest, &mut temp);
             encode_digest(reply_digest, &mut temp);
             checked_encode_variable_data(TSP_VID, new_vid.as_ref(), &mut temp)?;
-            encode_fixed_data(ED25519_SIGNATURE, sig_new_vid, &mut temp);
+            encode_embedded_signature(sig_new_vid, &mut temp)?;
         }
         Payload::RelationshipCancel { reply } => {
             temp.extend(&XRFD);
@@ -466,8 +542,7 @@ pub fn decode_payload(mut stream: &mut [u8]) -> Result<DecodedPayload<'_>, Decod
                 }
             } else {
                 let sig_new_vid;
-                (sig_new_vid, stream) = decode_fixed_data_mut::<64>(ED25519_SIGNATURE, stream)
-                    .ok_or(DecodeError::UnexpectedData)?;
+                (sig_new_vid, stream) = decoded_signature_from_stream(stream)?;
 
                 Payload::ParallelRelationProposal {
                     nonce: Nonce(*nonce),
@@ -495,8 +570,7 @@ pub fn decode_payload(mut stream: &mut [u8]) -> Result<DecodedPayload<'_>, Decod
 
                 (new_vid, stream) =
                     decode_variable_data_mut(TSP_VID, stream).ok_or(DecodeError::UnexpectedData)?;
-                (sig_new_vid, stream) = decode_fixed_data_mut::<64>(ED25519_SIGNATURE, stream)
-                    .ok_or(DecodeError::UnexpectedData)?;
+                (sig_new_vid, stream) = decoded_signature_from_stream(stream)?;
 
                 Payload::ParallelRelationAffirm {
                     request_digest,

--- a/tsp_sdk/src/cesr/packet/fuzzing.rs
+++ b/tsp_sdk/src/cesr/packet/fuzzing.rs
@@ -23,10 +23,8 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
             RoutedMessage,
             DirectRelationProposal,
             DirectRelationAffirm,
-            NestedRelationProposal,
-            NestedRelationAffirm,
-            NewIdentifierProposal,
-            RelationshipReferral,
+            ParallelRelationProposal,
+            ParallelRelationAffirm,
             RelationshipCancel,
         }
 
@@ -38,10 +36,8 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
                 Payload::RoutedMessage(_, _) => Variants::RoutedMessage,
                 Payload::DirectRelationProposal { .. } => Variants::DirectRelationProposal,
                 Payload::DirectRelationAffirm { .. } => Variants::DirectRelationAffirm,
-                Payload::NestedRelationProposal { .. } => Variants::NestedRelationProposal,
-                Payload::NestedRelationAffirm { .. } => Variants::NestedRelationAffirm,
-                Payload::NewIdentifierProposal { .. } => Variants::NewIdentifierProposal,
-                Payload::RelationshipReferral { .. } => Variants::RelationshipReferral,
+                Payload::ParallelRelationProposal { .. } => Variants::ParallelRelationProposal,
+                Payload::ParallelRelationAffirm { .. } => Variants::ParallelRelationAffirm,
                 Payload::RelationshipCancel { .. } => Variants::RelationshipCancel,
             }
         }
@@ -63,26 +59,23 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
             }
             Variants::DirectRelationProposal => Payload::DirectRelationProposal {
                 nonce: Nonce(Arbitrary::arbitrary(u)?),
-                hops: Arbitrary::arbitrary(u)?,
+                request_digest: digest(&DIGEST),
             },
             Variants::DirectRelationAffirm => Payload::DirectRelationAffirm {
-                reply: digest(&DIGEST),
+                request_digest: digest(&DIGEST),
+                reply_digest: digest(&DIGEST),
             },
-            Variants::NestedRelationProposal => Payload::NestedRelationProposal {
+            Variants::ParallelRelationProposal => Payload::ParallelRelationProposal {
                 nonce: Nonce(Arbitrary::arbitrary(u)?),
-                message: Arbitrary::arbitrary(u)?,
-            },
-            Variants::NestedRelationAffirm => Payload::NestedRelationAffirm {
-                reply: digest(&DIGEST),
-                message: Arbitrary::arbitrary(u)?,
-            },
-            Variants::NewIdentifierProposal => Payload::NewIdentifierProposal {
-                thread_id: digest(&DIGEST),
+                request_digest: digest(&DIGEST),
                 new_vid: Arbitrary::arbitrary(u)?,
-                sig_thread_id: &[42; 64],
+                sig_new_vid: &[42; 64],
             },
-            Variants::RelationshipReferral => Payload::RelationshipReferral {
-                referred_vid: Arbitrary::arbitrary(u)?,
+            Variants::ParallelRelationAffirm => Payload::ParallelRelationAffirm {
+                request_digest: digest(&DIGEST),
+                reply_digest: digest(&DIGEST),
+                new_vid: Arbitrary::arbitrary(u)?,
+                sig_new_vid: &[24; 64],
             },
             Variants::RelationshipCancel => Payload::RelationshipCancel {
                 reply: digest(&DIGEST),
@@ -104,57 +97,51 @@ impl<'a> PartialEq<Payload<'a, &'a mut [u8], &'a [u8]>> for Wrapper {
             (
                 Payload::DirectRelationProposal {
                     nonce: l_nonce,
-                    hops: l_hops,
+                    request_digest: l_request_digest,
                 },
                 Payload::DirectRelationProposal {
                     nonce: r_nonce,
-                    hops: r_hops,
+                    request_digest: r_request_digest,
                 },
-            ) => l_nonce.0 == r_nonce.0 && l_hops == r_hops,
+            ) => l_nonce.0 == r_nonce.0 && l_request_digest == r_request_digest,
             (
-                Payload::DirectRelationAffirm { reply: l_reply },
-                Payload::DirectRelationAffirm { reply: r_reply },
-            ) => l_reply == r_reply,
+                Payload::DirectRelationAffirm {
+                    request_digest: l_request,
+                    reply_digest: l_reply,
+                },
+                Payload::DirectRelationAffirm {
+                    request_digest: r_request,
+                    reply_digest: r_reply,
+                },
+            ) => l_request == r_request && l_reply == r_reply,
             (
-                Payload::NestedRelationProposal {
-                    message: l_msg,
+                Payload::ParallelRelationProposal {
+                    new_vid: l_vid,
+                    request_digest: l_request,
+                    sig_new_vid: _l_sig,
                     nonce: l_nonce,
                 },
-                Payload::NestedRelationProposal {
-                    message: r_msg,
+                Payload::ParallelRelationProposal {
+                    new_vid: r_vid,
+                    request_digest: r_request,
+                    sig_new_vid: _r_sig,
                     nonce: r_nonce,
                 },
-            ) => l_nonce.0 == r_nonce.0 && l_msg == r_msg,
+            ) => l_vid == r_vid && l_request == r_request && l_nonce == r_nonce,
             (
-                Payload::NestedRelationAffirm {
-                    reply: l_reply,
-                    message: l_msg,
-                },
-                Payload::NestedRelationAffirm {
-                    reply: r_reply,
-                    message: r_msg,
-                },
-            ) => l_reply == r_reply && l_msg == r_msg,
-            (
-                Payload::NewIdentifierProposal {
+                Payload::ParallelRelationAffirm {
+                    request_digest: l_request,
+                    reply_digest: l_reply,
                     new_vid: l_vid,
-                    thread_id: l_reply,
-                    sig_thread_id: _l_sig,
+                    sig_new_vid: _l_sig,
                 },
-                Payload::NewIdentifierProposal {
+                Payload::ParallelRelationAffirm {
+                    request_digest: r_request,
+                    reply_digest: r_reply,
                     new_vid: r_vid,
-                    thread_id: r_reply,
-                    sig_thread_id: _r_sig,
+                    sig_new_vid: _r_sig,
                 },
-            ) => l_vid == r_vid && l_reply == r_reply,
-            (
-                Payload::RelationshipReferral {
-                    referred_vid: l_vid,
-                },
-                Payload::RelationshipReferral {
-                    referred_vid: r_vid,
-                },
-            ) => l_vid == r_vid,
+            ) => l_request == r_request && l_reply == r_reply && l_vid == r_vid,
             (
                 Payload::RelationshipCancel { reply: l_reply },
                 Payload::RelationshipCancel { reply: r_reply },

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -5,6 +5,7 @@ use crate::definitions::{
     PrivateVid, PublicKeyData, PublicVerificationKeyData, RelationshipForm, TSPMessage,
     VerifiedVid,
 };
+use ed25519_dalek::Signer;
 #[cfg(not(feature = "pq"))]
 use hpke::kem;
 #[cfg(feature = "pq")]
@@ -27,6 +28,12 @@ use crate::crypto::CryptoError::Verify;
 pub use error::CryptoError;
 
 type CesrRelationshipPayload<'a> = crate::cesr::Payload<'a, &'a [u8], &'a [u8]>;
+
+pub(crate) struct ParallelSignatureInfo<'a> {
+    pub new_vid: &'a [u8],
+    pub sig_new_vid: &'a [u8],
+    pub signed_data: Vec<u8>,
+}
 
 // Which digest algorithm is active depends on the crypto backend feature set.
 #[allow(dead_code)]
@@ -60,6 +67,53 @@ fn encode_hashed_payload(
     let mut encoded = Vec::with_capacity(payload.calculate_size(sender_in_payload));
     crate::cesr::encode_payload(payload, sender_in_payload, &mut encoded)?;
     Ok(algorithm.hash(&encoded))
+}
+
+pub(crate) fn build_parallel_request_signed_data(
+    sender_in_payload: Option<&[u8]>,
+    digest_algorithm: RelationshipDigestAlgorithm,
+    nonce_bytes: [u8; 32],
+    request_digest: &mut Digest,
+    new_vid: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let nonce = crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes);
+    let mut signed_data = crate::cesr::encode_parallel_relation_proposal_challenge(
+        sender_in_payload,
+        &nonce,
+        digest_algorithm.field(request_digest),
+        new_vid,
+    )?;
+    *request_digest = digest_algorithm.hash(&signed_data);
+    signed_data = crate::cesr::encode_parallel_relation_proposal_challenge(
+        sender_in_payload,
+        &nonce,
+        digest_algorithm.field(request_digest),
+        new_vid,
+    )?;
+    Ok(signed_data)
+}
+
+pub(crate) fn build_parallel_accept_signed_data(
+    thread_id: &Digest,
+    sender_in_payload: Option<&[u8]>,
+    digest_algorithm: RelationshipDigestAlgorithm,
+    reply_digest: &mut Digest,
+    new_vid: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let mut signed_data = crate::cesr::encode_parallel_relation_affirm_challenge(
+        sender_in_payload,
+        digest_algorithm.field(thread_id),
+        digest_algorithm.field(reply_digest),
+        new_vid,
+    )?;
+    *reply_digest = digest_algorithm.hash(&signed_data);
+    signed_data = crate::cesr::encode_parallel_relation_affirm_challenge(
+        sender_in_payload,
+        digest_algorithm.field(thread_id),
+        digest_algorithm.field(reply_digest),
+        new_vid,
+    )?;
+    Ok(signed_data)
 }
 
 fn relationship_request_payload<'a>(
@@ -115,17 +169,40 @@ pub(crate) fn build_relationship_request_payload<'a>(
     nonce_bytes: [u8; 32],
     request_digest: &'a mut Digest,
 ) -> Result<(CesrRelationshipPayload<'a>, Digest), CryptoError> {
-    let placeholder_payload =
-        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest);
-    *request_digest =
-        encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
+    match form {
+        RelationshipForm::Direct => {
+            let placeholder_payload =
+                relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest);
+            *request_digest =
+                encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
 
-    let digest = *request_digest;
+            let digest = *request_digest;
 
-    Ok((
-        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
-        digest,
-    ))
+            Ok((
+                relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
+                digest,
+            ))
+        }
+        RelationshipForm::Parallel {
+            new_vid,
+            sig_new_vid: _,
+        } => {
+            build_parallel_request_signed_data(
+                sender_in_payload,
+                digest_algorithm,
+                nonce_bytes,
+                request_digest,
+                new_vid,
+            )?;
+
+            let digest = *request_digest;
+
+            Ok((
+                relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
+                digest,
+            ))
+        }
+    }
 }
 
 pub(crate) fn build_relationship_accept_payload<'a>(
@@ -135,17 +212,40 @@ pub(crate) fn build_relationship_accept_payload<'a>(
     digest_algorithm: RelationshipDigestAlgorithm,
     reply_digest: &'a mut Digest,
 ) -> Result<(CesrRelationshipPayload<'a>, Digest), CryptoError> {
-    let placeholder_payload =
-        relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest);
-    *reply_digest =
-        encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
+    match form {
+        RelationshipForm::Direct => {
+            let placeholder_payload =
+                relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest);
+            *reply_digest =
+                encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
 
-    let digest = *reply_digest;
+            let digest = *reply_digest;
 
-    Ok((
-        relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest),
-        digest,
-    ))
+            Ok((
+                relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest),
+                digest,
+            ))
+        }
+        RelationshipForm::Parallel {
+            new_vid,
+            sig_new_vid: _,
+        } => {
+            build_parallel_accept_signed_data(
+                thread_id,
+                sender_in_payload,
+                digest_algorithm,
+                reply_digest,
+                new_vid,
+            )?;
+
+            let digest = *reply_digest;
+
+            Ok((
+                relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest),
+                digest,
+            ))
+        }
+    }
 }
 
 pub(crate) fn open_relationship_request<'a>(
@@ -165,6 +265,57 @@ pub(crate) fn open_relationship_accept<'a>(
         reply_thread_id,
         form,
     }
+}
+
+pub(crate) fn sign_detached(sender: &dyn PrivateVid, data: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    Ok(match sender.signature_key_type() {
+        crate::definitions::VidSignatureKeyType::Ed25519 => {
+            let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
+                sender.signing_key().as_slice(),
+            )?);
+            sign_key.sign(data).to_bytes().to_vec()
+        }
+        #[cfg(feature = "pq")]
+        crate::definitions::VidSignatureKeyType::MlDsa65 => {
+            use ml_dsa::EncodedSigningKey;
+            let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
+                &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
+            );
+            sign_key.sign(data).encode().to_vec()
+        }
+    })
+}
+
+pub(crate) fn verify_detached(
+    sender: &dyn VerifiedVid,
+    signed_data: &[u8],
+    signature: &[u8],
+) -> Result<(), CryptoError> {
+    match sender.signature_key_type() {
+        crate::definitions::VidSignatureKeyType::Ed25519 => {
+            let signature = ed25519_dalek::Signature::from_slice(signature)
+                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+            let verifying_key =
+                ed25519_dalek::VerifyingKey::try_from(sender.verifying_key().as_slice())
+                    .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+            verifying_key
+                .verify_strict(signed_data, &signature)
+                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+        }
+        #[cfg(feature = "pq")]
+        crate::definitions::VidSignatureKeyType::MlDsa65 => {
+            let signature: ml_dsa::Signature<MlDsa65> = ml_dsa::Signature::try_from(signature)
+                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+            let verifying_key = ml_dsa::VerifyingKey::decode(
+                &EncodedVerifyingKey::<MlDsa65>::try_from(sender.verifying_key().as_slice())?,
+            );
+            verifying_key
+                .verify(signed_data, &signature)
+                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(not(feature = "pq"))]
@@ -203,6 +354,24 @@ pub fn seal_and_hash(
     payload: Payload<&[u8]>,
     digest: Option<&mut Digest>,
 ) -> Result<TSPMessage, CryptoError> {
+    seal_and_hash_with_relationship_nonce(
+        sender,
+        receiver,
+        nonconfidential_data,
+        payload,
+        digest,
+        None,
+    )
+}
+
+pub(crate) fn seal_and_hash_with_relationship_nonce(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    nonconfidential_data: Option<NonConfidentialData>,
+    payload: Payload<&[u8]>,
+    digest: Option<&mut Digest>,
+    request_nonce_override: Option<[u8; 32]>,
+) -> Result<TSPMessage, CryptoError> {
     #[cfg(not(feature = "nacl"))]
     let msg = match receiver.encryption_key_type() {
         VidEncryptionKeyType::X25519 => tsp_hpke::seal::<Aead, Kdf, kem::X25519HkdfSha256>(
@@ -211,6 +380,7 @@ pub fn seal_and_hash(
             nonconfidential_data,
             payload,
             digest,
+            request_nonce_override,
         ),
         #[cfg(feature = "pq")]
         VidEncryptionKeyType::X25519Kyber768Draft00 => {
@@ -220,12 +390,20 @@ pub fn seal_and_hash(
                 nonconfidential_data,
                 payload,
                 digest,
+                request_nonce_override,
             )
         }
     }?;
 
     #[cfg(feature = "nacl")]
-    let msg = tsp_nacl::seal(sender, receiver, nonconfidential_data, payload, digest)?;
+    let msg = tsp_nacl::seal(
+        sender,
+        receiver,
+        nonconfidential_data,
+        payload,
+        digest,
+        request_nonce_override,
+    )?;
 
     Ok(msg)
 }
@@ -243,34 +421,25 @@ pub fn open<'a>(
     sender: &dyn VerifiedVid,
     tsp_message: &'a mut [u8],
 ) -> Result<MessageContents<'a>, CryptoError> {
+    open_with_signature_info(receiver, sender, tsp_message)
+        .map(|(message_contents, _parallel_signature_info)| message_contents)
+}
+
+pub(crate) fn open_with_signature_info<'a>(
+    receiver: &dyn PrivateVid,
+    sender: &dyn VerifiedVid,
+    tsp_message: &'a mut [u8],
+) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     let view = crate::cesr::decode_envelope(tsp_message)?;
 
     // verify outer signature
     let verification_challenge = view.as_challenge();
-    match view.signature_type() {
-        SignatureType::NoSignature => {}
-        SignatureType::Ed25519 => {
-            let signature = ed25519_dalek::Signature::from_slice(verification_challenge.signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
-            let verifying_key =
-                ed25519_dalek::VerifyingKey::try_from(sender.verifying_key().as_slice())
-                    .map_err(|err| Verify(sender.identifier().to_string(), err))?;
-            verifying_key
-                .verify_strict(verification_challenge.signed_data, &signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
-        }
-        #[cfg(feature = "pq")]
-        SignatureType::MlDsa65 => {
-            let signature: ml_dsa::Signature<MlDsa65> =
-                ml_dsa::Signature::try_from(verification_challenge.signature)
-                    .map_err(|err| Verify(sender.identifier().to_string(), err))?;
-            let verifying_key = ml_dsa::VerifyingKey::decode(
-                &EncodedVerifyingKey::<MlDsa65>::try_from(sender.verifying_key().as_slice())?,
-            );
-            verifying_key
-                .verify(verification_challenge.signed_data, &signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
-        }
+    if !matches!(view.signature_type(), SignatureType::NoSignature) {
+        verify_detached(
+            sender,
+            verification_challenge.signed_data,
+            verification_challenge.signature,
+        )?;
     }
 
     // decode envelope

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -2,7 +2,8 @@
 use crate::definitions::VidEncryptionKeyType;
 use crate::definitions::{
     Digest, MessageType, NonConfidentialData, Payload, PrivateKeyData, PrivateSigningKeyData,
-    PrivateVid, PublicKeyData, PublicVerificationKeyData, TSPMessage, VerifiedVid,
+    PrivateVid, PublicKeyData, PublicVerificationKeyData, RelationshipForm, TSPMessage,
+    VerifiedVid,
 };
 #[cfg(not(feature = "pq"))]
 use hpke::kem;
@@ -24,6 +25,147 @@ mod tsp_nacl;
 use crate::cesr::{CryptoType, SignatureType};
 use crate::crypto::CryptoError::Verify;
 pub use error::CryptoError;
+
+type CesrRelationshipPayload<'a> = crate::cesr::Payload<'a, &'a [u8], &'a [u8]>;
+
+// Which digest algorithm is active depends on the crypto backend feature set.
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub(crate) enum RelationshipDigestAlgorithm {
+    Sha2_256,
+    Blake2b256,
+}
+
+impl RelationshipDigestAlgorithm {
+    fn field<'a>(self, digest: &'a Digest) -> crate::cesr::Digest<'a> {
+        match self {
+            RelationshipDigestAlgorithm::Sha2_256 => crate::cesr::Digest::Sha2_256(digest),
+            RelationshipDigestAlgorithm::Blake2b256 => crate::cesr::Digest::Blake2b256(digest),
+        }
+    }
+
+    fn hash(self, bytes: &[u8]) -> Digest {
+        match self {
+            RelationshipDigestAlgorithm::Sha2_256 => sha256(bytes),
+            RelationshipDigestAlgorithm::Blake2b256 => blake2b256(bytes),
+        }
+    }
+}
+
+fn encode_hashed_payload(
+    payload: &CesrRelationshipPayload<'_>,
+    sender_in_payload: Option<&[u8]>,
+    algorithm: RelationshipDigestAlgorithm,
+) -> Result<Digest, CryptoError> {
+    let mut encoded = Vec::with_capacity(payload.calculate_size(sender_in_payload));
+    crate::cesr::encode_payload(payload, sender_in_payload, &mut encoded)?;
+    Ok(algorithm.hash(&encoded))
+}
+
+fn relationship_request_payload<'a>(
+    form: &RelationshipForm<'a, &'a [u8]>,
+    digest_algorithm: RelationshipDigestAlgorithm,
+    nonce_bytes: [u8; 32],
+    request_digest: &'a Digest,
+) -> CesrRelationshipPayload<'a> {
+    match form {
+        RelationshipForm::Direct => crate::cesr::Payload::DirectRelationProposal {
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            request_digest: digest_algorithm.field(request_digest),
+        },
+        RelationshipForm::Parallel {
+            new_vid,
+            sig_new_vid,
+        } => crate::cesr::Payload::ParallelRelationProposal {
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            request_digest: digest_algorithm.field(request_digest),
+            sig_new_vid,
+            new_vid,
+        },
+    }
+}
+
+fn relationship_accept_payload<'a>(
+    thread_id: &'a Digest,
+    form: &RelationshipForm<'a, &'a [u8]>,
+    digest_algorithm: RelationshipDigestAlgorithm,
+    reply_digest: &'a Digest,
+) -> CesrRelationshipPayload<'a> {
+    match form {
+        RelationshipForm::Direct => crate::cesr::Payload::DirectRelationAffirm {
+            request_digest: digest_algorithm.field(thread_id),
+            reply_digest: digest_algorithm.field(reply_digest),
+        },
+        RelationshipForm::Parallel {
+            new_vid,
+            sig_new_vid,
+        } => crate::cesr::Payload::ParallelRelationAffirm {
+            request_digest: digest_algorithm.field(thread_id),
+            reply_digest: digest_algorithm.field(reply_digest),
+            sig_new_vid,
+            new_vid,
+        },
+    }
+}
+
+pub(crate) fn build_relationship_request_payload<'a>(
+    form: &RelationshipForm<'a, &'a [u8]>,
+    sender_in_payload: Option<&[u8]>,
+    digest_algorithm: RelationshipDigestAlgorithm,
+    nonce_bytes: [u8; 32],
+    request_digest: &'a mut Digest,
+) -> Result<(CesrRelationshipPayload<'a>, Digest), CryptoError> {
+    let placeholder_payload =
+        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest);
+    *request_digest =
+        encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
+
+    let digest = *request_digest;
+
+    Ok((
+        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
+        digest,
+    ))
+}
+
+pub(crate) fn build_relationship_accept_payload<'a>(
+    thread_id: &'a Digest,
+    form: &RelationshipForm<'a, &'a [u8]>,
+    sender_in_payload: Option<&[u8]>,
+    digest_algorithm: RelationshipDigestAlgorithm,
+    reply_digest: &'a mut Digest,
+) -> Result<(CesrRelationshipPayload<'a>, Digest), CryptoError> {
+    let placeholder_payload =
+        relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest);
+    *reply_digest =
+        encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
+
+    let digest = *reply_digest;
+
+    Ok((
+        relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest),
+        digest,
+    ))
+}
+
+pub(crate) fn open_relationship_request<'a>(
+    thread_id: Digest,
+    form: RelationshipForm<'a, &'a [u8]>,
+) -> Payload<'a, &'a [u8], &'a mut [u8]> {
+    Payload::RequestRelationship { thread_id, form }
+}
+
+pub(crate) fn open_relationship_accept<'a>(
+    thread_id: Digest,
+    reply_thread_id: Digest,
+    form: RelationshipForm<'a, &'a [u8]>,
+) -> Payload<'a, &'a [u8], &'a mut [u8]> {
+    Payload::AcceptRelationship {
+        thread_id,
+        reply_thread_id,
+        form,
+    }
+}
 
 #[cfg(not(feature = "pq"))]
 pub type Aead = hpke::aead::ChaCha20Poly1305;

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -22,7 +22,10 @@ use hpke::{
 #[cfg(all(not(feature = "nacl"), not(feature = "pq")))]
 use hpke::{OpModeS, single_shot_seal_in_place_detached};
 
-use super::{CryptoError, MessageContents, open_relationship_accept, open_relationship_request};
+use super::{
+    CryptoError, MessageContents, ParallelSignatureInfo, open_relationship_accept,
+    open_relationship_request,
+};
 #[cfg(not(feature = "nacl"))]
 use super::{
     RelationshipDigestAlgorithm, build_relationship_accept_payload,
@@ -43,6 +46,7 @@ pub(crate) fn seal<A, Kdf, Kem>(
     nonconfidential_data: Option<NonConfidentialData>,
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
+    request_nonce_override: Option<[u8; 32]>,
 ) -> Result<TSPMessage, CryptoError>
 where
     A: aead::Aead,
@@ -84,8 +88,11 @@ where
             thread_id: _ignored,
             form,
         } => {
-            let mut nonce_bytes = [0_u8; 32];
-            csprng.fill_bytes(&mut nonce_bytes);
+            let nonce_bytes = request_nonce_override.unwrap_or_else(|| {
+                let mut nonce_bytes = [0_u8; 32];
+                csprng.fill_bytes(&mut nonce_bytes);
+                nonce_bytes
+            });
 
             let (payload, payload_digest) = build_relationship_request_payload(
                 &form,
@@ -196,7 +203,7 @@ pub(crate) fn open<'a, A, Kdf, Kem>(
     raw_header: &'a [u8],
     envelope: Envelope<'a, &[u8]>,
     ciphertext: &'a mut [u8],
-) -> Result<MessageContents<'a>, CryptoError>
+) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError>
 where
     A: aead::Aead,
     Kdf: kdf::Kdf,
@@ -251,58 +258,95 @@ where
         }
     }
 
-    let secret_payload = match payload {
-        crate::cesr::Payload::GenericMessage(data) => Payload::Content(data as _),
-        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => {
+    let (secret_payload, parallel_signature_info) = match payload {
+        crate::cesr::Payload::GenericMessage(data) => (Payload::Content(data as _), None),
+        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => (
             open_relationship_request(
                 *request_digest.as_bytes(),
                 crate::definitions::RelationshipForm::Direct,
-            )
-        }
+            ),
+            None,
+        ),
         crate::cesr::Payload::DirectRelationAffirm {
             request_digest,
             reply_digest,
-        } => open_relationship_accept(
-            *request_digest.as_bytes(),
-            *reply_digest.as_bytes(),
-            crate::definitions::RelationshipForm::Direct,
+        } => (
+            open_relationship_accept(
+                *request_digest.as_bytes(),
+                *reply_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Direct,
+            ),
+            None,
         ),
-        crate::cesr::Payload::RelationshipCancel { reply, .. } => Payload::CancelRelationship {
-            thread_id: *reply.as_bytes(),
-        },
-        crate::cesr::Payload::NestedMessage(data) => Payload::NestedMessage(data),
-        crate::cesr::Payload::RoutedMessage(hops, data) => Payload::RoutedMessage(hops, data as _),
+        crate::cesr::Payload::RelationshipCancel { reply, .. } => (
+            Payload::CancelRelationship {
+                thread_id: *reply.as_bytes(),
+            },
+            None,
+        ),
+        crate::cesr::Payload::NestedMessage(data) => (Payload::NestedMessage(data), None),
+        crate::cesr::Payload::RoutedMessage(hops, data) => {
+            (Payload::RoutedMessage(hops, data as _), None)
+        }
         crate::cesr::Payload::ParallelRelationProposal {
+            nonce,
             request_digest,
             sig_new_vid,
             new_vid,
             ..
-        } => open_relationship_request(
-            *request_digest.as_bytes(),
-            crate::definitions::RelationshipForm::Parallel {
+        } => (
+            open_relationship_request(
+                *request_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Parallel {
+                    new_vid,
+                    sig_new_vid,
+                },
+            ),
+            Some(ParallelSignatureInfo {
                 new_vid,
                 sig_new_vid,
-            },
+                signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
+                    sender_identity,
+                    &nonce,
+                    request_digest,
+                    new_vid,
+                )?,
+            }),
         ),
         crate::cesr::Payload::ParallelRelationAffirm {
             request_digest,
             reply_digest,
             sig_new_vid,
             new_vid,
-        } => open_relationship_accept(
-            *request_digest.as_bytes(),
-            *reply_digest.as_bytes(),
-            crate::definitions::RelationshipForm::Parallel {
+        } => (
+            open_relationship_accept(
+                *request_digest.as_bytes(),
+                *reply_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Parallel {
+                    new_vid,
+                    sig_new_vid,
+                },
+            ),
+            Some(ParallelSignatureInfo {
                 new_vid,
                 sig_new_vid,
-            },
+                signed_data: crate::cesr::encode_parallel_relation_affirm_challenge(
+                    sender_identity,
+                    request_digest,
+                    reply_digest,
+                    new_vid,
+                )?,
+            }),
         ),
     };
 
     Ok((
-        envelope.nonconfidential_data,
-        secret_payload,
-        envelope.crypto_type,
-        envelope.signature_type,
+        (
+            envelope.nonconfidential_data,
+            secret_payload,
+            envelope.crypto_type,
+            envelope.signature_type,
+        ),
+        parallel_signature_info,
     ))
 }

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -12,7 +12,7 @@ use crate::{
 #[cfg(not(feature = "nacl"))]
 use ed25519_dalek::Signer;
 #[cfg(not(feature = "nacl"))]
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 #[cfg(not(feature = "pq"))]
 use hpke::{
@@ -22,7 +22,12 @@ use hpke::{
 #[cfg(all(not(feature = "nacl"), not(feature = "pq")))]
 use hpke::{OpModeS, single_shot_seal_in_place_detached};
 
-use super::{CryptoError, MessageContents};
+use super::{CryptoError, MessageContents, open_relationship_accept, open_relationship_request};
+#[cfg(not(feature = "nacl"))]
+use super::{
+    RelationshipDigestAlgorithm, build_relationship_accept_payload,
+    build_relationship_request_payload,
+};
 #[cfg(feature = "pq")]
 use hpke_pq::{
     Deserializable, OpModeR, OpModeS, Serializable, aead, kdf, kem,
@@ -67,58 +72,52 @@ where
         &mut data,
     )?;
 
+    let sender_in_payload = Some(sender.identifier().as_bytes());
+
+    let mut request_digest_storage = [0_u8; 32];
+    let mut reply_digest_storage = [0_u8; 32];
+    let mut payload_digest_override = None;
+
     let secret_payload = match secret_payload {
         Payload::Content(data) => crate::cesr::Payload::GenericMessage(data),
         Payload::RequestRelationship {
-            route,
             thread_id: _ignored,
-        } => crate::cesr::Payload::DirectRelationProposal {
-            nonce: fresh_nonce(&mut csprng),
-            hops: route.unwrap_or_else(Vec::new),
-        },
-        Payload::AcceptRelationship { ref thread_id } => {
-            crate::cesr::Payload::DirectRelationAffirm {
-                reply: crate::cesr::Digest::Sha2_256(thread_id),
-            }
+            form,
+        } => {
+            let mut nonce_bytes = [0_u8; 32];
+            csprng.fill_bytes(&mut nonce_bytes);
+
+            let (payload, payload_digest) = build_relationship_request_payload(
+                &form,
+                sender_in_payload,
+                RelationshipDigestAlgorithm::Sha2_256,
+                nonce_bytes,
+                &mut request_digest_storage,
+            )?;
+            payload_digest_override = Some(payload_digest);
+            payload
         }
-        Payload::RequestNestedRelationship {
-            inner,
-            thread_id: _ignored,
-        } => crate::cesr::Payload::NestedRelationProposal {
-            nonce: fresh_nonce(&mut csprng),
-            message: inner,
-        },
-        Payload::AcceptNestedRelationship {
+        Payload::AcceptRelationship {
             ref thread_id,
-            inner,
-        } => crate::cesr::Payload::NestedRelationAffirm {
-            reply: crate::cesr::Digest::Sha2_256(thread_id),
-            message: inner,
-        },
+            reply_thread_id: _ignored,
+            form,
+        } => {
+            let (payload, payload_digest) = build_relationship_accept_payload(
+                thread_id,
+                &form,
+                sender_in_payload,
+                RelationshipDigestAlgorithm::Sha2_256,
+                &mut reply_digest_storage,
+            )?;
+            payload_digest_override = Some(payload_digest);
+            payload
+        }
         Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
             reply: crate::cesr::Digest::Sha2_256(thread_id),
         },
         Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(data),
         Payload::RoutedMessage(hops, data) => crate::cesr::Payload::RoutedMessage(hops, data),
-        Payload::NewIdentifier {
-            ref thread_id,
-            new_vid,
-        } => crate::cesr::Payload::NewIdentifierProposal {
-            //TODO: we need to produce a signature here with `new_vid`, but we don't have the PrivateVid for it at this point and that
-            //cannot be done without changing the "upper" API.
-            thread_id: crate::cesr::Digest::Sha2_256(thread_id),
-            sig_thread_id: &[0; 64],
-            new_vid,
-        },
-        Payload::Referral { referred_vid } => {
-            crate::cesr::Payload::RelationshipReferral { referred_vid }
-        }
     };
-
-    #[cfg(feature = "essr")]
-    let sender_in_payload = Some(sender.identifier().as_bytes());
-    #[cfg(not(feature = "essr"))]
-    let sender_in_payload = None;
 
     // prepare CESR-encoded ciphertext
     let mut cesr_message = Vec::with_capacity(
@@ -149,7 +148,7 @@ where
 
     // hash the raw bytes of the plaintext before encryption
     if let Some(digest) = digest {
-        *digest = crate::crypto::sha256(&cesr_message)
+        *digest = payload_digest_override.unwrap_or_else(|| crate::crypto::sha256(&cesr_message));
     }
 
     // perform encryption
@@ -235,14 +234,6 @@ where
         &tag,
     )?;
 
-    // micro-optimization: only compute the thread_id digest if we really need it; we cannot do this
-    // later since after constructing the resulting Payload, we are giving out mutable borrows
-    let thread_id = match crate::cesr::decode_payload(ciphertext)?.payload {
-        crate::cesr::Payload::DirectRelationProposal { .. }
-        | crate::cesr::Payload::NestedRelationProposal { .. } => crate::crypto::sha256(ciphertext),
-        _ => Default::default(),
-    };
-
     #[allow(unused_variables)]
     let DecodedPayload {
         payload,
@@ -262,40 +253,50 @@ where
 
     let secret_payload = match payload {
         crate::cesr::Payload::GenericMessage(data) => Payload::Content(data as _),
-        crate::cesr::Payload::DirectRelationProposal { hops, .. } => Payload::RequestRelationship {
-            route: if hops.is_empty() { None } else { Some(hops) },
-            thread_id,
-        },
-        crate::cesr::Payload::DirectRelationAffirm { reply } => Payload::AcceptRelationship {
-            thread_id: *reply.as_bytes(),
-        },
-        crate::cesr::Payload::NestedRelationProposal { message: inner, .. } => {
-            Payload::RequestNestedRelationship { inner, thread_id }
+        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => {
+            open_relationship_request(
+                *request_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Direct,
+            )
         }
-        crate::cesr::Payload::NestedRelationAffirm { message, reply } => {
-            Payload::AcceptNestedRelationship {
-                inner: message,
-                thread_id: *reply.as_bytes(),
-            }
-        }
+        crate::cesr::Payload::DirectRelationAffirm {
+            request_digest,
+            reply_digest,
+        } => open_relationship_accept(
+            *request_digest.as_bytes(),
+            *reply_digest.as_bytes(),
+            crate::definitions::RelationshipForm::Direct,
+        ),
         crate::cesr::Payload::RelationshipCancel { reply, .. } => Payload::CancelRelationship {
             thread_id: *reply.as_bytes(),
         },
         crate::cesr::Payload::NestedMessage(data) => Payload::NestedMessage(data),
         crate::cesr::Payload::RoutedMessage(hops, data) => Payload::RoutedMessage(hops, data as _),
-        crate::cesr::Payload::NewIdentifierProposal {
-            thread_id,
-            sig_thread_id: _,
+        crate::cesr::Payload::ParallelRelationProposal {
+            request_digest,
+            sig_new_vid,
             new_vid,
-        } => Payload::NewIdentifier {
-            //TODO: the 'sig_thread_id' verification cannot happen at this point, and needs to be bubbled upward
-            //so it can be checked *after* the VID has been verified and key material retrieved.
-            thread_id: *thread_id.as_bytes(),
+            ..
+        } => open_relationship_request(
+            *request_digest.as_bytes(),
+            crate::definitions::RelationshipForm::Parallel {
+                new_vid,
+                sig_new_vid,
+            },
+        ),
+        crate::cesr::Payload::ParallelRelationAffirm {
+            request_digest,
+            reply_digest,
+            sig_new_vid,
             new_vid,
-        },
-        crate::cesr::Payload::RelationshipReferral { referred_vid } => {
-            Payload::Referral { referred_vid }
-        }
+        } => open_relationship_accept(
+            *request_digest.as_bytes(),
+            *reply_digest.as_bytes(),
+            crate::definitions::RelationshipForm::Parallel {
+                new_vid,
+                sig_new_vid,
+            },
+        ),
     };
 
     Ok((
@@ -304,10 +305,4 @@ where
         envelope.crypto_type,
         envelope.signature_type,
     ))
-}
-
-/// Generate N random bytes using the provided RNG
-#[cfg(not(feature = "nacl"))]
-fn fresh_nonce(csprng: &mut (impl rand::RngCore + rand::CryptoRng)) -> crate::cesr::Nonce {
-    crate::cesr::Nonce::generate(|dst| csprng.fill_bytes(dst))
 }

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -4,9 +4,11 @@ use crate::{
 };
 use crypto_box::{ChaChaBox, PublicKey, SecretKey, aead::AeadInPlace};
 
+use super::{CryptoError, MessageContents, open_relationship_accept, open_relationship_request};
+#[cfg(feature = "nacl")]
 use super::{
-    CryptoError, MessageContents, RelationshipDigestAlgorithm, build_relationship_accept_payload,
-    build_relationship_request_payload, open_relationship_accept, open_relationship_request,
+    RelationshipDigestAlgorithm, build_relationship_accept_payload,
+    build_relationship_request_payload,
 };
 #[cfg(feature = "nacl")]
 use crate::{

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 use crypto_box::{ChaChaBox, PublicKey, SecretKey, aead::AeadInPlace};
 
-use super::{CryptoError, MessageContents};
+use super::{
+    CryptoError, MessageContents, RelationshipDigestAlgorithm, build_relationship_accept_payload,
+    build_relationship_request_payload, open_relationship_accept, open_relationship_request,
+};
 #[cfg(feature = "nacl")]
 use crate::{
     cesr::SignatureType,
@@ -17,7 +20,7 @@ use ed25519_dalek::Signer;
 #[cfg(all(feature = "pq", feature = "nacl"))]
 use ml_dsa::{EncodedSigningKey, MlDsa65};
 #[cfg(feature = "nacl")]
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 #[cfg(feature = "nacl")]
 pub(crate) fn seal(
@@ -44,46 +47,45 @@ pub(crate) fn seal(
         &mut data,
     )?;
 
+    let sender_in_payload = Some(sender.identifier().as_bytes());
+
+    let mut request_digest_storage = [0_u8; 32];
+    let mut reply_digest_storage = [0_u8; 32];
+    let mut payload_digest_override = None;
+
     let secret_payload = match secret_payload {
         Payload::Content(data) => crate::cesr::Payload::GenericMessage(data),
         Payload::RequestRelationship {
-            route,
             thread_id: _ignored,
-        } => crate::cesr::Payload::DirectRelationProposal {
-            nonce: fresh_nonce(&mut csprng),
-            hops: route.unwrap_or_else(Vec::new),
-        },
-        Payload::AcceptRelationship { ref thread_id } => {
-            crate::cesr::Payload::DirectRelationAffirm {
-                reply: crate::cesr::Digest::Blake2b256(thread_id),
-            }
+            form,
+        } => {
+            let mut nonce_bytes = [0_u8; 32];
+            csprng.fill_bytes(&mut nonce_bytes);
+
+            let (payload, payload_digest) = build_relationship_request_payload(
+                &form,
+                sender_in_payload,
+                RelationshipDigestAlgorithm::Blake2b256,
+                nonce_bytes,
+                &mut request_digest_storage,
+            )?;
+            payload_digest_override = Some(payload_digest);
+            payload
         }
-        Payload::RequestNestedRelationship {
-            inner,
-            thread_id: _ignored,
-        } => crate::cesr::Payload::NestedRelationProposal {
-            nonce: fresh_nonce(&mut csprng),
-            message: inner,
-        },
-        Payload::AcceptNestedRelationship {
+        Payload::AcceptRelationship {
             ref thread_id,
-            inner,
-        } => crate::cesr::Payload::NestedRelationAffirm {
-            reply: crate::cesr::Digest::Blake2b256(thread_id),
-            message: inner,
-        },
-        Payload::NewIdentifier {
-            ref thread_id,
-            new_vid,
-        } => crate::cesr::Payload::NewIdentifierProposal {
-            //TODO: we need to produce a signature here with `new_vid`, but we don't have the PrivateVid for it at this point and that
-            //cannot be done without changing the "upper" API.
-            thread_id: crate::cesr::Digest::Blake2b256(thread_id),
-            sig_thread_id: &[0; 64],
-            new_vid,
-        },
-        Payload::Referral { referred_vid } => {
-            crate::cesr::Payload::RelationshipReferral { referred_vid }
+            reply_thread_id: _ignored,
+            form,
+        } => {
+            let (payload, payload_digest) = build_relationship_accept_payload(
+                thread_id,
+                &form,
+                sender_in_payload,
+                RelationshipDigestAlgorithm::Blake2b256,
+                &mut reply_digest_storage,
+            )?;
+            payload_digest_override = Some(payload_digest);
+            payload
         }
         Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
             reply: crate::cesr::Digest::Blake2b256(thread_id),
@@ -95,19 +97,12 @@ pub(crate) fn seal(
     // prepare CESR-encoded ciphertext
     let mut cesr_message = Vec::new();
 
-    #[cfg(feature = "essr")]
-    crate::cesr::encode_payload(
-        &secret_payload,
-        Some(sender.identifier().as_bytes()),
-        &mut cesr_message,
-    )?;
-
-    #[cfg(not(feature = "essr"))]
-    crate::cesr::encode_payload(&secret_payload, None, &mut cesr_message)?;
+    crate::cesr::encode_payload(&secret_payload, sender_in_payload, &mut cesr_message)?;
 
     // hash the raw bytes of the plaintext before encryption
     if let Some(digest) = digest {
-        *digest = crate::crypto::blake2b256(&cesr_message)
+        *digest =
+            payload_digest_override.unwrap_or_else(|| crate::crypto::blake2b256(&cesr_message));
     }
 
     let sender_secret_key = SecretKey::from_slice(sender.decryption_key())?;
@@ -173,8 +168,6 @@ pub(crate) fn open<'a>(
 
     receiver_box.decrypt_in_place_detached(nonce.into(), &[], ciphertext, tag.into())?;
 
-    let thread_id = crate::crypto::blake2b256(ciphertext);
-
     #[allow(unused_variables)]
     let DecodedPayload {
         payload,
@@ -194,39 +187,45 @@ pub(crate) fn open<'a>(
 
     let secret_payload = match payload {
         crate::cesr::Payload::GenericMessage(data) => Payload::Content(data as _),
-        crate::cesr::Payload::DirectRelationProposal { hops, .. } => Payload::RequestRelationship {
-            route: if hops.is_empty() { None } else { Some(hops) },
-            thread_id,
-        },
-        crate::cesr::Payload::DirectRelationAffirm { reply } => Payload::AcceptRelationship {
-            thread_id: *reply.as_bytes(),
-        },
-        crate::cesr::Payload::NestedRelationProposal { message, .. } => {
-            Payload::RequestNestedRelationship {
-                inner: message,
-                thread_id,
-            }
+        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => {
+            open_relationship_request(
+                *request_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Direct,
+            )
         }
-        crate::cesr::Payload::NestedRelationAffirm {
-            message: inner,
-            reply,
-        } => Payload::AcceptNestedRelationship {
-            inner,
-            thread_id: *reply.as_bytes(),
-        },
-        crate::cesr::Payload::NewIdentifierProposal {
-            thread_id,
-            sig_thread_id: _,
+        crate::cesr::Payload::DirectRelationAffirm {
+            request_digest,
+            reply_digest,
+        } => open_relationship_accept(
+            *request_digest.as_bytes(),
+            *reply_digest.as_bytes(),
+            crate::definitions::RelationshipForm::Direct,
+        ),
+        crate::cesr::Payload::ParallelRelationProposal {
+            request_digest,
+            sig_new_vid,
             new_vid,
-        } => Payload::NewIdentifier {
-            //TODO: the sig_thread_id cannot be verified at this point, so needs to be bubbled upwards so it can be checked
-            //*after* the new VID has been retrieved and verified.
-            thread_id: *thread_id.as_bytes(),
+            ..
+        } => open_relationship_request(
+            *request_digest.as_bytes(),
+            crate::definitions::RelationshipForm::Parallel {
+                new_vid,
+                sig_new_vid,
+            },
+        ),
+        crate::cesr::Payload::ParallelRelationAffirm {
+            request_digest,
+            reply_digest,
+            sig_new_vid,
             new_vid,
-        },
-        crate::cesr::Payload::RelationshipReferral { referred_vid } => {
-            Payload::Referral { referred_vid }
-        }
+        } => open_relationship_accept(
+            *request_digest.as_bytes(),
+            *reply_digest.as_bytes(),
+            crate::definitions::RelationshipForm::Parallel {
+                new_vid,
+                sig_new_vid,
+            },
+        ),
         crate::cesr::Payload::RelationshipCancel { reply, .. } => Payload::CancelRelationship {
             thread_id: *reply.as_bytes(),
         },
@@ -240,10 +239,4 @@ pub(crate) fn open<'a>(
         envelope.crypto_type,
         envelope.signature_type,
     ))
-}
-
-/// Generate N random bytes using the provided RNG
-#[cfg(feature = "nacl")]
-fn fresh_nonce(csprng: &mut (impl rand::RngCore + rand::CryptoRng)) -> crate::cesr::Nonce {
-    crate::cesr::Nonce::generate(|dst| csprng.fill_bytes(dst))
 }

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 use crypto_box::{ChaChaBox, PublicKey, SecretKey, aead::AeadInPlace};
 
-use super::{CryptoError, MessageContents, open_relationship_accept, open_relationship_request};
+use super::{
+    CryptoError, MessageContents, ParallelSignatureInfo, open_relationship_accept,
+    open_relationship_request,
+};
 #[cfg(feature = "nacl")]
 use super::{
     RelationshipDigestAlgorithm, build_relationship_accept_payload,
@@ -31,6 +34,7 @@ pub(crate) fn seal(
     nonconfidential_data: Option<NonConfidentialData>,
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
+    request_nonce_override: Option<[u8; 32]>,
 ) -> Result<TSPMessage, CryptoError> {
     let mut csprng = StdRng::from_entropy();
 
@@ -61,8 +65,11 @@ pub(crate) fn seal(
             thread_id: _ignored,
             form,
         } => {
-            let mut nonce_bytes = [0_u8; 32];
-            csprng.fill_bytes(&mut nonce_bytes);
+            let nonce_bytes = request_nonce_override.unwrap_or_else(|| {
+                let mut nonce_bytes = [0_u8; 32];
+                csprng.fill_bytes(&mut nonce_bytes);
+                nonce_bytes
+            });
 
             let (payload, payload_digest) = build_relationship_request_payload(
                 &form,
@@ -160,7 +167,7 @@ pub(crate) fn open<'a>(
     _raw_header: &'a [u8],
     envelope: Envelope<'a, &[u8]>,
     ciphertext: &'a mut [u8],
-) -> Result<MessageContents<'a>, CryptoError> {
+) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     let (ciphertext, footer) = ciphertext.split_at_mut(ciphertext.len() - 16 - 24);
     let (tag, nonce) = footer.split_at(16);
 
@@ -187,58 +194,95 @@ pub(crate) fn open<'a>(
         }
     }
 
-    let secret_payload = match payload {
-        crate::cesr::Payload::GenericMessage(data) => Payload::Content(data as _),
-        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => {
+    let (secret_payload, parallel_signature_info) = match payload {
+        crate::cesr::Payload::GenericMessage(data) => (Payload::Content(data as _), None),
+        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => (
             open_relationship_request(
                 *request_digest.as_bytes(),
                 crate::definitions::RelationshipForm::Direct,
-            )
-        }
+            ),
+            None,
+        ),
         crate::cesr::Payload::DirectRelationAffirm {
             request_digest,
             reply_digest,
-        } => open_relationship_accept(
-            *request_digest.as_bytes(),
-            *reply_digest.as_bytes(),
-            crate::definitions::RelationshipForm::Direct,
+        } => (
+            open_relationship_accept(
+                *request_digest.as_bytes(),
+                *reply_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Direct,
+            ),
+            None,
         ),
         crate::cesr::Payload::ParallelRelationProposal {
+            nonce,
             request_digest,
             sig_new_vid,
             new_vid,
             ..
-        } => open_relationship_request(
-            *request_digest.as_bytes(),
-            crate::definitions::RelationshipForm::Parallel {
+        } => (
+            open_relationship_request(
+                *request_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Parallel {
+                    new_vid,
+                    sig_new_vid,
+                },
+            ),
+            Some(ParallelSignatureInfo {
                 new_vid,
                 sig_new_vid,
-            },
+                signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
+                    sender_identity,
+                    &nonce,
+                    request_digest,
+                    new_vid,
+                )?,
+            }),
         ),
         crate::cesr::Payload::ParallelRelationAffirm {
             request_digest,
             reply_digest,
             sig_new_vid,
             new_vid,
-        } => open_relationship_accept(
-            *request_digest.as_bytes(),
-            *reply_digest.as_bytes(),
-            crate::definitions::RelationshipForm::Parallel {
+        } => (
+            open_relationship_accept(
+                *request_digest.as_bytes(),
+                *reply_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Parallel {
+                    new_vid,
+                    sig_new_vid,
+                },
+            ),
+            Some(ParallelSignatureInfo {
                 new_vid,
                 sig_new_vid,
-            },
+                signed_data: crate::cesr::encode_parallel_relation_affirm_challenge(
+                    sender_identity,
+                    request_digest,
+                    reply_digest,
+                    new_vid,
+                )?,
+            }),
         ),
-        crate::cesr::Payload::RelationshipCancel { reply, .. } => Payload::CancelRelationship {
-            thread_id: *reply.as_bytes(),
-        },
-        crate::cesr::Payload::NestedMessage(data) => Payload::NestedMessage(data),
-        crate::cesr::Payload::RoutedMessage(hops, data) => Payload::RoutedMessage(hops, data as _),
+        crate::cesr::Payload::RelationshipCancel { reply, .. } => (
+            Payload::CancelRelationship {
+                thread_id: *reply.as_bytes(),
+            },
+            None,
+        ),
+        crate::cesr::Payload::NestedMessage(data) => (Payload::NestedMessage(data), None),
+        crate::cesr::Payload::RoutedMessage(hops, data) => {
+            (Payload::RoutedMessage(hops, data as _), None)
+        }
     };
 
     Ok((
-        envelope.nonconfidential_data,
-        secret_payload,
-        envelope.crypto_type,
-        envelope.signature_type,
+        (
+            envelope.nonconfidential_data,
+            secret_payload,
+            envelope.crypto_type,
+            envelope.signature_type,
+        ),
+        parallel_signature_info,
     ))
 }

--- a/tsp_sdk/src/definitions/conversions.rs
+++ b/tsp_sdk/src/definitions/conversions.rs
@@ -1,4 +1,4 @@
-use super::ReceivedTspMessage;
+use super::{ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage};
 use bytes::BytesMut;
 
 // Rust, there has to be a better way.
@@ -34,24 +34,60 @@ impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
             RequestRelationship {
                 sender,
                 receiver,
-                route,
-                nested_vid,
                 thread_id,
+                form,
+                delivery,
             } => RequestRelationship {
                 sender,
                 receiver,
-                route,
-                nested_vid,
                 thread_id,
+                form: match form {
+                    ReceivedRelationshipForm::Direct => ReceivedRelationshipForm::Direct,
+                    ReceivedRelationshipForm::Parallel {
+                        new_vid,
+                        sig_new_vid,
+                    } => ReceivedRelationshipForm::Parallel {
+                        new_vid,
+                        sig_new_vid: f(sig_new_vid),
+                    },
+                },
+                delivery: match delivery {
+                    ReceivedRelationshipDelivery::Direct => ReceivedRelationshipDelivery::Direct,
+                    ReceivedRelationshipDelivery::Nested { nested_vid } => {
+                        ReceivedRelationshipDelivery::Nested { nested_vid }
+                    }
+                    ReceivedRelationshipDelivery::Routed => ReceivedRelationshipDelivery::Routed,
+                },
             },
             AcceptRelationship {
                 sender,
                 receiver,
-                nested_vid,
+                thread_id,
+                reply_thread_id,
+                form,
+                delivery,
             } => AcceptRelationship {
                 sender,
                 receiver,
-                nested_vid,
+                thread_id,
+                reply_thread_id,
+                form: match form {
+                    ReceivedRelationshipForm::Direct => ReceivedRelationshipForm::Direct,
+                    ReceivedRelationshipForm::Parallel {
+                        new_vid,
+                        sig_new_vid,
+                    } => ReceivedRelationshipForm::Parallel {
+                        new_vid,
+                        sig_new_vid: f(sig_new_vid),
+                    },
+                },
+                delivery: match delivery {
+                    ReceivedRelationshipDelivery::Direct => ReceivedRelationshipDelivery::Direct,
+                    ReceivedRelationshipDelivery::Nested { nested_vid } => {
+                        ReceivedRelationshipDelivery::Nested { nested_vid }
+                    }
+                    ReceivedRelationshipDelivery::Routed => ReceivedRelationshipDelivery::Routed,
+                },
             },
             CancelRelationship { sender, receiver } => CancelRelationship { sender, receiver },
             ForwardRequest {
@@ -66,24 +102,6 @@ impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
                 next_hop,
                 route,
                 opaque_payload,
-            },
-            NewIdentifier {
-                sender,
-                receiver,
-                new_vid,
-            } => NewIdentifier {
-                sender,
-                receiver,
-                new_vid,
-            },
-            Referral {
-                sender,
-                receiver,
-                referred_vid,
-            } => Referral {
-                sender,
-                receiver,
-                referred_vid,
             },
             #[cfg(feature = "async")]
             PendingMessage {

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -44,12 +44,20 @@ pub struct MessageType {
 }
 
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingNestedRelationship {
+    pub thread_id: Digest,
+    pub local_nested_vid: String,
+}
+
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub enum RelationshipStatus {
     _Controlled,
     Bidirectional {
         thread_id: Digest,
-        outstanding_nested_thread_ids: Vec<Digest>,
+        remote_thread_id: Digest,
+        outstanding_nested_requests: Vec<PendingNestedRelationship>,
     },
     Unidirectional {
         thread_id: Digest,
@@ -61,17 +69,11 @@ pub enum RelationshipStatus {
 }
 
 impl RelationshipStatus {
-    pub(crate) fn bi_default() -> Self {
-        RelationshipStatus::Bidirectional {
-            thread_id: [0; 32],
-            outstanding_nested_thread_ids: vec![],
-        }
-    }
-
-    pub(crate) fn bi(thread_id: Digest) -> Self {
+    pub(crate) fn bi(thread_id: Digest, remote_thread_id: Digest) -> Self {
         RelationshipStatus::Bidirectional {
             thread_id,
-            outstanding_nested_thread_ids: vec![],
+            remote_thread_id,
+            outstanding_nested_requests: vec![],
         }
     }
 }
@@ -89,6 +91,19 @@ impl Display for RelationshipStatus {
 }
 
 #[derive(Debug)]
+pub enum ReceivedRelationshipForm<Data: AsRef<[u8]> = BytesMut> {
+    Direct,
+    Parallel { new_vid: String, sig_new_vid: Data },
+}
+
+#[derive(Debug)]
+pub enum ReceivedRelationshipDelivery {
+    Direct,
+    Nested { nested_vid: String },
+    Routed,
+}
+
+#[derive(Debug)]
 pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
     GenericMessage {
         sender: String,
@@ -100,14 +115,17 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
     RequestRelationship {
         sender: String,
         receiver: String,
-        route: Option<Vec<Vec<u8>>>,
-        nested_vid: Option<String>,
         thread_id: Digest,
+        form: ReceivedRelationshipForm<Data>,
+        delivery: ReceivedRelationshipDelivery,
     },
     AcceptRelationship {
         sender: String,
         receiver: String,
-        nested_vid: Option<String>,
+        thread_id: Digest,
+        reply_thread_id: Digest,
+        form: ReceivedRelationshipForm<Data>,
+        delivery: ReceivedRelationshipDelivery,
     },
     CancelRelationship {
         sender: String,
@@ -120,16 +138,6 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
         route: Vec<BytesMut>,
         opaque_payload: BytesMut,
     },
-    NewIdentifier {
-        sender: String,
-        receiver: String,
-        new_vid: String,
-    },
-    Referral {
-        sender: String,
-        receiver: String,
-        referred_vid: String,
-    },
     #[cfg(feature = "async")]
     PendingMessage {
         unknown_vid: String,
@@ -140,6 +148,15 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
 mod conversions;
 
 #[derive(Debug, PartialEq, Eq)]
+pub enum RelationshipForm<'a, Bytes: AsRef<[u8]>> {
+    Direct,
+    Parallel {
+        new_vid: VidData<'a>,
+        sig_new_vid: Bytes,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum Payload<'a, Bytes: AsRef<[u8]>, MaybeMutBytes: AsRef<[u8]> = Bytes> {
     Content(Bytes),
     NestedMessage(MaybeMutBytes),
@@ -148,26 +165,13 @@ pub enum Payload<'a, Bytes: AsRef<[u8]>, MaybeMutBytes: AsRef<[u8]> = Bytes> {
         thread_id: Digest,
     },
     RequestRelationship {
-        route: Option<Vec<VidData<'a>>>,
         thread_id: Digest,
+        form: RelationshipForm<'a, Bytes>,
     },
     AcceptRelationship {
         thread_id: Digest,
-    },
-    RequestNestedRelationship {
-        inner: MaybeMutBytes,
-        thread_id: Digest,
-    },
-    AcceptNestedRelationship {
-        inner: MaybeMutBytes,
-        thread_id: Digest,
-    },
-    NewIdentifier {
-        thread_id: Digest,
-        new_vid: VidData<'a>,
-    },
-    Referral {
-        referred_vid: VidData<'a>,
+        reply_thread_id: Digest,
+        form: RelationshipForm<'a, Bytes>,
     },
 }
 
@@ -180,10 +184,6 @@ impl<Bytes: AsRef<[u8]>, MaybeMutBytes: AsRef<[u8]>> Payload<'_, Bytes, MaybeMut
             Payload::CancelRelationship { .. } => &[],
             Payload::RequestRelationship { .. } => &[],
             Payload::AcceptRelationship { .. } => &[],
-            Payload::RequestNestedRelationship { .. } => &[],
-            Payload::AcceptNestedRelationship { .. } => &[],
-            Payload::NewIdentifier { .. } => &[],
-            Payload::Referral { .. } => &[],
         }
     }
 }
@@ -213,10 +213,6 @@ impl<Bytes: AsRef<[u8]>> fmt::Display for Payload<'_, Bytes> {
             Payload::CancelRelationship { .. } => write!(f, "Cancel Relationship"),
             Payload::RequestRelationship { .. } => write!(f, "Request Relationship"),
             Payload::AcceptRelationship { .. } => write!(f, "Accept Relationship"),
-            Payload::RequestNestedRelationship { .. } => write!(f, "Request Nested Relationship"),
-            Payload::AcceptNestedRelationship { .. } => write!(f, "Accept Nested Relationship"),
-            Payload::NewIdentifier { .. } => write!(f, "Request Identifier Change"),
-            Payload::Referral { .. } => write!(f, "Relationship Referral"),
         }
     }
 }

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -51,6 +51,21 @@ pub struct PendingNestedRelationship {
 }
 
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingParallelRelationship {
+    pub thread_id: Digest,
+    pub local_parallel_vid: String,
+    pub outer_receiver: String,
+}
+
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingIncomingParallelRelationship {
+    pub thread_id: Digest,
+    pub local_outer_vid: String,
+}
+
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub enum RelationshipStatus {
     _Controlled,

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -160,6 +160,26 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
     },
 }
 
+impl<Data: AsRef<[u8]>> ReceivedTspMessage<Data> {
+    pub fn pending_message_parts(&self) -> Option<(&str, &[u8])> {
+        #[cfg(feature = "async")]
+        {
+            match self {
+                Self::PendingMessage {
+                    unknown_vid,
+                    payload,
+                } => Some((unknown_vid.as_str(), payload.as_ref())),
+                _ => None,
+            }
+        }
+
+        #[cfg(not(feature = "async"))]
+        {
+            None
+        }
+    }
+}
+
 mod conversions;
 
 #[derive(Debug, PartialEq, Eq)]

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -134,7 +134,8 @@ pub use secure_storage::AskarSecureStorage;
 pub use secure_storage::SecureStorage;
 
 pub use definitions::{
-    Payload, PendingNestedRelationship, PrivateVid, ReceivedRelationshipDelivery,
+    Payload, PendingIncomingParallelRelationship, PendingNestedRelationship,
+    PendingParallelRelationship, PrivateVid, ReceivedRelationshipDelivery,
     ReceivedRelationshipForm, ReceivedTspMessage, RelationshipForm, RelationshipStatus,
     VerifiedVid,
 };

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -118,6 +118,11 @@ mod secure_storage;
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "async")]
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod parallel_relationship_test;
+
 /// Test utilities and helpers for writing tests.
 ///
 /// This module is available when compiling tests and provides

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -133,7 +133,11 @@ pub use secure_storage::AskarSecureStorage;
 #[cfg(feature = "async")]
 pub use secure_storage::SecureStorage;
 
-pub use definitions::{Payload, PrivateVid, ReceivedTspMessage, RelationshipStatus, VerifiedVid};
+pub use definitions::{
+    Payload, PendingNestedRelationship, PrivateVid, ReceivedRelationshipDelivery,
+    ReceivedRelationshipForm, ReceivedTspMessage, RelationshipForm, RelationshipStatus,
+    VerifiedVid,
+};
 pub use error::Error;
 pub use store::{Aliases, SecureStore};
 pub use vid::{ExportVid, OwnedVid, Vid};

--- a/tsp_sdk/src/parallel_relationship_test.rs
+++ b/tsp_sdk/src/parallel_relationship_test.rs
@@ -1,0 +1,265 @@
+use crate::{
+    AsyncSecureStore, ReceivedRelationshipDelivery, ReceivedRelationshipForm, RelationshipStatus,
+    VerifiedVid, test_utils::*,
+};
+use futures::StreamExt;
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+use tokio::time::timeout;
+
+fn can_use_loopback_transport() -> bool {
+    let Ok(listener) = TcpListener::bind(("127.0.0.1", 0)) else {
+        return false;
+    };
+    let Ok(addr) = listener.local_addr() else {
+        return false;
+    };
+
+    TcpStream::connect(addr).is_ok()
+}
+
+fn establish_existing_relationship(
+    a_store: &AsyncSecureStore,
+    a_vid: &dyn VerifiedVid,
+    b_store: &AsyncSecureStore,
+    b_vid: &dyn VerifiedVid,
+) {
+    a_store
+        .set_relation_and_status_for_vid(
+            b_vid.identifier(),
+            RelationshipStatus::Bidirectional {
+                thread_id: [1; 32],
+                remote_thread_id: [2; 32],
+                outstanding_nested_requests: vec![],
+            },
+            a_vid.identifier(),
+        )
+        .unwrap();
+    b_store
+        .set_relation_and_status_for_vid(
+            a_vid.identifier(),
+            RelationshipStatus::Bidirectional {
+                thread_id: [2; 32],
+                remote_thread_id: [1; 32],
+                outstanding_nested_requests: vec![],
+            },
+            b_vid.identifier(),
+        )
+        .unwrap();
+}
+
+fn assert_bidirectional_relationship(store: &AsyncSecureStore, local_vid: &str, remote_vid: &str) {
+    assert!(matches!(
+        store
+            .get_relation_status_for_vid_pair(local_vid, remote_vid)
+            .unwrap(),
+        RelationshipStatus::Bidirectional { .. }
+    ));
+}
+
+#[tokio::test]
+#[serial_test::serial(tcp)]
+async fn test_parallel_relationship_accept_bootstraps_unknown_sender_async() {
+    if !can_use_loopback_transport() {
+        eprintln!("skipping async bootstrap test: local TCP transport is unavailable");
+        return;
+    }
+
+    let alice_db = create_async_test_store();
+    let bob_db = create_async_test_store();
+    let (alice, bob) = create_test_vid_pair();
+    let alice_parallel = create_test_vid();
+    let bob_parallel = create_test_vid();
+
+    alice_db.add_private_vid(alice.clone(), None).unwrap();
+    bob_db.add_private_vid(bob.clone(), None).unwrap();
+    alice_db
+        .add_private_vid(alice_parallel.clone(), None)
+        .unwrap();
+    bob_db.add_private_vid(bob_parallel.clone(), None).unwrap();
+    alice_db.add_verified_vid(bob.clone(), None).unwrap();
+    bob_db.add_verified_vid(alice.clone(), None).unwrap();
+    bob_db
+        .add_verified_vid(alice_parallel.clone(), None)
+        .unwrap();
+    establish_existing_relationship(&alice_db, &alice, &bob_db, &bob);
+
+    assert!(
+        !alice_db
+            .has_verified_vid(bob_parallel.identifier())
+            .unwrap()
+    );
+
+    let mut bob_messages = bob_db.receive(bob.identifier()).await.unwrap();
+    let mut alice_parallel_messages = alice_db.receive(alice_parallel.identifier()).await.unwrap();
+
+    alice_db
+        .send_parallel_relationship_request(
+            alice.identifier(),
+            bob.identifier(),
+            alice_parallel.identifier(),
+        )
+        .await
+        .unwrap();
+
+    let request = timeout(Duration::from_secs(5), bob_messages.next())
+        .await
+        .expect("timed out waiting for parallel request")
+        .expect("parallel request stream ended")
+        .expect("failed to receive parallel request");
+
+    let crate::definitions::ReceivedTspMessage::RequestRelationship {
+        sender,
+        receiver,
+        thread_id,
+        form:
+            ReceivedRelationshipForm::Parallel {
+                new_vid,
+                sig_new_vid: _,
+            },
+        delivery: ReceivedRelationshipDelivery::Direct,
+    } = request
+    else {
+        panic!("bob did not receive a parallel relationship request");
+    };
+
+    assert_eq!(sender, alice.identifier());
+    assert_eq!(receiver, bob.identifier());
+    assert_eq!(new_vid, alice_parallel.identifier());
+
+    bob_db
+        .send_parallel_relationship_accept(
+            bob_parallel.identifier(),
+            alice_parallel.identifier(),
+            thread_id,
+        )
+        .await
+        .unwrap();
+
+    let accept = timeout(Duration::from_secs(5), alice_parallel_messages.next())
+        .await
+        .expect("timed out waiting for parallel accept")
+        .expect("parallel accept stream ended")
+        .expect("failed to receive parallel accept");
+
+    let crate::definitions::ReceivedTspMessage::AcceptRelationship {
+        sender,
+        receiver,
+        thread_id: received_thread_id,
+        reply_thread_id: _,
+        form:
+            ReceivedRelationshipForm::Parallel {
+                new_vid,
+                sig_new_vid: _,
+            },
+        delivery: ReceivedRelationshipDelivery::Direct,
+    } = accept
+    else {
+        panic!("alice did not receive a parallel relationship accept");
+    };
+
+    assert_eq!(sender, bob.identifier());
+    assert_eq!(receiver, alice_parallel.identifier());
+    assert_eq!(received_thread_id, thread_id);
+    assert_eq!(new_vid, bob_parallel.identifier());
+    assert!(
+        alice_db
+            .has_verified_vid(bob_parallel.identifier())
+            .unwrap()
+    );
+    assert_bidirectional_relationship(
+        &alice_db,
+        alice_parallel.identifier(),
+        bob_parallel.identifier(),
+    );
+    assert_bidirectional_relationship(&alice_db, alice.identifier(), bob.identifier());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_parallel_relationship_state_persists_after_import_and_reopen() {
+    let alice_db = create_async_test_store();
+    let bob_db = create_async_test_store();
+    let (alice, bob) = create_test_vid_pair();
+    let alice_parallel = create_test_vid();
+    let bob_parallel = create_test_vid();
+
+    alice_db.add_private_vid(alice.clone(), None).unwrap();
+    bob_db.add_private_vid(bob.clone(), None).unwrap();
+    alice_db
+        .add_private_vid(alice_parallel.clone(), None)
+        .unwrap();
+    bob_db.add_private_vid(bob_parallel.clone(), None).unwrap();
+    alice_db.add_verified_vid(bob.clone(), None).unwrap();
+    bob_db.add_verified_vid(alice.clone(), None).unwrap();
+    alice_db
+        .add_verified_vid(bob_parallel.clone(), None)
+        .unwrap();
+    bob_db
+        .add_verified_vid(alice_parallel.clone(), None)
+        .unwrap();
+    establish_existing_relationship(&alice_db, &alice, &bob_db, &bob);
+
+    let (_endpoint, mut request) = alice_db
+        .make_parallel_relationship_request(
+            alice.identifier(),
+            bob.identifier(),
+            alice_parallel.identifier(),
+        )
+        .unwrap();
+
+    let crate::definitions::ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+        bob_db.as_store().open_message(&mut request).unwrap()
+    else {
+        panic!("bob did not open a parallel relationship request");
+    };
+
+    let (_endpoint, mut accept) = bob_db
+        .make_parallel_relationship_accept(
+            bob_parallel.identifier(),
+            alice_parallel.identifier(),
+            thread_id,
+        )
+        .unwrap();
+
+    let crate::definitions::ReceivedTspMessage::AcceptRelationship { .. } =
+        alice_db.as_store().open_message(&mut accept).unwrap()
+    else {
+        panic!("alice did not open a parallel relationship accept");
+    };
+
+    assert_bidirectional_relationship(&alice_db, alice.identifier(), bob.identifier());
+    assert_bidirectional_relationship(
+        &alice_db,
+        alice_parallel.identifier(),
+        bob_parallel.identifier(),
+    );
+    assert_bidirectional_relationship(&bob_db, bob.identifier(), alice.identifier());
+    assert_bidirectional_relationship(
+        &bob_db,
+        bob_parallel.identifier(),
+        alice_parallel.identifier(),
+    );
+
+    let imported_alice = create_async_test_store();
+    let (vids, aliases, keys) = alice_db.export().unwrap();
+    imported_alice.import(vids, aliases, keys).unwrap();
+
+    assert_bidirectional_relationship(&imported_alice, alice.identifier(), bob.identifier());
+    assert_bidirectional_relationship(
+        &imported_alice,
+        alice_parallel.identifier(),
+        bob_parallel.identifier(),
+    );
+
+    let fixture = create_persisted_store().await;
+    fixture.persist_from(&bob_db).await;
+    let reopened_bob = fixture.reopen_into_store().await;
+
+    assert_bidirectional_relationship(&reopened_bob, bob.identifier(), alice.identifier());
+    assert_bidirectional_relationship(
+        &reopened_bob,
+        bob_parallel.identifier(),
+        alice_parallel.identifier(),
+    );
+}

--- a/tsp_sdk/src/secure_storage.rs
+++ b/tsp_sdk/src/secure_storage.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use crate::definitions::{VidEncryptionKeyType, VidSignatureKeyType};
 use crate::{
-    Error, ExportVid, RelationshipStatus,
+    Error, ExportVid, PendingIncomingParallelRelationship, PendingParallelRelationship,
+    RelationshipStatus,
     store::{Aliases, WebvhUpdateKeys},
 };
 use aries_askar::{ErrorKind, StoreKeyMethod, entry::EntryOperation};
@@ -51,6 +52,10 @@ pub(crate) struct Metadata {
     relation_vid: Option<String>,
     parent_vid: Option<String>,
     tunnel: Option<Box<[String]>>,
+    #[serde(default)]
+    pending_parallel_requests: Vec<PendingParallelRelationship>,
+    #[serde(default)]
+    pending_incoming_parallel_requests: Vec<PendingIncomingParallelRelationship>,
     metadata: Option<serde_json::Value>,
 }
 
@@ -186,6 +191,8 @@ impl SecureStorage for AskarSecureStorage {
                 relation_vid: export.relation_vid,
                 parent_vid: export.parent_vid,
                 tunnel: export.tunnel,
+                pending_parallel_requests: export.pending_parallel_requests,
+                pending_incoming_parallel_requests: export.pending_incoming_parallel_requests,
                 metadata: export.metadata,
             }) {
                 if let Err(e) = conn.insert("vid", &id, data.as_bytes(), None, None).await {
@@ -310,6 +317,8 @@ impl SecureStorage for AskarSecureStorage {
                 relation_vid: data.relation_vid,
                 parent_vid: data.parent_vid,
                 tunnel: data.tunnel,
+                pending_parallel_requests: data.pending_parallel_requests,
+                pending_incoming_parallel_requests: data.pending_incoming_parallel_requests,
                 metadata: data.metadata,
             };
 

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -1100,12 +1100,25 @@ impl SecureStore {
                         })
                     }
                     Payload::RequestRelationship { thread_id, form } => {
-                        if let Some(parallel_sender_vid) = parallel_sender_vid {
-                            parallel_sender_vid.persist(self)?;
-                        }
                         let form = received_relationship_form(form)?;
 
                         if let ReceivedRelationshipForm::Parallel { new_vid, .. } = &form {
+                            match self.relation_status_for_vid_pair(&intended_receiver, &sender)? {
+                                RelationshipStatus::Bidirectional { .. } => {}
+                                RelationshipStatus::_Controlled
+                                | RelationshipStatus::Unidirectional { .. }
+                                | RelationshipStatus::ReverseUnidirectional { .. }
+                                | RelationshipStatus::Unrelated => {
+                                    return Err(requires_existing_parallel_relationship_error());
+                                }
+                            }
+
+                            let parallel_sender_vid = parallel_sender_vid.ok_or_else(|| {
+                                Error::Relationship(
+                                    "missing verified parallel VID for request message".into(),
+                                )
+                            })?;
+                            parallel_sender_vid.persist(self)?;
                             self.add_pending_incoming_parallel_request(
                                 new_vid,
                                 thread_id,
@@ -2679,6 +2692,68 @@ mod test {
         };
 
         assert_eq!(vid, alice_parallel.identifier());
+        assert!(matches!(
+            b_store.get_verified_vid(alice_parallel.identifier()),
+            Err(Error::UnverifiedVid(_))
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_request_requires_existing_outer_relationship() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let alice_parallel = create_test_vid();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        let mut nonce_bytes = [0_u8; 32];
+        StdRng::from_entropy().fill_bytes(&mut nonce_bytes);
+        let mut thread_id = [0_u8; 32];
+        let signed_data = crate::crypto::build_parallel_request_signed_data(
+            Some(alice.identifier().as_bytes()),
+            relationship_digest_algorithm(),
+            nonce_bytes,
+            &mut thread_id,
+            alice_parallel.identifier().as_bytes(),
+        )
+        .unwrap();
+        let sig_new_vid = crate::crypto::sign_detached(&alice_parallel, &signed_data).unwrap();
+
+        let sender_vid = a_store.get_private_vid(alice.identifier()).unwrap();
+        let receiver_vid = a_store.get_verified_vid(bob.identifier()).unwrap();
+        let mut request_digest = Default::default();
+        let mut sealed = crate::crypto::seal_and_hash_with_relationship_nonce(
+            &*sender_vid,
+            &*receiver_vid,
+            None,
+            Payload::RequestRelationship {
+                thread_id: Default::default(),
+                form: RelationshipForm::Parallel {
+                    new_vid: alice_parallel.identifier().as_ref(),
+                    sig_new_vid: sig_new_vid.as_slice(),
+                },
+            },
+            Some(&mut request_digest),
+            Some(nonce_bytes),
+        )
+        .unwrap();
+
+        let Err(Error::Relationship(message)) = b_store.open_message(&mut sealed) else {
+            panic!("unexpected message result");
+        };
+
+        assert_eq!(
+            message,
+            "parallel relationship-forming requires an existing bidirectional relationship"
+        );
         assert!(matches!(
             b_store.get_verified_vid(alice_parallel.identifier()),
             Err(Error::UnverifiedVid(_))

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -3,8 +3,9 @@ use crate::{
     cesr::EnvelopeType,
     crypto::CryptoError,
     definitions::{
-        Digest, MessageType, Payload, PrivateVid, ReceivedTspMessage, RelationshipStatus,
-        VerifiedVid,
+        Digest, MessageType, Payload, PendingNestedRelationship, PrivateVid,
+        ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage,
+        RelationshipForm, RelationshipStatus, VerifiedVid,
     },
     error::Error,
     vid::{VidError, resolve::verify_vid_offline},
@@ -12,6 +13,7 @@ use crate::{
 #[cfg(feature = "async")]
 use bytes::Bytes;
 use bytes::BytesMut;
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 use std::{
     collections::HashMap,
     fmt::Display,
@@ -73,6 +75,57 @@ impl VidContext {
     /// Get the route for this VID
     pub(crate) fn get_route(&self) -> Option<&[String]> {
         self.tunnel.as_deref()
+    }
+}
+
+fn nested_digest(bytes: &[u8]) -> Digest {
+    #[cfg(feature = "nacl")]
+    {
+        crate::crypto::blake2b256(bytes)
+    }
+
+    #[cfg(not(feature = "nacl"))]
+    {
+        crate::crypto::sha256(bytes)
+    }
+}
+
+fn nested_digest_field<'a>(digest: &'a Digest) -> crate::cesr::Digest<'a> {
+    #[cfg(feature = "nacl")]
+    {
+        crate::cesr::Digest::Blake2b256(digest)
+    }
+
+    #[cfg(not(feature = "nacl"))]
+    {
+        crate::cesr::Digest::Sha2_256(digest)
+    }
+}
+
+enum NestedRelationshipEvent {
+    Request {
+        nested_vid: String,
+        thread_id: Digest,
+    },
+    Accept {
+        nested_vid: String,
+        thread_id: Digest,
+        reply_thread_id: Digest,
+    },
+}
+
+fn received_relationship_form<'a>(
+    form: RelationshipForm<'a, &'a [u8]>,
+) -> Result<ReceivedRelationshipForm<&'a [u8]>, Error> {
+    match form {
+        RelationshipForm::Direct => Ok(ReceivedRelationshipForm::Direct),
+        RelationshipForm::Parallel {
+            new_vid,
+            sig_new_vid,
+        } => Ok(ReceivedRelationshipForm::Parallel {
+            new_vid: std::str::from_utf8(new_vid)?.to_string(),
+            sig_new_vid,
+        }),
     }
 }
 
@@ -573,18 +626,180 @@ impl SecureStore {
         Ok(message)
     }
 
-    /// Resolve a route, extract the next hop and verify the route
-    fn resolve_route<'a>(&'a self, hop_list: &'a [&str]) -> Result<(String, Vec<&'a [u8]>), Error> {
-        let Some(next_hop) = hop_list.first() else {
-            return Err(Error::InvalidRoute(
-                "relationship route must not be empty".into(),
-            ));
+    fn make_signed_nested_request_message(
+        &self,
+        sender: &dyn PrivateVid,
+    ) -> Result<(Vec<u8>, Digest), Error> {
+        let mut csprng = StdRng::from_entropy();
+        let mut nonce_bytes = [0_u8; 32];
+        csprng.fill_bytes(&mut nonce_bytes);
+
+        let sender_identity = Some(sender.identifier().as_bytes());
+        let mut request_digest = [0_u8; 32];
+
+        let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
+            crate::cesr::Payload::DirectRelationProposal {
+                nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+                request_digest: nested_digest_field(&request_digest),
+            };
+
+        let mut encoded_payload =
+            Vec::with_capacity(placeholder_payload.calculate_size(sender_identity));
+        crate::cesr::encode_payload(&placeholder_payload, sender_identity, &mut encoded_payload)?;
+
+        request_digest = nested_digest(&encoded_payload);
+
+        encoded_payload.clear();
+        let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
+            crate::cesr::Payload::DirectRelationProposal {
+                nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+                request_digest: nested_digest_field(&request_digest),
+            };
+        crate::cesr::encode_payload(&payload, sender_identity, &mut encoded_payload)?;
+
+        let message = crate::crypto::sign(sender, None, &encoded_payload)?;
+
+        Ok((message, request_digest))
+    }
+
+    fn make_signed_nested_accept_message(
+        &self,
+        sender: &dyn PrivateVid,
+        receiver: &dyn VerifiedVid,
+        thread_id: Digest,
+    ) -> Result<(Vec<u8>, Digest), Error> {
+        let sender_identity = Some(sender.identifier().as_bytes());
+        let mut reply_thread_id = [0_u8; 32];
+
+        let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
+            crate::cesr::Payload::DirectRelationAffirm {
+                request_digest: nested_digest_field(&thread_id),
+                reply_digest: nested_digest_field(&reply_thread_id),
+            };
+
+        let mut encoded_payload =
+            Vec::with_capacity(placeholder_payload.calculate_size(sender_identity));
+        crate::cesr::encode_payload(&placeholder_payload, sender_identity, &mut encoded_payload)?;
+
+        reply_thread_id = nested_digest(&encoded_payload);
+
+        encoded_payload.clear();
+        let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
+            crate::cesr::Payload::DirectRelationAffirm {
+                request_digest: nested_digest_field(&thread_id),
+                reply_digest: nested_digest_field(&reply_thread_id),
+            };
+        crate::cesr::encode_payload(&payload, sender_identity, &mut encoded_payload)?;
+
+        let message = crate::crypto::sign(sender, Some(receiver), &encoded_payload)?;
+
+        Ok((message, reply_thread_id))
+    }
+
+    fn try_open_nested_relationship_message(
+        &self,
+        outer_sender: &str,
+        inner: &mut [u8],
+    ) -> Result<Option<NestedRelationshipEvent>, Error> {
+        let EnvelopeType::SignedMessage {
+            sender: inner_sender,
+            receiver: inner_receiver,
+            ..
+        } = crate::cesr::probe(inner)?
+        else {
+            return Ok(None);
         };
 
-        let next_hop = self.get_verified_vid(next_hop)?.identifier().to_owned();
-        let path = hop_list[1..].iter().map(|x| x.as_bytes()).collect();
+        let inner_sender = std::str::from_utf8(inner_sender)?.to_string();
+        let inner_receiver = inner_receiver
+            .map(std::str::from_utf8)
+            .transpose()?
+            .map(str::to_owned);
 
-        Ok((next_hop, path))
+        let (inner_message, _) = match self.get_verified_vid(&inner_sender) {
+            Ok(sender_vid) => crate::crypto::verify(&*sender_vid, inner)?,
+            Err(_) => {
+                let Ok(sender_vid) = verify_vid_offline(&inner_sender) else {
+                    return Ok(None);
+                };
+                crate::crypto::verify(&sender_vid, inner)?
+            }
+        };
+
+        let mut payload_bytes = inner_message.to_vec();
+        let crate::cesr::DecodedPayload {
+            payload,
+            sender_identity,
+        } = match crate::cesr::decode_payload(&mut payload_bytes) {
+            Ok(decoded) => decoded,
+            Err(_) => return Ok(None),
+        };
+
+        if sender_identity != Some(inner_sender.as_bytes()) {
+            return Err(Error::Relationship(
+                "nested relationship control payload sender mismatch".into(),
+            ));
+        }
+
+        match payload {
+            crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => {
+                if inner_receiver.is_some() {
+                    return Err(Error::Relationship(
+                        "invalid nested relationship request receiver".into(),
+                    ));
+                }
+
+                if self.get_verified_vid(&inner_sender).is_err() {
+                    self.add_nested_vid(&inner_sender)?;
+                }
+                self.set_parent_for_vid(&inner_sender, Some(outer_sender))?;
+
+                Ok(Some(NestedRelationshipEvent::Request {
+                    nested_vid: inner_sender,
+                    thread_id: *request_digest.as_bytes(),
+                }))
+            }
+            crate::cesr::Payload::DirectRelationAffirm {
+                request_digest,
+                reply_digest,
+            } => {
+                let Some(connect_to_vid) = inner_receiver else {
+                    return Err(Error::Relationship(
+                        "invalid nested relationship accept receiver".into(),
+                    ));
+                };
+
+                if self.get_verified_vid(&inner_sender).is_err() {
+                    self.add_nested_vid(&inner_sender)?;
+                }
+                self.set_parent_for_vid(&inner_sender, Some(outer_sender))?;
+                self.consume_pending_nested_request(
+                    outer_sender,
+                    *request_digest.as_bytes(),
+                    &connect_to_vid,
+                )?;
+
+                let relation_status =
+                    RelationshipStatus::bi(*request_digest.as_bytes(), *reply_digest.as_bytes());
+                self.set_relation_and_status_for_vid(
+                    &connect_to_vid,
+                    relation_status.clone(),
+                    &inner_sender,
+                )?;
+                self.set_relation_and_status_for_vid(
+                    &inner_sender,
+                    relation_status,
+                    &connect_to_vid,
+                )?;
+
+                Ok(Some(NestedRelationshipEvent::Accept {
+                    nested_vid: inner_sender,
+                    thread_id: *request_digest.as_bytes(),
+                    reply_thread_id: *reply_digest.as_bytes(),
+                }))
+            }
+            _ => Ok(None),
+        }
     }
 
     /// Pass along an in-transit routed TSP `opaque_message` that is not meant for us, given earlier resolved VIDs.
@@ -690,6 +905,35 @@ impl SecureStore {
                         },
                     }),
                     Payload::NestedMessage(inner) => {
+                        if let Some(received_message) =
+                            self.try_open_nested_relationship_message(&sender, inner)?
+                        {
+                            return Ok(match received_message {
+                                NestedRelationshipEvent::Request {
+                                    nested_vid,
+                                    thread_id,
+                                } => ReceivedTspMessage::RequestRelationship {
+                                    sender,
+                                    receiver: intended_receiver,
+                                    thread_id,
+                                    form: ReceivedRelationshipForm::Direct,
+                                    delivery: ReceivedRelationshipDelivery::Nested { nested_vid },
+                                },
+                                NestedRelationshipEvent::Accept {
+                                    nested_vid,
+                                    thread_id,
+                                    reply_thread_id,
+                                } => ReceivedTspMessage::AcceptRelationship {
+                                    sender,
+                                    receiver: intended_receiver,
+                                    thread_id,
+                                    reply_thread_id,
+                                    form: ReceivedRelationshipForm::Direct,
+                                    delivery: ReceivedRelationshipDelivery::Nested { nested_vid },
+                                },
+                            });
+                        }
+
                         // in case the inner vid isn't recognized (which can realistically happen in Routed mode),
                         // in async mode we might want to ask if they still want to open the message; but for that
                         // we must communicate the payload to them so they can process it further.
@@ -737,29 +981,49 @@ impl SecureStore {
                             opaque_payload: BytesMut::from_iter(message.iter()),
                         })
                     }
-                    Payload::RequestRelationship { route, thread_id } => {
+                    Payload::RequestRelationship { thread_id, form } => {
+                        let form = received_relationship_form(form)?;
+
                         Ok(ReceivedTspMessage::RequestRelationship {
                             sender,
                             receiver: intended_receiver,
-                            route: route.map(|vec| vec.iter().map(|vid| vid.to_vec()).collect()),
                             thread_id,
-                            nested_vid: None,
+                            form,
+                            delivery: ReceivedRelationshipDelivery::Direct,
                         })
                     }
-                    Payload::AcceptRelationship { thread_id } => {
-                        self.upgrade_relation(receiver_pid.identifier(), &sender, thread_id)?;
+                    Payload::AcceptRelationship {
+                        thread_id,
+                        reply_thread_id,
+                        form,
+                    } => {
+                        let is_direct = matches!(&form, RelationshipForm::Direct);
+                        let form = received_relationship_form(form)?;
+
+                        if is_direct {
+                            self.upgrade_relation(
+                                receiver_pid.identifier(),
+                                &sender,
+                                thread_id,
+                                reply_thread_id,
+                            )?;
+                        }
 
                         Ok(ReceivedTspMessage::AcceptRelationship {
                             sender,
                             receiver: intended_receiver,
-                            nested_vid: None,
+                            thread_id,
+                            reply_thread_id,
+                            form,
+                            delivery: ReceivedRelationshipDelivery::Direct,
                         })
                     }
                     Payload::CancelRelationship { thread_id } => {
                         if let Some(context) = self.vids.write()?.get_mut(&sender) {
                             match context.relation_status {
                                 RelationshipStatus::Bidirectional {
-                                    thread_id: digest, ..
+                                    remote_thread_id: digest,
+                                    ..
                                 }
                                 | RelationshipStatus::Unidirectional { thread_id: digest }
                                 | RelationshipStatus::ReverseUnidirectional { thread_id: digest } =>
@@ -784,108 +1048,6 @@ impl SecureStore {
                         Ok(ReceivedTspMessage::CancelRelationship {
                             sender,
                             receiver: intended_receiver,
-                        })
-                    }
-                    Payload::RequestNestedRelationship { inner, thread_id } => {
-                        let EnvelopeType::SignedMessage {
-                            sender: inner_vid,
-                            receiver: None,
-                            ..
-                        } = crate::cesr::probe(inner)?
-                        else {
-                            return Err(Error::Relationship(
-                                "invalid nested request, not a signed message".into(),
-                            ));
-                        };
-
-                        let inner_vid = std::str::from_utf8(inner_vid)?.to_string();
-
-                        self.add_nested_vid(&inner_vid)?;
-
-                        // the act of opening this message is simply verifying the signature, because this SDK doesn't yet
-                        // support sending data as part of control messages. This can easily change.
-                        let _ = self.open_message(inner)?;
-
-                        self.set_parent_for_vid(&inner_vid, Some(&sender))?;
-
-                        Ok(ReceivedTspMessage::RequestRelationship {
-                            sender,
-                            receiver: intended_receiver,
-                            route: None,
-                            thread_id,
-                            nested_vid: Some(inner_vid),
-                        })
-                    }
-                    Payload::AcceptNestedRelationship { thread_id, inner } => {
-                        let EnvelopeType::SignedMessage {
-                            sender: vid,
-                            receiver: Some(connect_to_vid),
-                            ..
-                        } = crate::cesr::probe(inner)?
-                        else {
-                            return Err(Error::Relationship(
-                                "invalid nested accept reply, not a signed message".into(),
-                            ));
-                        };
-
-                        let vid = std::str::from_utf8(vid)?.to_string();
-                        let connect_to_vid = std::str::from_utf8(connect_to_vid)?.to_string();
-                        self.add_nested_vid(&vid)?;
-
-                        let _ = self.open_message(inner)?;
-
-                        self.set_parent_for_vid(&vid, Some(&sender))?;
-                        self.add_nested_relation(&sender, &vid, thread_id)?;
-                        self.set_relation_and_status_for_vid(
-                            &connect_to_vid,
-                            RelationshipStatus::bi_default(),
-                            &vid,
-                        )?;
-                        self.set_relation_and_status_for_vid(
-                            &vid,
-                            RelationshipStatus::bi_default(),
-                            &connect_to_vid,
-                        )?;
-
-                        Ok(ReceivedTspMessage::AcceptRelationship {
-                            sender,
-                            receiver: intended_receiver,
-                            nested_vid: Some(vid),
-                        })
-                    }
-                    Payload::NewIdentifier { thread_id, new_vid } => {
-                        let vid = std::str::from_utf8(new_vid)?.to_string();
-                        match self.get_vid(&sender)?.relation_status {
-                            RelationshipStatus::Bidirectional {
-                                thread_id: check_id,
-                                ..
-                            } => {
-                                if check_id == thread_id {
-                                    Ok(ReceivedTspMessage::NewIdentifier {
-                                        sender,
-                                        receiver: intended_receiver,
-                                        new_vid: vid,
-                                    })
-                                } else {
-                                    Err(Error::Relationship(
-                                        "thread_id does not match, not accepting new identifier"
-                                            .into(),
-                                    ))
-                                }
-                            }
-                            _ => Err(Error::Relationship(format!(
-                                "no bidirectional relationship with {sender}, not accepting new identifier"
-                            ))),
-                        }
-                    }
-                    Payload::Referral { referred_vid } => {
-                        //NOTE: we could also check the relationship status here, but since a 3rd party introduction
-                        //might be of interest to a user anyway regardless of existing status, we are less strict about it
-                        let vid = std::str::from_utf8(referred_vid)?;
-                        Ok(ReceivedTspMessage::Referral {
-                            sender,
-                            receiver: intended_receiver,
-                            referred_vid: vid.to_string(),
                         })
                     }
                 }
@@ -933,30 +1095,25 @@ impl SecureStore {
         receiver: &str,
         route: Option<&[&str]>,
     ) -> Result<(Url, Vec<u8>), Error> {
+        if route.is_some() {
+            return Err(Error::Relationship(
+                "routed relationship-forming requires Reply_Path; not implemented".into(),
+            ));
+        }
+
         let sender = self.get_private_vid(sender)?;
         let receiver = self.get_verified_vid(receiver)?;
-
-        let path = route;
-        let route = route.map(|collection| collection.iter().map(|vid| vid.as_ref()).collect());
-
         let mut thread_id = Default::default();
         let tsp_message = crate::crypto::seal_and_hash(
             &*sender,
             &*receiver,
             None,
             Payload::RequestRelationship {
-                route,
                 thread_id: Default::default(),
+                form: RelationshipForm::Direct,
             },
             Some(&mut thread_id),
         )?;
-
-        let (transport, tsp_message) = if let Some(hop_list) = path {
-            self.set_route_for_vid(receiver.identifier(), hop_list)?;
-            self.resolve_route_and_send(hop_list, &tsp_message)?
-        } else {
-            (receiver.endpoint().clone(), tsp_message)
-        };
 
         self.set_relation_and_status_for_vid(
             receiver.identifier(),
@@ -964,7 +1121,7 @@ impl SecureStore {
             sender.identifier(),
         )?;
 
-        Ok((transport, tsp_message.to_owned()))
+        Ok((receiver.endpoint().clone(), tsp_message.to_owned()))
     }
 
     /// Accept a direct relationship between the resolved VIDs identifier by `sender` and `receiver`.
@@ -977,25 +1134,31 @@ impl SecureStore {
         thread_id: Digest,
         route: Option<&[&str]>,
     ) -> Result<(Url, Vec<u8>), Error> {
-        let (transport, tsp_message) = self.seal_message_payload(
+        if route.is_some() {
+            return Err(Error::Relationship(
+                "routed relationship-forming requires Reply_Path; not implemented".into(),
+            ));
+        }
+
+        let mut reply_thread_id = Default::default();
+        let (transport, tsp_message) = self.seal_message_payload_and_hash(
             sender,
             receiver,
             None,
-            Payload::AcceptRelationship { thread_id },
+            Payload::AcceptRelationship {
+                thread_id,
+                reply_thread_id: Default::default(),
+                form: RelationshipForm::Direct,
+            },
+            Some(&mut reply_thread_id),
         )?;
-
-        let (transport, tsp_message) = if let Some(hop_list) = route {
-            self.set_route_for_vid(receiver, hop_list)?;
-            self.resolve_route_and_send(hop_list, &tsp_message)?
-        } else {
-            (transport.to_owned(), tsp_message)
-        };
 
         self.set_relation_and_status_for_vid(
             receiver,
             RelationshipStatus::Bidirectional {
-                thread_id,
-                outstanding_nested_thread_ids: Default::default(),
+                thread_id: reply_thread_id,
+                remote_thread_id: thread_id,
+                outstanding_nested_requests: Default::default(),
             },
             sender,
         )?;
@@ -1042,22 +1205,16 @@ impl SecureStore {
         let receiver = self.get_verified_vid(receiver)?;
 
         let nested_vid = self.make_propositioning_vid(sender.identifier())?;
+        let (inner_message, thread_id) = self.make_signed_nested_request_message(&nested_vid)?;
 
-        let inner_message = crate::crypto::sign(&nested_vid, None, &[])?;
-
-        let mut thread_id = Default::default();
-        let (endpoint, tsp_message) = self.seal_message_payload_and_hash(
+        let (endpoint, tsp_message) = self.seal_message_payload(
             sender.identifier(),
             receiver.identifier(),
             None,
-            Payload::RequestNestedRelationship {
-                inner: &inner_message,
-                thread_id: Default::default(),
-            },
-            Some(&mut thread_id),
+            Payload::NestedMessage(&inner_message),
         )?;
 
-        self.add_nested_thread_id(receiver.identifier(), thread_id)?;
+        self.add_pending_nested_request(receiver.identifier(), thread_id, nested_vid.identifier())?;
 
         Ok(((endpoint, tsp_message), nested_vid))
     }
@@ -1073,17 +1230,6 @@ impl SecureStore {
         thread_id: Digest,
     ) -> Result<((Url, Vec<u8>), OwnedVid), Error> {
         let nested_vid = self.make_propositioning_vid(parent_sender)?;
-        self.set_relation_and_status_for_vid(
-            nested_vid.identifier(),
-            RelationshipStatus::bi(thread_id),
-            nested_receiver,
-        )?;
-        self.set_relation_and_status_for_vid(
-            nested_receiver,
-            RelationshipStatus::bi(thread_id),
-            nested_vid.identifier(),
-        )?;
-
         let receiver_vid = self.get_vid(nested_receiver)?;
         let parent_receiver = receiver_vid
             .get_parent_vid()
@@ -1091,78 +1237,29 @@ impl SecureStore {
                 "missing parent for {nested_receiver}"
             )))?;
 
-        let inner_message = crate::crypto::sign(&nested_vid, Some(&*receiver_vid.vid), &[])?;
+        let (inner_message, reply_thread_id) =
+            self.make_signed_nested_accept_message(&nested_vid, &*receiver_vid.vid, thread_id)?;
 
         let (transport, tsp_message) = self.seal_message_payload(
             parent_sender,
             parent_receiver,
             None,
-            Payload::AcceptNestedRelationship {
-                thread_id,
-                inner: &inner_message,
-            },
+            Payload::NestedMessage(&inner_message),
         )?;
 
-        self.set_relation_status_for_vid(
+        let relation_status = RelationshipStatus::bi(reply_thread_id, thread_id);
+        self.set_relation_and_status_for_vid(
+            nested_vid.identifier(),
+            relation_status.clone(),
             nested_receiver,
-            RelationshipStatus::Bidirectional {
-                thread_id,
-                outstanding_nested_thread_ids: Default::default(),
-            },
+        )?;
+        self.set_relation_and_status_for_vid(
+            nested_receiver,
+            relation_status,
+            nested_vid.identifier(),
         )?;
 
         Ok(((transport, tsp_message), nested_vid))
-    }
-
-    pub fn make_new_identifier_notice(
-        &self,
-        sender: &str,
-        receiver: &str,
-        new_vid: &str,
-    ) -> Result<(Url, Vec<u8>), Error> {
-        // check that the new vid is actually one of ours
-        let new_vid = self.get_private_vid(new_vid)?;
-
-        let RelationshipStatus::Bidirectional { thread_id, .. } =
-            self.get_vid(receiver)?.relation_status
-        else {
-            return Err(Error::Relationship(format!(
-                "no relationship with {receiver}"
-            )));
-        };
-
-        let (transport, tsp_message) = self.seal_message_payload(
-            sender,
-            receiver,
-            None,
-            Payload::NewIdentifier {
-                thread_id,
-                new_vid: new_vid.identifier().as_ref(),
-            },
-        )?;
-
-        Ok((transport, tsp_message))
-    }
-
-    pub fn make_relationship_referral(
-        &self,
-        sender: &str,
-        receiver: &str,
-        referred_vid: &str,
-    ) -> Result<(Url, Vec<u8>), Error> {
-        // check that we actually know the referred vid
-        let referred_vid = self.get_vid(referred_vid)?;
-
-        let (transport, tsp_message) = self.seal_message_payload(
-            sender,
-            receiver,
-            None,
-            Payload::Referral {
-                referred_vid: referred_vid.vid.identifier().as_ref(),
-            },
-        )?;
-
-        Ok((transport, tsp_message))
     }
 
     fn make_propositioning_vid(&self, parent_vid: &str) -> Result<OwnedVid, Error> {
@@ -1175,7 +1272,24 @@ impl SecureStore {
         Ok(vid)
     }
 
-    /// Send a message given a route, extracting the next hop and verifying it in the process
+    // Keep the routed relationship-forming scaffolding in place for a future
+    // Reply_Path/routed-accept implementation, even though the public entry
+    // points currently reject routed relationship-forming.
+    #[allow(dead_code)]
+    fn resolve_route<'a>(&'a self, hop_list: &'a [&str]) -> Result<(String, Vec<&'a [u8]>), Error> {
+        let Some(next_hop) = hop_list.first() else {
+            return Err(Error::InvalidRoute(
+                "relationship route must not be empty".into(),
+            ));
+        };
+
+        let next_hop = self.get_verified_vid(next_hop)?.identifier().to_owned();
+        let path = hop_list[1..].iter().map(|x| x.as_bytes()).collect();
+
+        Ok((next_hop, path))
+    }
+
+    #[allow(dead_code)]
     fn resolve_route_and_send(
         &self,
         hop_list: &[&str],
@@ -1197,6 +1311,7 @@ impl SecureStore {
         my_vid: &str,
         other_vid: &str,
         thread_id: Digest,
+        remote_thread_id: Digest,
     ) -> Result<(), Error> {
         let mut vids = self.vids.write()?;
         let Some(context) = vids.get_mut(other_vid) else {
@@ -1222,36 +1337,45 @@ impl SecureStore {
 
         context.relation_status = RelationshipStatus::Bidirectional {
             thread_id: digest,
-            outstanding_nested_thread_ids: Default::default(),
+            remote_thread_id,
+            outstanding_nested_requests: Default::default(),
         };
 
         Ok(())
     }
 
-    fn add_nested_thread_id(&self, vid: &str, thread_id: Digest) -> Result<(), Error> {
+    fn add_pending_nested_request(
+        &self,
+        vid: &str,
+        thread_id: Digest,
+        local_nested_vid: &str,
+    ) -> Result<(), Error> {
         let mut vids = self.vids.write()?;
         let Some(context) = vids.get_mut(vid) else {
             return Err(Error::MissingVid(vid.into()));
         };
 
         let RelationshipStatus::Bidirectional {
-            ref mut outstanding_nested_thread_ids,
+            ref mut outstanding_nested_requests,
             ..
         } = context.relation_status
         else {
             return Err(Error::Relationship(format!("no relationship with {vid}")));
         };
 
-        outstanding_nested_thread_ids.push(thread_id);
+        outstanding_nested_requests.push(PendingNestedRelationship {
+            thread_id,
+            local_nested_vid: local_nested_vid.to_string(),
+        });
 
         Ok(())
     }
 
-    fn add_nested_relation(
+    fn consume_pending_nested_request(
         &self,
         parent_vid: &str,
-        nested_vid: &str,
         thread_id: Digest,
+        expected_local_nested_vid: &str,
     ) -> Result<(), Error> {
         let mut vids = self.vids.write()?;
         let Some(context) = vids.get_mut(parent_vid) else {
@@ -1261,7 +1385,7 @@ impl SecureStore {
         };
 
         let RelationshipStatus::Bidirectional {
-            ref mut outstanding_nested_thread_ids,
+            ref mut outstanding_nested_requests,
             ..
         } = context.relation_status
         else {
@@ -1270,27 +1394,20 @@ impl SecureStore {
             )));
         };
 
-        // find the thread_id in the list of outstanding thread id's of the parent and remove it
-        let Some(index) = outstanding_nested_thread_ids
+        let Some(index) = outstanding_nested_requests
             .iter()
-            .position(|&x| x == thread_id)
+            .position(|request| request.thread_id == thread_id)
         else {
             return Err(Error::Relationship(format!(
-                "cannot find thread_id for nested vid {nested_vid}"
+                "cannot find thread_id for parent vid {parent_vid}"
             )));
         };
-        outstanding_nested_thread_ids.remove(index);
-
-        let Some(context) = vids.get_mut(nested_vid) else {
+        if outstanding_nested_requests[index].local_nested_vid != expected_local_nested_vid {
             return Err(Error::Relationship(format!(
-                "unknown nested vid {nested_vid}"
+                "nested relationship accept receiver mismatch for parent vid {parent_vid}"
             )));
-        };
-
-        context.relation_status = RelationshipStatus::Bidirectional {
-            thread_id,
-            outstanding_nested_thread_ids: Default::default(),
-        };
+        }
+        outstanding_nested_requests.remove(index);
 
         Ok(())
     }
@@ -1301,7 +1418,10 @@ mod test {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use crate::test_utils::*;
-    use crate::{ReceivedTspMessage, RelationshipStatus, VerifiedVid};
+    use crate::{
+        Payload, ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage,
+        RelationshipForm, RelationshipStatus, VerifiedVid,
+    };
 
     fn assert_url_matches(url: &url::Url, expected_receiver: &dyn VerifiedVid) {
         assert_eq!(url.as_str(), expected_receiver.endpoint().as_str());
@@ -1542,7 +1662,7 @@ mod test {
 
     #[test]
     #[wasm_bindgen_test]
-    fn test_make_new_identity() {
+    fn test_open_parallel_relationship_request() {
         let a_store = create_test_store();
         let b_store = create_test_store();
         let (alice, bob) = create_test_vid_pair();
@@ -1550,71 +1670,222 @@ mod test {
 
         a_store.add_private_vid(alice.clone(), None).unwrap();
         b_store.add_private_vid(bob.clone(), None).unwrap();
-        a_store.add_private_vid(charles.clone(), None).unwrap();
-
         a_store.add_verified_vid(bob.clone(), None).unwrap();
         b_store.add_verified_vid(alice.clone(), None).unwrap();
 
-        let status = super::RelationshipStatus::bi_default();
-
-        a_store
-            .replace_relation_status_for_vid(bob.identifier(), status.clone())
-            .unwrap();
-        b_store
-            .replace_relation_status_for_vid(alice.identifier(), status)
-            .unwrap();
-
-        // alice introduces her new identity to bob
+        let mut request_digest = [0; 32];
         let (url, mut sealed) = a_store
-            .make_new_identifier_notice(alice.identifier(), bob.identifier(), charles.identifier())
+            .seal_message_payload_and_hash(
+                alice.identifier(),
+                bob.identifier(),
+                None,
+                Payload::RequestRelationship {
+                    thread_id: Default::default(),
+                    form: RelationshipForm::Parallel {
+                        new_vid: charles.identifier().as_ref(),
+                        sig_new_vid: &[7; 64],
+                    },
+                },
+                Some(&mut request_digest),
+            )
             .unwrap();
 
         assert_url_matches(&url, &bob);
         let received = b_store.open_message(&mut sealed).unwrap();
 
-        let ReceivedTspMessage::NewIdentifier {
+        let ReceivedTspMessage::RequestRelationship {
             sender,
             receiver,
-            new_vid,
+            thread_id: received_request_digest,
+            form:
+                ReceivedRelationshipForm::Parallel {
+                    new_vid,
+                    sig_new_vid,
+                },
+            delivery: ReceivedRelationshipDelivery::Direct,
         } = received
         else {
             panic!("unexpected message type");
         };
         assert_eq!(sender, alice.identifier());
         assert_eq!(receiver, bob.identifier());
+        assert_eq!(received_request_digest, request_digest);
         assert_eq!(new_vid, charles.identifier());
+        assert_eq!(sig_new_vid, &[7; 64]);
     }
 
     #[test]
     #[wasm_bindgen_test]
-    fn test_make_referral() {
-        let store = create_test_store();
+    fn test_open_parallel_relationship_accept() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
         let (alice, bob) = create_test_vid_pair();
-        let charles = create_test_vid();
+        let diana = create_test_vid();
 
-        store.add_private_vid(alice.clone(), None).unwrap();
-        store.add_private_vid(bob.clone(), None).unwrap();
-        store.add_verified_vid(charles.clone(), None).unwrap();
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
 
-        // alice vouches for charlies to bob
-        let (url, mut sealed) = store
-            .make_relationship_referral(alice.identifier(), bob.identifier(), charles.identifier())
+        let mut reply_digest = [0; 32];
+        let (url, mut sealed) = b_store
+            .seal_message_payload_and_hash(
+                bob.identifier(),
+                alice.identifier(),
+                None,
+                Payload::AcceptRelationship {
+                    thread_id: [2; 32],
+                    reply_thread_id: Default::default(),
+                    form: RelationshipForm::Parallel {
+                        new_vid: diana.identifier().as_ref(),
+                        sig_new_vid: &[8; 64],
+                    },
+                },
+                Some(&mut reply_digest),
+            )
             .unwrap();
 
-        assert_url_matches(&url, &bob);
-        let received = store.open_message(&mut sealed).unwrap();
+        assert_url_matches(&url, &alice);
+        let received = a_store.open_message(&mut sealed).unwrap();
 
-        let ReceivedTspMessage::Referral {
+        let ReceivedTspMessage::AcceptRelationship {
             sender,
             receiver,
-            referred_vid,
+            thread_id: request_digest,
+            reply_thread_id: received_reply_digest,
+            form:
+                ReceivedRelationshipForm::Parallel {
+                    new_vid,
+                    sig_new_vid,
+                },
+            delivery: ReceivedRelationshipDelivery::Direct,
         } = received
         else {
             panic!("unexpected message type");
         };
-        assert_eq!(sender, alice.identifier());
-        assert_eq!(receiver, bob.identifier());
-        assert_eq!(referred_vid, charles.identifier());
+        assert_eq!(sender, bob.identifier());
+        assert_eq!(receiver, alice.identifier());
+        assert_eq!(request_digest, [2; 32]);
+        assert_eq!(received_reply_digest, reply_digest);
+        assert_eq!(new_vid, diana.identifier());
+        assert_eq!(sig_new_vid, &[8; 64]);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_direct_relationship_tracks_local_and_remote_thread_ids() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        let (_url, mut request) = a_store
+            .make_relationship_request(alice.identifier(), bob.identifier(), None)
+            .unwrap();
+
+        let request_digest = match a_store
+            .relation_status_for_vid_pair(alice.identifier(), bob.identifier())
+            .unwrap()
+        {
+            RelationshipStatus::Unidirectional { thread_id } => thread_id,
+            status => panic!("unexpected requester status after request: {status}"),
+        };
+
+        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+            b_store.open_message(&mut request).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+        assert_eq!(thread_id, request_digest);
+
+        b_store
+            .set_relation_and_status_for_vid(
+                alice.identifier(),
+                RelationshipStatus::Unidirectional { thread_id },
+                bob.identifier(),
+            )
+            .unwrap();
+
+        let (_url, mut accept) = b_store
+            .make_relationship_accept(bob.identifier(), alice.identifier(), thread_id, None)
+            .unwrap();
+
+        let reply_digest = match b_store
+            .relation_status_for_vid_pair(bob.identifier(), alice.identifier())
+            .unwrap()
+        {
+            RelationshipStatus::Bidirectional {
+                thread_id,
+                remote_thread_id,
+                ..
+            } => {
+                assert_eq!(remote_thread_id, request_digest);
+                thread_id
+            }
+            status => panic!("unexpected replier status after accept: {status}"),
+        };
+
+        let ReceivedTspMessage::AcceptRelationship { .. } =
+            a_store.open_message(&mut accept).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        match a_store
+            .relation_status_for_vid_pair(alice.identifier(), bob.identifier())
+            .unwrap()
+        {
+            RelationshipStatus::Bidirectional {
+                thread_id,
+                remote_thread_id,
+                ..
+            } => {
+                assert_eq!(thread_id, request_digest);
+                assert_eq!(remote_thread_id, reply_digest);
+            }
+            status => panic!("unexpected requester status after accept: {status}"),
+        }
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_relationship_forming_requires_reply_path_for_routes() {
+        let store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let hop = create_test_vid();
+
+        store.add_private_vid(alice.clone(), None).unwrap();
+        store.add_verified_vid(bob.clone(), None).unwrap();
+        store.add_verified_vid(hop.clone(), None).unwrap();
+
+        let err = store
+            .make_relationship_request(
+                alice.identifier(),
+                bob.identifier(),
+                Some(&[hop.identifier()]),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Relationship(message) if message.contains("Reply_Path")
+        ));
+
+        let err = store
+            .make_relationship_accept(
+                alice.identifier(),
+                bob.identifier(),
+                [3; 32],
+                Some(&[hop.identifier()]),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Relationship(message) if message.contains("Reply_Path")
+        ));
     }
 
     #[test]
@@ -1888,13 +2159,16 @@ mod test {
         let received = b_store.open_message(&mut sealed).unwrap();
 
         let ReceivedTspMessage::RequestRelationship {
-            nested_vid: None,
             thread_id,
+            form,
+            delivery,
             ..
         } = received
         else {
             panic!()
         };
+        assert!(matches!(form, ReceivedRelationshipForm::Direct));
+        assert!(matches!(delivery, ReceivedRelationshipDelivery::Direct));
 
         let (_url, mut sealed) = b_store
             .make_relationship_accept(b.identifier(), a.identifier(), thread_id, None)
@@ -1913,27 +2187,38 @@ mod test {
         let received = b_store.open_message(&mut sealed).unwrap();
 
         let ReceivedTspMessage::RequestRelationship {
-            nested_vid: Some(ref nested_vid_1),
             thread_id,
+            form,
+            delivery,
             ..
         } = received
         else {
             panic!()
         };
+        let ReceivedRelationshipDelivery::Nested {
+            nested_vid: nested_vid_1,
+        } = delivery
+        else {
+            panic!()
+        };
+        assert!(matches!(form, ReceivedRelationshipForm::Direct));
 
         let ((_url, mut sealed), nested_b) = b_store
-            .make_nested_relationship_accept(b.identifier(), nested_vid_1, thread_id)
+            .make_nested_relationship_accept(b.identifier(), &nested_vid_1, thread_id)
             .unwrap();
 
         let received = a_store.open_message(&mut sealed).unwrap();
 
-        let ReceivedTspMessage::AcceptRelationship {
-            nested_vid: Some(ref nested_vid_2),
-            ..
-        } = received
+        let ReceivedTspMessage::AcceptRelationship { form, delivery, .. } = received else {
+            panic!()
+        };
+        let ReceivedRelationshipDelivery::Nested {
+            nested_vid: nested_vid_2,
+        } = delivery
         else {
             panic!()
         };
+        assert!(matches!(form, ReceivedRelationshipForm::Direct));
 
         assert_eq!(nested_a.identifier(), nested_vid_1);
         assert_eq!(nested_b.identifier(), nested_vid_2);
@@ -1955,12 +2240,12 @@ mod test {
         );
 
         assert_eq!(
-            b_store.get_vid(nested_vid_1).unwrap().get_parent_vid(),
+            b_store.get_vid(&nested_vid_1).unwrap().get_parent_vid(),
             Some(a.identifier())
         );
 
         assert_eq!(
-            a_store.get_vid(nested_vid_2).unwrap().get_parent_vid(),
+            a_store.get_vid(&nested_vid_2).unwrap().get_parent_vid(),
             Some(b.identifier())
         );
 

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -3,7 +3,8 @@ use crate::{
     cesr::EnvelopeType,
     crypto::CryptoError,
     definitions::{
-        Digest, MessageType, Payload, PendingNestedRelationship, PrivateVid,
+        Digest, MessageType, Payload, PendingIncomingParallelRelationship,
+        PendingNestedRelationship, PendingParallelRelationship, PrivateVid,
         ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage,
         RelationshipForm, RelationshipStatus, VerifiedVid,
     },
@@ -29,6 +30,8 @@ pub(crate) struct VidContext {
     relation_vid: Option<String>,
     parent_vid: Option<String>,
     tunnel: Option<Box<[String]>>,
+    pending_parallel_requests: Vec<PendingParallelRelationship>,
+    pending_incoming_parallel_requests: Vec<PendingIncomingParallelRelationship>,
     metadata: Option<serde_json::Value>,
 }
 
@@ -254,6 +257,10 @@ impl SecureStore {
                 relation_vid: context.relation_vid.clone(),
                 parent_vid: context.parent_vid.clone(),
                 tunnel: context.tunnel.clone(),
+                pending_parallel_requests: context.pending_parallel_requests.clone(),
+                pending_incoming_parallel_requests: context
+                    .pending_incoming_parallel_requests
+                    .clone(),
                 metadata: context.metadata.clone(),
             })
             .collect::<Vec<_>>();
@@ -284,6 +291,8 @@ impl SecureStore {
                     relation_vid: vid.relation_vid,
                     parent_vid: vid.parent_vid,
                     tunnel: vid.tunnel,
+                    pending_parallel_requests: vid.pending_parallel_requests,
+                    pending_incoming_parallel_requests: vid.pending_incoming_parallel_requests,
                     metadata: vid.metadata,
                 },
             );
@@ -334,6 +343,8 @@ impl SecureStore {
                 relation_vid: None,
                 parent_vid: None,
                 tunnel: None,
+                pending_parallel_requests: vec![],
+                pending_incoming_parallel_requests: vec![],
                 metadata,
             });
 
@@ -363,6 +374,8 @@ impl SecureStore {
                 relation_vid: None,
                 parent_vid: None,
                 tunnel: None,
+                pending_parallel_requests: vec![],
+                pending_incoming_parallel_requests: vec![],
                 metadata: metadata
                     .map(serde_json::to_value)
                     .transpose()
@@ -991,9 +1004,11 @@ impl SecureStore {
                     message,
                 )?;
 
-                if let Some(parallel_signature_info) = parallel_signature_info {
-                    self.verify_parallel_relationship_signature(parallel_signature_info)?;
-                }
+                let parallel_sender_vid = parallel_signature_info
+                    .map(|parallel_signature_info| {
+                        self.verify_parallel_relationship_signature(parallel_signature_info)
+                    })
+                    .transpose()?;
                 sender_vid.persist(self)?;
 
                 match payload {
@@ -1085,7 +1100,18 @@ impl SecureStore {
                         })
                     }
                     Payload::RequestRelationship { thread_id, form } => {
+                        if let Some(parallel_sender_vid) = parallel_sender_vid {
+                            parallel_sender_vid.persist(self)?;
+                        }
                         let form = received_relationship_form(form)?;
+
+                        if let ReceivedRelationshipForm::Parallel { new_vid, .. } = &form {
+                            self.add_pending_incoming_parallel_request(
+                                new_vid,
+                                thread_id,
+                                &intended_receiver,
+                            )?;
+                        }
 
                         Ok(ReceivedTspMessage::RequestRelationship {
                             sender,
@@ -1107,6 +1133,26 @@ impl SecureStore {
                             self.upgrade_relation(
                                 receiver_pid.identifier(),
                                 &sender,
+                                thread_id,
+                                reply_thread_id,
+                            )?;
+                        } else {
+                            self.consume_pending_parallel_request(
+                                receiver_pid.identifier(),
+                                thread_id,
+                                &sender,
+                            )?;
+                            let parallel_sender_vid = parallel_sender_vid.ok_or_else(|| {
+                                Error::Relationship(
+                                    "missing verified parallel VID for accept message".into(),
+                                )
+                            })?;
+                            let parallel_sender_identifier =
+                                parallel_sender_vid.as_verified().identifier().to_string();
+                            parallel_sender_vid.persist(self)?;
+                            self.establish_bidirectional_relation(
+                                receiver_pid.identifier(),
+                                &parallel_sender_identifier,
                                 thread_id,
                                 reply_thread_id,
                             )?;
@@ -1318,6 +1364,12 @@ impl SecureStore {
             signature_material.request_nonce,
         )?;
 
+        self.add_pending_parallel_request(
+            receiver.identifier(),
+            thread_id,
+            sender_new_vid.identifier(),
+        )?;
+
         Ok((receiver.endpoint().clone(), tsp_message.to_owned()))
     }
 
@@ -1350,15 +1402,7 @@ impl SecureStore {
             Some(&mut reply_thread_id),
         )?;
 
-        self.set_relation_and_status_for_vid(
-            receiver,
-            RelationshipStatus::Bidirectional {
-                thread_id: reply_thread_id,
-                remote_thread_id: thread_id,
-                outstanding_nested_requests: Default::default(),
-            },
-            sender,
-        )?;
+        self.establish_bidirectional_relation(sender, receiver, reply_thread_id, thread_id)?;
 
         Ok((transport, tsp_message))
     }
@@ -1372,17 +1416,20 @@ impl SecureStore {
     ) -> Result<(Url, Vec<u8>), Error> {
         let sender_new_vid = self.get_private_vid(sender_new_vid)?;
         let receiver_new_vid = self.get_verified_vid(receiver_new_vid)?;
+        let pending_incoming_request =
+            self.find_pending_incoming_parallel_request(receiver_new_vid.identifier(), thread_id)?;
+        let outer_sender = self.get_private_vid(&pending_incoming_request.local_outer_vid)?;
         let signature_material = self.build_parallel_signature_material(
             &*sender_new_vid,
             ParallelSignatureContext::Accept {
-                sender_identity: sender_new_vid.identifier(),
+                sender_identity: outer_sender.identifier(),
                 thread_id,
             },
         )?;
         let mut reply_thread_id = signature_material.digest;
 
         let tsp_message = crate::crypto::seal_and_hash(
-            &*sender_new_vid,
+            &*outer_sender,
             &*receiver_new_vid,
             None,
             Payload::AcceptRelationship {
@@ -1395,6 +1442,14 @@ impl SecureStore {
             },
             Some(&mut reply_thread_id),
         )?;
+
+        self.establish_bidirectional_relation(
+            sender_new_vid.identifier(),
+            receiver_new_vid.identifier(),
+            reply_thread_id,
+            thread_id,
+        )?;
+        self.remove_pending_incoming_parallel_request(receiver_new_vid.identifier(), thread_id)?;
 
         Ok((receiver_new_vid.endpoint().clone(), tsp_message.to_owned()))
     }
@@ -1539,6 +1594,24 @@ impl SecureStore {
         self.add_verified_vid(nested_vid, None)
     }
 
+    fn establish_bidirectional_relation(
+        &self,
+        my_vid: &str,
+        other_vid: &str,
+        thread_id: Digest,
+        remote_thread_id: Digest,
+    ) -> Result<(), Error> {
+        self.set_relation_and_status_for_vid(
+            other_vid,
+            RelationshipStatus::Bidirectional {
+                thread_id,
+                remote_thread_id,
+                outstanding_nested_requests: Default::default(),
+            },
+            my_vid,
+        )
+    }
+
     fn upgrade_relation(
         &self,
         my_vid: &str,
@@ -1580,7 +1653,7 @@ impl SecureStore {
     fn verify_parallel_relationship_signature(
         &self,
         parallel_signature_info: crate::crypto::ParallelSignatureInfo<'_>,
-    ) -> Result<(), Error> {
+    ) -> Result<DeferredVerifiedVid, Error> {
         let new_vid = std::str::from_utf8(parallel_signature_info.new_vid)?;
         let verified_vid = self.get_verified_vid_or_resolve_offline(new_vid, |error| {
             unverified_parallel_vid_error(new_vid, error)
@@ -1591,9 +1664,156 @@ impl SecureStore {
             &parallel_signature_info.signed_data,
             parallel_signature_info.sig_new_vid,
         )?;
-        verified_vid.persist(self)?;
+
+        Ok(verified_vid)
+    }
+
+    fn add_pending_parallel_request(
+        &self,
+        outer_receiver: &str,
+        thread_id: Digest,
+        local_parallel_vid: &str,
+    ) -> Result<(), Error> {
+        let mut vids = self.vids.write()?;
+        let Some(outer_context) = vids.get(outer_receiver) else {
+            return Err(Error::MissingVid(outer_receiver.into()));
+        };
+
+        if !matches!(
+            outer_context.relation_status,
+            RelationshipStatus::Bidirectional { .. }
+        ) {
+            return Err(Error::Relationship(format!(
+                "no bidirectional relationship with {outer_receiver}"
+            )));
+        }
+
+        let Some(local_context) = vids.get_mut(local_parallel_vid) else {
+            return Err(Error::MissingVid(local_parallel_vid.into()));
+        };
+
+        local_context
+            .pending_parallel_requests
+            .push(PendingParallelRelationship {
+                thread_id,
+                local_parallel_vid: local_parallel_vid.to_string(),
+                outer_receiver: outer_receiver.to_string(),
+            });
 
         Ok(())
+    }
+
+    fn add_pending_incoming_parallel_request(
+        &self,
+        remote_parallel_vid: &str,
+        thread_id: Digest,
+        local_outer_vid: &str,
+    ) -> Result<(), Error> {
+        let mut vids = self.vids.write()?;
+        let Some(remote_context) = vids.get_mut(remote_parallel_vid) else {
+            return Err(Error::MissingVid(remote_parallel_vid.into()));
+        };
+
+        remote_context.pending_incoming_parallel_requests.push(
+            PendingIncomingParallelRelationship {
+                thread_id,
+                local_outer_vid: local_outer_vid.to_string(),
+            },
+        );
+
+        Ok(())
+    }
+
+    fn find_pending_incoming_parallel_request(
+        &self,
+        remote_parallel_vid: &str,
+        thread_id: Digest,
+    ) -> Result<PendingIncomingParallelRelationship, Error> {
+        let vids = self.vids.read()?;
+        let Some(remote_context) = vids.get(remote_parallel_vid) else {
+            return Err(Error::MissingVid(remote_parallel_vid.into()));
+        };
+
+        remote_context
+            .pending_incoming_parallel_requests
+            .iter()
+            .find(|request| request.thread_id == thread_id)
+            .cloned()
+            .ok_or_else(|| {
+                Error::Relationship(format!(
+                    "cannot find pending incoming parallel request for {remote_parallel_vid}"
+                ))
+            })
+    }
+
+    fn remove_pending_incoming_parallel_request(
+        &self,
+        remote_parallel_vid: &str,
+        thread_id: Digest,
+    ) -> Result<(), Error> {
+        let mut vids = self.vids.write()?;
+        let Some(remote_context) = vids.get_mut(remote_parallel_vid) else {
+            return Err(Error::MissingVid(remote_parallel_vid.into()));
+        };
+
+        let Some(index) = remote_context
+            .pending_incoming_parallel_requests
+            .iter()
+            .position(|request| request.thread_id == thread_id)
+        else {
+            return Err(Error::Relationship(format!(
+                "cannot find pending incoming parallel request for {remote_parallel_vid}"
+            )));
+        };
+        remote_context
+            .pending_incoming_parallel_requests
+            .remove(index);
+
+        Ok(())
+    }
+
+    fn consume_pending_parallel_request(
+        &self,
+        local_parallel_vid: &str,
+        thread_id: Digest,
+        expected_outer_receiver: &str,
+    ) -> Result<(), Error> {
+        let mut vids = self.vids.write()?;
+
+        let Some(local_context) = vids.get_mut(local_parallel_vid) else {
+            return Err(Error::MissingVid(local_parallel_vid.into()));
+        };
+
+        if let Some(index) = local_context
+            .pending_parallel_requests
+            .iter()
+            .position(|request| {
+                request.thread_id == thread_id
+                    && request.local_parallel_vid == local_parallel_vid
+                    && request.outer_receiver == expected_outer_receiver
+            })
+        {
+            local_context.pending_parallel_requests.remove(index);
+            return Ok(());
+        }
+
+        if local_context
+            .pending_parallel_requests
+            .iter()
+            .any(|request| {
+                request.thread_id == thread_id
+                    && request.local_parallel_vid == local_parallel_vid
+                    && !request.outer_receiver.is_empty()
+            })
+        {
+            return Err(Error::Relationship(format!(
+                "parallel relationship accept sender mismatch for {local_parallel_vid}"
+            )));
+        }
+
+        Err(Error::Relationship(format!(
+            "cannot find pending parallel request for {local_parallel_vid}"
+        )))
     }
 
     fn add_pending_nested_request(
@@ -1673,8 +1893,9 @@ mod test {
     use crate::store::relationship_digest_algorithm;
     use crate::test_utils::*;
     use crate::{
-        Error, Payload, ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage,
-        RelationshipForm, RelationshipStatus, SecureStore, VerifiedVid, crypto::CryptoError,
+        Error, Payload, PendingParallelRelationship, ReceivedRelationshipDelivery,
+        ReceivedRelationshipForm, ReceivedTspMessage, RelationshipForm, RelationshipStatus,
+        SecureStore, VerifiedVid, crypto::CryptoError,
     };
 
     fn assert_url_matches(url: &url::Url, expected_receiver: &dyn VerifiedVid) {
@@ -1709,6 +1930,13 @@ mod test {
                 b_vid.identifier(),
             )
             .unwrap();
+    }
+
+    fn reopen_store(store: &SecureStore) -> SecureStore {
+        let reopened = SecureStore::new();
+        let (vids, aliases, keys) = store.export().unwrap();
+        reopened.import(vids, aliases, keys).unwrap();
+        reopened
     }
 
     #[test]
@@ -2040,6 +2268,20 @@ mod test {
             .unwrap();
 
         assert_url_matches(&url, &alice_parallel);
+        let RelationshipStatus::Bidirectional {
+            thread_id: sender_thread_id,
+            remote_thread_id: sender_remote_thread_id,
+            outstanding_nested_requests,
+        } = b_store
+            .relation_status_for_vid_pair(bob_parallel.identifier(), alice_parallel.identifier())
+            .unwrap()
+        else {
+            panic!("parallel accept did not establish sender-side relationship");
+        };
+        assert_eq!(sender_remote_thread_id, thread_id);
+        assert!(sender_thread_id.iter().any(|byte| *byte != 0));
+        assert!(outstanding_nested_requests.is_empty());
+
         let received = a_store.open_message(&mut sealed).unwrap();
 
         let ReceivedTspMessage::AcceptRelationship {
@@ -2057,7 +2299,7 @@ mod test {
         else {
             panic!("unexpected message type");
         };
-        assert_eq!(sender, bob_parallel.identifier());
+        assert_eq!(sender, bob.identifier());
         assert_eq!(receiver, alice_parallel.identifier());
         assert_eq!(new_vid, bob_parallel.identifier());
         assert_eq!(
@@ -2070,6 +2312,316 @@ mod test {
         assert_eq!(request_digest, thread_id);
         assert!(received_reply_digest.iter().any(|byte| *byte != 0));
         assert_eq!(sig_new_vid.len(), 64);
+
+        let RelationshipStatus::Bidirectional {
+            thread_id: receiver_thread_id,
+            remote_thread_id: receiver_remote_thread_id,
+            outstanding_nested_requests,
+        } = a_store
+            .relation_status_for_vid_pair(alice_parallel.identifier(), bob_parallel.identifier())
+            .unwrap()
+        else {
+            panic!("parallel accept did not establish receiver-side relationship");
+        };
+        assert_eq!(receiver_thread_id, thread_id);
+        assert_eq!(receiver_remote_thread_id, received_reply_digest);
+        assert!(outstanding_nested_requests.is_empty());
+        assert_eq!(sender_thread_id, received_reply_digest);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_accept_requires_pending_request() {
+        let b_store = create_test_store();
+        let alice_parallel = create_test_vid();
+        let bob_parallel = create_test_vid();
+
+        b_store.add_private_vid(bob_parallel.clone(), None).unwrap();
+        b_store
+            .add_verified_vid(alice_parallel.clone(), None)
+            .unwrap();
+
+        let random_thread_id = [7; 32];
+        let Err(Error::Relationship(message)) = b_store.make_parallel_relationship_accept(
+            bob_parallel.identifier(),
+            alice_parallel.identifier(),
+            random_thread_id,
+        ) else {
+            panic!("unexpected accept construction result");
+        };
+
+        assert!(message.contains("pending incoming parallel request"));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_accept_after_reopen() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let alice_parallel = create_test_vid();
+        let bob_parallel = create_test_vid();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
+        b_store.add_private_vid(bob_parallel.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let (_url, mut request) = a_store
+            .make_parallel_relationship_request(
+                alice.identifier(),
+                bob.identifier(),
+                alice_parallel.identifier(),
+            )
+            .unwrap();
+        let reopened_a_store = reopen_store(&a_store);
+
+        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+            b_store.open_message(&mut request).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        let (_url, mut accept) = b_store
+            .make_parallel_relationship_accept(
+                bob_parallel.identifier(),
+                alice_parallel.identifier(),
+                thread_id,
+            )
+            .unwrap();
+
+        let ReceivedTspMessage::AcceptRelationship {
+            reply_thread_id, ..
+        } = reopened_a_store.open_message(&mut accept).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        match reopened_a_store
+            .relation_status_for_vid_pair(alice_parallel.identifier(), bob_parallel.identifier())
+            .unwrap()
+        {
+            RelationshipStatus::Bidirectional {
+                thread_id: reopened_thread_id,
+                remote_thread_id,
+                ..
+            } => {
+                assert_eq!(reopened_thread_id, thread_id);
+                assert_eq!(remote_thread_id, reply_thread_id);
+            }
+            status => panic!("unexpected requester status after reopen: {status}"),
+        }
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_accept_can_be_sent_after_receiver_reopen() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let alice_parallel = create_test_vid();
+        let bob_parallel = create_test_vid();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
+        b_store.add_private_vid(bob_parallel.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let (_url, mut request) = a_store
+            .make_parallel_relationship_request(
+                alice.identifier(),
+                bob.identifier(),
+                alice_parallel.identifier(),
+            )
+            .unwrap();
+        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+            b_store.open_message(&mut request).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        let reopened_b_store = reopen_store(&b_store);
+        let (_url, mut accept) = reopened_b_store
+            .make_parallel_relationship_accept(
+                bob_parallel.identifier(),
+                alice_parallel.identifier(),
+                thread_id,
+            )
+            .unwrap();
+
+        let ReceivedTspMessage::AcceptRelationship {
+            sender,
+            form: ReceivedRelationshipForm::Parallel { new_vid, .. },
+            ..
+        } = a_store.open_message(&mut accept).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        assert_eq!(sender, bob.identifier());
+        assert_eq!(new_vid, bob_parallel.identifier());
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_accept_rejects_wrong_outer_sender() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let c_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let alice_parallel = create_test_vid();
+        let charlie = create_test_vid();
+        let charlie_parallel = create_test_vid();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let (_url, mut request) = a_store
+            .make_parallel_relationship_request(
+                alice.identifier(),
+                bob.identifier(),
+                alice_parallel.identifier(),
+            )
+            .unwrap();
+        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+            b_store.open_message(&mut request).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        c_store.add_private_vid(charlie.clone(), None).unwrap();
+        c_store
+            .add_private_vid(charlie_parallel.clone(), None)
+            .unwrap();
+        c_store
+            .add_verified_vid(alice_parallel.clone(), None)
+            .unwrap();
+
+        let mut reply_thread_id = [0_u8; 32];
+        let signed_data = crate::crypto::build_parallel_accept_signed_data(
+            &thread_id,
+            Some(charlie.identifier().as_bytes()),
+            relationship_digest_algorithm(),
+            &mut reply_thread_id,
+            charlie_parallel.identifier().as_bytes(),
+        )
+        .unwrap();
+        let sig_new_vid = crate::crypto::sign_detached(&charlie_parallel, &signed_data).unwrap();
+        let forged_sender = c_store.get_private_vid(charlie.identifier()).unwrap();
+        let forged_receiver = c_store
+            .get_verified_vid(alice_parallel.identifier())
+            .unwrap();
+        let mut forged_accept = crate::crypto::seal_and_hash(
+            &*forged_sender,
+            &*forged_receiver,
+            None,
+            Payload::AcceptRelationship {
+                thread_id,
+                reply_thread_id: Default::default(),
+                form: RelationshipForm::Parallel {
+                    new_vid: charlie_parallel.identifier().as_bytes(),
+                    sig_new_vid: sig_new_vid.as_slice(),
+                },
+            },
+            Some(&mut reply_thread_id),
+        )
+        .unwrap();
+
+        let Err(Error::Relationship(message)) = a_store.open_message(&mut forged_accept) else {
+            panic!("unexpected message result");
+        };
+        assert!(message.contains("sender mismatch"));
+        assert!(matches!(
+            a_store
+                .relation_status_for_vid_pair(
+                    alice_parallel.identifier(),
+                    charlie_parallel.identifier()
+                )
+                .unwrap(),
+            RelationshipStatus::Unrelated
+        ));
+
+        let (vids, _, _) = a_store.export().unwrap();
+        let Some(alice_parallel_export) = vids
+            .iter()
+            .find(|vid| vid.id == alice_parallel.identifier())
+        else {
+            panic!("missing exported local parallel vid");
+        };
+        assert_eq!(alice_parallel_export.pending_parallel_requests.len(), 1);
+        assert_eq!(
+            alice_parallel_export.pending_parallel_requests[0].outer_receiver,
+            bob.identifier()
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_request_is_tracked_on_local_parallel_vid() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let alice_parallel = create_test_vid();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let (_url, mut request) = a_store
+            .make_parallel_relationship_request(
+                alice.identifier(),
+                bob.identifier(),
+                alice_parallel.identifier(),
+            )
+            .unwrap();
+
+        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+            b_store.open_message(&mut request).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        let (vids, _, _) = a_store.export().unwrap();
+        let Some(alice_parallel_export) = vids
+            .iter()
+            .find(|vid| vid.id == alice_parallel.identifier())
+        else {
+            panic!("missing exported local parallel vid");
+        };
+        assert_eq!(
+            alice_parallel_export.pending_parallel_requests,
+            vec![PendingParallelRelationship {
+                thread_id,
+                local_parallel_vid: alice_parallel.identifier().to_string(),
+                outer_receiver: bob.identifier().to_string(),
+            }]
+        );
+
+        let Some(bob_export) = vids.iter().find(|vid| vid.id == bob.identifier()) else {
+            panic!("missing exported outer receiver vid");
+        };
+        assert!(bob_export.pending_parallel_requests.is_empty());
     }
 
     #[test]

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -90,6 +90,18 @@ fn nested_digest(bytes: &[u8]) -> Digest {
     }
 }
 
+fn relationship_digest_algorithm() -> crate::crypto::RelationshipDigestAlgorithm {
+    #[cfg(feature = "nacl")]
+    {
+        crate::crypto::RelationshipDigestAlgorithm::Blake2b256
+    }
+
+    #[cfg(not(feature = "nacl"))]
+    {
+        crate::crypto::RelationshipDigestAlgorithm::Sha2_256
+    }
+}
+
 fn nested_digest_field<'a>(digest: &'a Digest) -> crate::cesr::Digest<'a> {
     #[cfg(feature = "nacl")]
     {
@@ -127,6 +139,76 @@ fn received_relationship_form<'a>(
             sig_new_vid,
         }),
     }
+}
+
+fn unverified_parallel_vid_error(vid: &str, error: VidError) -> Error {
+    match error {
+        VidError::InvalidVid(_) => Error::UnverifiedVid(vid.to_string()),
+        other => other.into(),
+    }
+}
+
+fn unverified_source_error(vid: &str) -> Error {
+    #[cfg(feature = "async")]
+    {
+        Error::UnverifiedSource(vid.to_string(), None)
+    }
+
+    #[cfg(not(feature = "async"))]
+    {
+        Error::UnverifiedSource(vid.to_string())
+    }
+}
+
+fn requires_existing_parallel_relationship_error() -> Error {
+    Error::Relationship(
+        "parallel relationship-forming requires an existing bidirectional relationship".into(),
+    )
+}
+
+enum DeferredVerifiedVid {
+    Known(Arc<dyn VerifiedVid>),
+    Deferred(crate::Vid),
+}
+
+impl DeferredVerifiedVid {
+    fn as_verified(&self) -> &dyn VerifiedVid {
+        match self {
+            DeferredVerifiedVid::Known(vid) => &**vid,
+            DeferredVerifiedVid::Deferred(vid) => vid,
+        }
+    }
+
+    fn persist(self, store: &SecureStore) -> Result<(), Error> {
+        if let DeferredVerifiedVid::Deferred(vid) = self {
+            store.add_verified_vid(vid, None)?;
+        }
+
+        Ok(())
+    }
+}
+
+struct ParallelSignatureMaterial {
+    digest: Digest,
+    sig_new_vid: Vec<u8>,
+    request_nonce: Option<[u8; 32]>,
+}
+
+enum ParallelSignatureContext<'a> {
+    Request {
+        sender_identity: &'a str,
+        nonce: [u8; 32],
+    },
+    Accept {
+        sender_identity: &'a str,
+        thread_id: Digest,
+    },
+}
+
+fn random_nonce_bytes() -> [u8; 32] {
+    let mut nonce_bytes = [0_u8; 32];
+    StdRng::from_entropy().fill_bytes(&mut nonce_bytes);
+    nonce_bytes
 }
 
 pub type Aliases = HashMap<String, String>;
@@ -435,6 +517,20 @@ impl SecureStore {
     /// Retrieve the [VerifiedVid] identified by `vid` from the wallet if it exists.
     pub fn get_verified_vid(&self, vid: &str) -> Result<Arc<dyn VerifiedVid>, Error> {
         Ok(self.get_vid(vid)?.vid)
+    }
+
+    fn get_verified_vid_or_resolve_offline(
+        &self,
+        vid: &str,
+        map_offline_error: impl FnOnce(VidError) -> Error,
+    ) -> Result<DeferredVerifiedVid, Error> {
+        match self.get_verified_vid(vid) {
+            Ok(verified_vid) => Ok(DeferredVerifiedVid::Known(verified_vid)),
+            Err(Error::UnverifiedVid(_)) => Ok(DeferredVerifiedVid::Deferred(
+                verify_vid_offline(vid).map_err(map_offline_error)?,
+            )),
+            Err(error) => Err(error),
+        }
     }
 
     /// Retrieve the [VidContext] identified by `vid` from the wallet, if it exists.
@@ -882,16 +978,23 @@ impl SecureStore {
                 };
 
                 let sender = std::str::from_utf8(sender)?.to_string();
+                let sender_vid = self.get_verified_vid_or_resolve_offline(&sender, |_| {
+                    unverified_source_error(&sender)
+                })?;
 
-                let Ok(sender_vid) = self.get_verified_vid(&sender) else {
-                    #[cfg(feature = "async")]
-                    return Err(Error::UnverifiedSource(sender, None));
-                    #[cfg(not(feature = "async"))]
-                    return Err(Error::UnverifiedSource(sender));
-                };
+                let (
+                    (nonconfidential_data, payload, crypto_type, signature_type),
+                    parallel_signature_info,
+                ) = crate::crypto::open_with_signature_info(
+                    &*receiver_pid,
+                    sender_vid.as_verified(),
+                    message,
+                )?;
 
-                let (nonconfidential_data, payload, crypto_type, signature_type) =
-                    crate::crypto::open(&*receiver_pid, &*sender_vid, message)?;
+                if let Some(parallel_signature_info) = parallel_signature_info {
+                    self.verify_parallel_relationship_signature(parallel_signature_info)?;
+                }
+                sender_vid.persist(self)?;
 
                 match payload {
                     Payload::Content(message) => Ok(ReceivedTspMessage::GenericMessage {
@@ -1124,6 +1227,100 @@ impl SecureStore {
         Ok((receiver.endpoint().clone(), tsp_message.to_owned()))
     }
 
+    fn build_parallel_signature_material(
+        &self,
+        sender_new_vid: &dyn PrivateVid,
+        context: ParallelSignatureContext<'_>,
+    ) -> Result<ParallelSignatureMaterial, Error> {
+        let digest_algorithm = relationship_digest_algorithm();
+        let mut digest = [0_u8; 32];
+
+        let (signed_data, request_nonce) = match context {
+            ParallelSignatureContext::Request {
+                sender_identity,
+                nonce,
+            } => (
+                crate::crypto::build_parallel_request_signed_data(
+                    Some(sender_identity.as_bytes()),
+                    digest_algorithm,
+                    nonce,
+                    &mut digest,
+                    sender_new_vid.identifier().as_bytes(),
+                )?,
+                Some(nonce),
+            ),
+            ParallelSignatureContext::Accept {
+                sender_identity,
+                thread_id,
+            } => (
+                crate::crypto::build_parallel_accept_signed_data(
+                    &thread_id,
+                    Some(sender_identity.as_bytes()),
+                    digest_algorithm,
+                    &mut digest,
+                    sender_new_vid.identifier().as_bytes(),
+                )?,
+                None,
+            ),
+        };
+
+        let sig_new_vid = crate::crypto::sign_detached(sender_new_vid, &signed_data)?;
+
+        Ok(ParallelSignatureMaterial {
+            digest,
+            sig_new_vid,
+            request_nonce,
+        })
+    }
+
+    /// Make a parallel relationship request using an existing relationship as a referral.
+    pub fn make_parallel_relationship_request(
+        &self,
+        sender: &str,
+        receiver: &str,
+        sender_new_vid: &str,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        let sender = self.get_private_vid(sender)?;
+        let receiver = self.get_verified_vid(receiver)?;
+        let sender_new_vid = self.get_private_vid(sender_new_vid)?;
+
+        match self.relation_status_for_vid_pair(sender.identifier(), receiver.identifier())? {
+            RelationshipStatus::Bidirectional { .. } => {}
+            RelationshipStatus::_Controlled
+            | RelationshipStatus::Unidirectional { .. }
+            | RelationshipStatus::ReverseUnidirectional { .. }
+            | RelationshipStatus::Unrelated => {
+                return Err(requires_existing_parallel_relationship_error());
+            }
+        }
+
+        let signature_material = self.build_parallel_signature_material(
+            &*sender_new_vid,
+            ParallelSignatureContext::Request {
+                sender_identity: sender.identifier(),
+                nonce: random_nonce_bytes(),
+            },
+        )?;
+        let mut thread_id = signature_material.digest;
+
+        let tsp_message = crate::crypto::seal_and_hash_with_relationship_nonce(
+            &*sender,
+            &*receiver,
+            None,
+            Payload::RequestRelationship {
+                thread_id: Default::default(),
+                form: RelationshipForm::Parallel {
+                    new_vid: sender_new_vid.identifier().as_bytes(),
+                    sig_new_vid: signature_material.sig_new_vid.as_slice(),
+                },
+            },
+            Some(&mut thread_id),
+            signature_material.request_nonce,
+        )?;
+
+        Ok((receiver.endpoint().clone(), tsp_message.to_owned()))
+    }
+
     /// Accept a direct relationship between the resolved VIDs identifier by `sender` and `receiver`.
     /// `thread_id` must be the same as the one that was present in the relationship request.
     /// Encodes the control message, encrypts, signs and sends a TSP message
@@ -1164,6 +1361,42 @@ impl SecureStore {
         )?;
 
         Ok((transport, tsp_message))
+    }
+
+    /// Make a parallel relationship accept message over the new relationship.
+    pub fn make_parallel_relationship_accept(
+        &self,
+        sender_new_vid: &str,
+        receiver_new_vid: &str,
+        thread_id: Digest,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        let sender_new_vid = self.get_private_vid(sender_new_vid)?;
+        let receiver_new_vid = self.get_verified_vid(receiver_new_vid)?;
+        let signature_material = self.build_parallel_signature_material(
+            &*sender_new_vid,
+            ParallelSignatureContext::Accept {
+                sender_identity: sender_new_vid.identifier(),
+                thread_id,
+            },
+        )?;
+        let mut reply_thread_id = signature_material.digest;
+
+        let tsp_message = crate::crypto::seal_and_hash(
+            &*sender_new_vid,
+            &*receiver_new_vid,
+            None,
+            Payload::AcceptRelationship {
+                thread_id,
+                reply_thread_id: Default::default(),
+                form: RelationshipForm::Parallel {
+                    new_vid: sender_new_vid.identifier().as_bytes(),
+                    sig_new_vid: signature_material.sig_new_vid.as_slice(),
+                },
+            },
+            Some(&mut reply_thread_id),
+        )?;
+
+        Ok((receiver_new_vid.endpoint().clone(), tsp_message.to_owned()))
     }
 
     /// Cancels a direct relationship between the resolved `sender` and `receiver` VIDs.
@@ -1344,6 +1577,25 @@ impl SecureStore {
         Ok(())
     }
 
+    fn verify_parallel_relationship_signature(
+        &self,
+        parallel_signature_info: crate::crypto::ParallelSignatureInfo<'_>,
+    ) -> Result<(), Error> {
+        let new_vid = std::str::from_utf8(parallel_signature_info.new_vid)?;
+        let verified_vid = self.get_verified_vid_or_resolve_offline(new_vid, |error| {
+            unverified_parallel_vid_error(new_vid, error)
+        })?;
+
+        crate::crypto::verify_detached(
+            verified_vid.as_verified(),
+            &parallel_signature_info.signed_data,
+            parallel_signature_info.sig_new_vid,
+        )?;
+        verified_vid.persist(self)?;
+
+        Ok(())
+    }
+
     fn add_pending_nested_request(
         &self,
         vid: &str,
@@ -1415,16 +1667,48 @@ impl SecureStore {
 
 #[cfg(test)]
 mod test {
+    use rand::{RngCore, SeedableRng, rngs::StdRng};
     use wasm_bindgen_test::wasm_bindgen_test;
 
+    use crate::store::relationship_digest_algorithm;
     use crate::test_utils::*;
     use crate::{
-        Payload, ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage,
-        RelationshipForm, RelationshipStatus, VerifiedVid,
+        Error, Payload, ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage,
+        RelationshipForm, RelationshipStatus, SecureStore, VerifiedVid, crypto::CryptoError,
     };
 
     fn assert_url_matches(url: &url::Url, expected_receiver: &dyn VerifiedVid) {
         assert_eq!(url.as_str(), expected_receiver.endpoint().as_str());
+    }
+
+    fn establish_existing_relationship(
+        a_store: &SecureStore,
+        a_vid: &dyn VerifiedVid,
+        b_store: &SecureStore,
+        b_vid: &dyn VerifiedVid,
+    ) {
+        a_store
+            .set_relation_and_status_for_vid(
+                b_vid.identifier(),
+                RelationshipStatus::Bidirectional {
+                    thread_id: [1; 32],
+                    remote_thread_id: [2; 32],
+                    outstanding_nested_requests: vec![],
+                },
+                a_vid.identifier(),
+            )
+            .unwrap();
+        b_store
+            .set_relation_and_status_for_vid(
+                a_vid.identifier(),
+                RelationshipStatus::Bidirectional {
+                    thread_id: [2; 32],
+                    remote_thread_id: [1; 32],
+                    outstanding_nested_requests: vec![],
+                },
+                b_vid.identifier(),
+            )
+            .unwrap();
     }
 
     #[test]
@@ -1666,27 +1950,21 @@ mod test {
         let a_store = create_test_store();
         let b_store = create_test_store();
         let (alice, bob) = create_test_vid_pair();
-        let charles = create_test_vid();
+        let alice_parallel = create_test_vid();
 
         a_store.add_private_vid(alice.clone(), None).unwrap();
         b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
         a_store.add_verified_vid(bob.clone(), None).unwrap();
         b_store.add_verified_vid(alice.clone(), None).unwrap();
-
-        let mut request_digest = [0; 32];
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
         let (url, mut sealed) = a_store
-            .seal_message_payload_and_hash(
+            .make_parallel_relationship_request(
                 alice.identifier(),
                 bob.identifier(),
-                None,
-                Payload::RequestRelationship {
-                    thread_id: Default::default(),
-                    form: RelationshipForm::Parallel {
-                        new_vid: charles.identifier().as_ref(),
-                        sig_new_vid: &[7; 64],
-                    },
-                },
-                Some(&mut request_digest),
+                alice_parallel.identifier(),
             )
             .unwrap();
 
@@ -1709,9 +1987,16 @@ mod test {
         };
         assert_eq!(sender, alice.identifier());
         assert_eq!(receiver, bob.identifier());
-        assert_eq!(received_request_digest, request_digest);
-        assert_eq!(new_vid, charles.identifier());
-        assert_eq!(sig_new_vid, &[7; 64]);
+        assert_eq!(new_vid, alice_parallel.identifier());
+        assert_eq!(
+            b_store
+                .get_verified_vid(alice_parallel.identifier())
+                .unwrap()
+                .identifier(),
+            alice_parallel.identifier()
+        );
+        assert!(received_request_digest.iter().any(|byte| *byte != 0));
+        assert_eq!(sig_new_vid.len(), 64);
     }
 
     #[test]
@@ -1720,32 +2005,41 @@ mod test {
         let a_store = create_test_store();
         let b_store = create_test_store();
         let (alice, bob) = create_test_vid_pair();
-        let diana = create_test_vid();
+        let alice_parallel = create_test_vid();
+        let bob_parallel = create_test_vid();
 
         a_store.add_private_vid(alice.clone(), None).unwrap();
         b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
+        b_store.add_private_vid(bob_parallel.clone(), None).unwrap();
         a_store.add_verified_vid(bob.clone(), None).unwrap();
         b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
 
-        let mut reply_digest = [0; 32];
-        let (url, mut sealed) = b_store
-            .seal_message_payload_and_hash(
-                bob.identifier(),
+        let (_url, mut request) = a_store
+            .make_parallel_relationship_request(
                 alice.identifier(),
-                None,
-                Payload::AcceptRelationship {
-                    thread_id: [2; 32],
-                    reply_thread_id: Default::default(),
-                    form: RelationshipForm::Parallel {
-                        new_vid: diana.identifier().as_ref(),
-                        sig_new_vid: &[8; 64],
-                    },
-                },
-                Some(&mut reply_digest),
+                bob.identifier(),
+                alice_parallel.identifier(),
+            )
+            .unwrap();
+        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+            b_store.open_message(&mut request).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+
+        let (url, mut sealed) = b_store
+            .make_parallel_relationship_accept(
+                bob_parallel.identifier(),
+                alice_parallel.identifier(),
+                thread_id,
             )
             .unwrap();
 
-        assert_url_matches(&url, &alice);
+        assert_url_matches(&url, &alice_parallel);
         let received = a_store.open_message(&mut sealed).unwrap();
 
         let ReceivedTspMessage::AcceptRelationship {
@@ -1763,12 +2057,142 @@ mod test {
         else {
             panic!("unexpected message type");
         };
-        assert_eq!(sender, bob.identifier());
-        assert_eq!(receiver, alice.identifier());
-        assert_eq!(request_digest, [2; 32]);
-        assert_eq!(received_reply_digest, reply_digest);
-        assert_eq!(new_vid, diana.identifier());
-        assert_eq!(sig_new_vid, &[8; 64]);
+        assert_eq!(sender, bob_parallel.identifier());
+        assert_eq!(receiver, alice_parallel.identifier());
+        assert_eq!(new_vid, bob_parallel.identifier());
+        assert_eq!(
+            a_store
+                .get_verified_vid(bob_parallel.identifier())
+                .unwrap()
+                .identifier(),
+            bob_parallel.identifier()
+        );
+        assert_eq!(request_digest, thread_id);
+        assert!(received_reply_digest.iter().any(|byte| *byte != 0));
+        assert_eq!(sig_new_vid.len(), 64);
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_request_rejects_invalid_signature_new() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let alice_parallel = create_test_vid();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_private_vid(alice_parallel.clone(), None)
+            .unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        let mut nonce_bytes = [0_u8; 32];
+        StdRng::from_entropy().fill_bytes(&mut nonce_bytes);
+        let mut thread_id = [0_u8; 32];
+        let signed_data = crate::crypto::build_parallel_request_signed_data(
+            Some(alice.identifier().as_bytes()),
+            relationship_digest_algorithm(),
+            nonce_bytes,
+            &mut thread_id,
+            alice_parallel.identifier().as_bytes(),
+        )
+        .unwrap();
+        let mut sig_new_vid = crate::crypto::sign_detached(&alice_parallel, &signed_data).unwrap();
+        sig_new_vid[0] ^= 0x01;
+
+        let sender_vid = a_store.get_private_vid(alice.identifier()).unwrap();
+        let receiver_vid = a_store.get_verified_vid(bob.identifier()).unwrap();
+        let mut request_digest = Default::default();
+        let mut sealed = crate::crypto::seal_and_hash_with_relationship_nonce(
+            &*sender_vid,
+            &*receiver_vid,
+            None,
+            Payload::RequestRelationship {
+                thread_id: Default::default(),
+                form: RelationshipForm::Parallel {
+                    new_vid: alice_parallel.identifier().as_ref(),
+                    sig_new_vid: sig_new_vid.as_slice(),
+                },
+            },
+            Some(&mut request_digest),
+            Some(nonce_bytes),
+        )
+        .unwrap();
+
+        let Err(Error::Crypto(CryptoError::Verify(vid, _))) = b_store.open_message(&mut sealed)
+        else {
+            panic!("unexpected message result");
+        };
+
+        assert_eq!(vid, alice_parallel.identifier());
+        assert!(matches!(
+            b_store.get_verified_vid(alice_parallel.identifier()),
+            Err(Error::UnverifiedVid(_))
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_invalid_outer_signature_does_not_persist_unknown_sender() {
+        let receiver_store = create_test_store();
+        let sender_store = create_test_store();
+        let sender = create_test_vid();
+        let receiver = create_test_vid();
+
+        receiver_store
+            .add_private_vid(receiver.clone(), None)
+            .unwrap();
+        sender_store.add_private_vid(sender.clone(), None).unwrap();
+        sender_store
+            .add_verified_vid(receiver.clone(), None)
+            .unwrap();
+
+        let (_url, mut sealed) = sender_store
+            .seal_message(sender.identifier(), receiver.identifier(), None, b"hello")
+            .unwrap();
+        let last = sealed
+            .last_mut()
+            .expect("sealed message should not be empty");
+        *last ^= 0x01;
+
+        let Err(Error::Crypto(CryptoError::Verify(vid, _))) =
+            receiver_store.open_message(&mut sealed)
+        else {
+            panic!("unexpected message result");
+        };
+
+        assert_eq!(vid, sender.identifier());
+        assert!(matches!(
+            receiver_store.get_verified_vid(sender.identifier()),
+            Err(Error::UnverifiedVid(_))
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_parallel_relationship_request_requires_existing_relationship() {
+        let store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        let alice_parallel = create_test_vid();
+
+        store.add_private_vid(alice.clone(), None).unwrap();
+        store.add_private_vid(alice_parallel.clone(), None).unwrap();
+        store.add_verified_vid(bob.clone(), None).unwrap();
+
+        let err = store
+            .make_parallel_relationship_request(
+                alice.identifier(),
+                bob.identifier(),
+                alice_parallel.identifier(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::Relationship(message) if message.contains("existing bidirectional relationship")
+        ));
     }
 
     #[test]

--- a/tsp_sdk/src/test.rs
+++ b/tsp_sdk/src/test.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AskarSecureStorage, AsyncSecureStore, OwnedVid, RelationshipStatus, SecureStorage, VerifiedVid,
-    test_utils::*,
+    AskarSecureStorage, AsyncSecureStore, OwnedVid, ReceivedRelationshipDelivery,
+    ReceivedRelationshipForm, RelationshipStatus, SecureStorage, VerifiedVid, test_utils::*,
 };
 use futures::StreamExt;
 use std::collections::BTreeMap;
@@ -332,14 +332,22 @@ async fn test_routed_mode() {
     alice_db
         .set_relation_and_status_for_vid(
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
-            RelationshipStatus::Bidirectional { thread_id: Default::default(), outstanding_nested_thread_ids: vec![] },
+            RelationshipStatus::Bidirectional {
+                thread_id: Default::default(),
+                remote_thread_id: Default::default(),
+                outstanding_nested_requests: vec![],
+            },
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
         )
         .unwrap();
     alice_db
         .set_relation_and_status_for_vid(
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
-            RelationshipStatus::Bidirectional { thread_id: Default::default(), outstanding_nested_thread_ids: vec![] },
+            RelationshipStatus::Bidirectional {
+                thread_id: Default::default(),
+                remote_thread_id: Default::default(),
+                outstanding_nested_requests: vec![],
+            },
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
         )
         .unwrap();
@@ -792,8 +800,9 @@ fn relationship_status_signature(status: RelationshipStatus) -> String {
         RelationshipStatus::ReverseUnidirectional { thread_id } => format!("RevUni:{thread_id:?}"),
         RelationshipStatus::Bidirectional {
             thread_id,
-            outstanding_nested_thread_ids,
-        } => format!("Bi:{thread_id:?}:{outstanding_nested_thread_ids:?}"),
+            remote_thread_id,
+            outstanding_nested_requests,
+        } => format!("Bi:{thread_id:?}:{remote_thread_id:?}:{outstanding_nested_requests:?}"),
     }
 }
 
@@ -1033,9 +1042,9 @@ async fn test_nested_relationship_transition_after_reopen() {
         .unwrap()
     {
         RelationshipStatus::Bidirectional {
-            outstanding_nested_thread_ids,
+            outstanding_nested_requests,
             ..
-        } => *outstanding_nested_thread_ids.last().unwrap(),
+        } => outstanding_nested_requests.last().unwrap().thread_id,
         _ => panic!("missing outstanding nested thread id"),
     };
 
@@ -1043,13 +1052,18 @@ async fn test_nested_relationship_transition_after_reopen() {
     let b_store = persist_reopen_cycle(&b_store, &fixture_b, 1).await;
 
     let crate::ReceivedTspMessage::RequestRelationship {
-        nested_vid: Some(nested_vid),
         thread_id,
+        form,
+        delivery,
         ..
     } = b_store.open_message(&mut nested_request).unwrap()
     else {
         panic!("nested relationship request was not decoded");
     };
+    let ReceivedRelationshipDelivery::Nested { nested_vid } = delivery else {
+        panic!("nested relationship request kind was not decoded");
+    };
+    assert!(matches!(form, ReceivedRelationshipForm::Direct));
     assert_eq!(nested_vid, nested_a_vid.identifier());
     assert_eq!(thread_id, nested_thread);
 
@@ -1058,17 +1072,22 @@ async fn test_nested_relationship_transition_after_reopen() {
         .unwrap();
     let a_store = persist_reopen_cycle(&a_store, &fixture_a, 1).await;
 
-    let crate::ReceivedTspMessage::AcceptRelationship {
-        nested_vid: Some(accepted_nested_vid),
-        ..
-    } = a_store.open_message(&mut nested_accept).unwrap()
+    let crate::ReceivedTspMessage::AcceptRelationship { form, delivery, .. } =
+        a_store.open_message(&mut nested_accept).unwrap()
     else {
         panic!("nested relationship accept was not decoded");
     };
+    let ReceivedRelationshipDelivery::Nested {
+        nested_vid: accepted_nested_vid,
+    } = delivery
+    else {
+        panic!("nested relationship accept kind was not decoded");
+    };
+    assert!(matches!(form, ReceivedRelationshipForm::Direct));
     assert_eq!(accepted_nested_vid, nested_b_vid.identifier());
 
     let RelationshipStatus::Bidirectional {
-        outstanding_nested_thread_ids,
+        outstanding_nested_requests,
         ..
     } = a_store
         .get_relation_status_for_vid_pair(&a_vid, &b_vid)
@@ -1077,7 +1096,9 @@ async fn test_nested_relationship_transition_after_reopen() {
         panic!("parent relation is not bidirectional after nested accept");
     };
     assert!(
-        !outstanding_nested_thread_ids.contains(&thread_id),
+        !outstanding_nested_requests
+            .iter()
+            .any(|pending| pending.thread_id == thread_id),
         "nested thread id was not consumed after nested accept"
     );
 

--- a/tsp_sdk/src/test_utils.rs
+++ b/tsp_sdk/src/test_utils.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     OwnedVid, RelationshipStatus, SecureStore,
-    definitions::{Digest, VerifiedVid},
+    definitions::{Digest, PendingNestedRelationship, VerifiedVid},
 };
 use once_cell::sync::Lazy;
 use std::path::{Path, PathBuf};
@@ -117,7 +117,11 @@ fn relationship_status_for(index: usize) -> RelationshipStatus {
         },
         _ => RelationshipStatus::Bidirectional {
             thread_id: relationship_digest(index),
-            outstanding_nested_thread_ids: vec![relationship_digest(index + 10_000)],
+            remote_thread_id: relationship_digest(index + 1_000),
+            outstanding_nested_requests: vec![PendingNestedRelationship {
+                thread_id: relationship_digest(index + 10_000),
+                local_nested_vid: format!("did:example:nested:{index}"),
+            }],
         },
     }
 }
@@ -170,7 +174,11 @@ pub fn create_prepopulated_store() -> SecureStore {
             remote_parent.identifier(),
             RelationshipStatus::Bidirectional {
                 thread_id: relationship_digest(20_001),
-                outstanding_nested_thread_ids: vec![relationship_digest(20_002)],
+                remote_thread_id: relationship_digest(20_011),
+                outstanding_nested_requests: vec![PendingNestedRelationship {
+                    thread_id: relationship_digest(20_002),
+                    local_nested_vid: "did:example:nested:20_002".to_string(),
+                }],
             },
             &root_local,
         )
@@ -186,7 +194,11 @@ pub fn create_prepopulated_store() -> SecureStore {
             remote_nested.identifier(),
             RelationshipStatus::Bidirectional {
                 thread_id: relationship_digest(20_101),
-                outstanding_nested_thread_ids: vec![relationship_digest(20_102)],
+                remote_thread_id: relationship_digest(20_111),
+                outstanding_nested_requests: vec![PendingNestedRelationship {
+                    thread_id: relationship_digest(20_102),
+                    local_nested_vid: "did:example:nested:20_102".to_string(),
+                }],
             },
             nested_local.identifier(),
         )
@@ -243,7 +255,11 @@ pub fn create_dirty_store_with_transition_seed() -> (AsyncSecureStore, DirtyTran
             remote_bidirectional.identifier(),
             RelationshipStatus::Bidirectional {
                 thread_id: relationship_digest(30_001),
-                outstanding_nested_thread_ids: vec![relationship_digest(30_002)],
+                remote_thread_id: relationship_digest(30_011),
+                outstanding_nested_requests: vec![PendingNestedRelationship {
+                    thread_id: relationship_digest(30_002),
+                    local_nested_vid: "did:example:nested:30_002".to_string(),
+                }],
             },
             local.identifier(),
         )

--- a/tsp_sdk/src/vid/mod.rs
+++ b/tsp_sdk/src/vid/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
     RelationshipStatus,
     definitions::{
-        PrivateKeyData, PrivateSigningKeyData, PrivateVid, PublicKeyData,
-        PublicVerificationKeyData, VerifiedVid,
+        PendingIncomingParallelRelationship, PendingParallelRelationship, PrivateKeyData,
+        PrivateSigningKeyData, PrivateVid, PublicKeyData, PublicVerificationKeyData, VerifiedVid,
     },
 };
 
@@ -225,6 +225,10 @@ pub struct ExportVid {
     pub relation_vid: Option<String>,
     pub parent_vid: Option<String>,
     pub tunnel: Option<Box<[String]>>,
+    #[cfg_attr(feature = "serialize", serde(default))]
+    pub pending_parallel_requests: Vec<PendingParallelRelationship>,
+    #[cfg_attr(feature = "serialize", serde(default))]
+    pub pending_incoming_parallel_requests: Vec<PendingIncomingParallelRelationship>,
     pub metadata: Option<serde_json::Value>,
 }
 


### PR DESCRIPTION
Closing #236

There are still a few backward-compatibility issues I need to work through.

This PR is pretty large. A big chunk of it is protocol-format cleanup: it now fully follows the spec-defined XRFI / XRFA format instead of the custom format previously used in the SDK. We may need to bump TSP_VERSION here.

Another major part is the test cases, which were updated to reflect the actual spec-compliant implementation. During development, I tried to keep the changes split across commits as much as possible.


**PR Commit Summary**

| Commit | Summary |
|---|---|
| [5e7f036](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/5e7f036403e6bf4a54496f28476d788bc6e82509) `Impl spec XRFI/XRFA message` | Reworked `XRFI/XRFA` encoding, decoding, message modeling, and store handling around the full protocol semantics, replacing the previous simplified relationship control message structure and laying the foundation for parallel/referral flow. |
| [bf6ba60](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/bf6ba607d358b0f2a05336fea2a5a65c96f61ee6) `Fix tsp_javascript and tsp_python` | Fixed the JavaScript/Python bindings after the protocol-layer changes by updating message mappings, APIs, and tests so the bindings matched the SDK again. |
| [980115a](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/980115af26b968eeea98e16df1b872bac7ed63f3)`Make the send path sign with the actual new private VID` | Fixed the signing behavior on the parallel/referral send path so it signs with the actual new private VID rather than reusing identity material from the outer relationship. |
| [b232d64](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/b232d64c6e316af83b20b7510596f6f2c58d9cef) `Align parallel accept flow with referral XRFA semantics` | Aligned the parallel accept state machine, persistence, and validation with referral `XRFA` semantics, including pending state tracking, post-reopen handling, and rejection of invalid outer senders. |
| [83603f1](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/83603f145eaf01b2dcf0184c0e80a9fd7d849f31) `Add CLI support for parallel relationship request and accept` | Added CLI support for initiating and accepting parallel relationships, including `request --parallel`, `accept --parallel`, wait behavior, and end-to-end CLI coverage. |
| [743c8ef](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/743c8ef2a1b130aeece69b7a63f056d4eecdc4c9) `Document the parallel relationship CLI flow` | Added CLI documentation, navigation, and example flow for parallel relationships so the docs match the current CLI behavior. |
| [a6a2a50](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/a6a2a50c53c1539ae0298fdb73e461192fdc140b) `Add parallel relationship test` | Added a dedicated SDK test module for parallel relationships, covering acceptance scenarios such as persistence/reopen and async receive/bootstrap behavior. |
| [1261188](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/12611884f14215a3331e60a4055037dc043ae832) `Expose parallel relationship flow in JavaScript and Python bindings` | Exposed parallel relationship request/accept APIs in the JavaScript and Python bindings so non-Rust callers can initiate and complete the flow. |
| [e6d384b](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/e6d384bb3d7c3075e551b82c4ab17f4dc2e70cef) `Align node wrappers and tests with parallel relationship semantics` | Updated the Node wrapper and the Node/Python tests so flattened message shapes and assertions match the new parallel relationship semantics. |
| [5d67c61](https://github.com/openwallet-foundation-labs/tsp/pull/303/commits/5d67c61d8bb1ffe4ef2811446a9f0156977e751f) `Fix clippy` | Final cleanup for compile/lint issues, including `PendingMessage` coverage in the JS bindings and clippy fixes in CLI tests, without changing protocol behavior. |
