### PR TITLE
Fix buffer counter reset after ack and reduce log noise

### DIFF
--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -323,7 +323,10 @@ async fn main() {
                     buf.expire(state.buffer_ttl);
                     expired_count += before - buf.messages.len();
                 }
-                buffers.retain(|_, buf| !buf.messages.is_empty());
+                // Note: do NOT remove empty buffers — the next_id counter
+                // must survive so new messages get monotonically increasing IDs.
+                // Otherwise, clients with Last-Event-ID will skip replayed messages
+                // that got lower IDs after the counter reset.
                 if expired_count > 0 {
                     tracing::debug!("Buffer cleanup: expired {expired_count} messages");
                 }

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -583,7 +583,7 @@ impl AsyncSecureStore {
                     }
                     .map(|msg| msg.into_owned())
                     .map_err(|e| {
-                        tracing::error!("{}", e);
+                        tracing::debug!("Message processing error (non-fatal): {}", e);
                         e
                     })
                 }


### PR DESCRIPTION
The intermediary's cleanup task removed empty buffer entries from the HashMap, which reset the per-recipient next_id counter to 0. After a client acked all messages and the buffer was cleaned, new messages got IDs starting from 0 — but clients resuming with Last-Event-ID from the previous sequence would skip all messages with lower IDs, causing silent message loss.

Fix: keep empty buffer entries so the monotonic ID counter survives across ack cycles. The counter is a protocol agreement between the client and intermediary that persists as long as the DID relationship.

Also downgrade error-level log in async_store receive streams to debug. These relationship errors (first-contact establishment, thread_id mismatch during SSE replay) are expected during normal operation and should not pollute application logs.