### PR TITLE
fix(cesr): add missing #[error] on EncodeError::InvalidSignatureType

### DIFF
--- a/tsp_sdk/src/cesr/error.rs
+++ b/tsp_sdk/src/cesr/error.rs
@@ -9,6 +9,7 @@ pub enum EncodeError {
     MissingReceiver,
     #[error("VID is not valid for CESR encoding")]
     InvalidVid,
+    #[error("invalid signature type")]
     InvalidSignatureType,
 }
 


### PR DESCRIPTION
## Summary

Noticed while looking at the diff from #309 that `EncodeError::InvalidSignatureType` never got its `#[error]` annotation in the migration. thiserror 2.x doesn't shout about this — it just quietly falls back to the Debug repr, so any code path that hits this variant ends up printing the raw enum name `"InvalidSignatureType"` instead of a readable message. Bit of a silent regression.

The fix is one line. Wording matches `DecodeError::InvalidSignatureType` which is already annotated correctly in the same file, so this just makes the two sides consistent.

## Changes

- **`tsp_sdk/src/cesr/error.rs`** — added `#[error("invalid signature type")]` on `EncodeError::InvalidSignatureType`

## Testing

Existing tests all pass — they match on variant names, not on Display output, so there's nothing to update. No behaviour changes for callers either since the variant name is preserved.

## Checklist
- [x] One-line change, no logic touched
- [x] Follows the wording already used in `DecodeError::InvalidSignatureType`
- [x] No new dependencies
- [x] Finishes what #309 started

Closes regression introduced in #309