### PR TITLE
fix(cesr): return error from encode_count instead of panicking on overflow

### DIFF
--- a/tsp_sdk/src/cesr/encode.rs
+++ b/tsp_sdk/src/cesr/encode.rs
@@ -89,6 +89,21 @@ pub fn encode_count(
     Ok(())
 }
 
+/// Encode a genus with known identifier and version
+#[allow(dead_code)]
+pub fn encode_genus(
+    genus: [u8; 3],
+    (major, minor, patch): (u8, u8, u8),
+    stream: &mut impl for<'a> Extend<&'a u8>,
+) {
+    let version = (bits(major, 6) << 12) | (bits(minor, 6) << 6) | bits(patch, 6);
+    let word1 = (DASH << 18) | (DASH << 12) | (bits(genus[0], 6) << 6) | bits(genus[1], 6);
+    let word2 = (bits(genus[2], 6) << 18) | version;
+
+    stream.extend(&u32::to_be_bytes(word1)[1..]);
+    stream.extend(&u32::to_be_bytes(word2)[1..]);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -107,19 +122,4 @@ mod tests {
         encode_count(0, 42usize, &mut stream).expect("small count should succeed");
         assert!(!stream.is_empty());
     }
-}
-
-/// Encode a genus with known identifier and version
-#[allow(dead_code)]
-pub fn encode_genus(
-    genus: [u8; 3],
-    (major, minor, patch): (u8, u8, u8),
-    stream: &mut impl for<'a> Extend<&'a u8>,
-) {
-    let version = (bits(major, 6) << 12) | (bits(minor, 6) << 6) | bits(patch, 6);
-    let word1 = (DASH << 18) | (DASH << 12) | (bits(genus[0], 6) << 6) | bits(genus[1], 6);
-    let word2 = (bits(genus[2], 6) << 18) | version;
-
-    stream.extend(&u32::to_be_bytes(word1)[1..]);
-    stream.extend(&u32::to_be_bytes(word2)[1..]);
 }

--- a/tsp_sdk/src/cesr/encode.rs
+++ b/tsp_sdk/src/cesr/encode.rs
@@ -1,4 +1,4 @@
-use super::{bits, selector::*};
+use super::{bits, error::EncodeError, selector::*};
 
 /// Encode fixed size data with a known identifier
 pub fn encode_fixed_data(
@@ -72,9 +72,9 @@ pub fn encode_count(
     identifier: u16,
     count: impl Into<usize>,
     stream: &mut impl for<'a> Extend<&'a u8>,
-) {
+) -> Result<(), EncodeError> {
     let count: usize = count.into();
-    let count: u32 = count.try_into().unwrap();
+    let count: u32 = count.try_into().map_err(|_| EncodeError::CountOverflow)?;
     if count < 4096 {
         let word = (DASH << 18) | (bits(identifier, 6) << 12) | bits(count, 12);
 
@@ -85,6 +85,27 @@ pub fn encode_count(
 
         stream.extend(&u32::to_be_bytes(word1)[1..]);
         stream.extend(&u32::to_be_bytes(word2)[1..]);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_count_overflow_returns_error() {
+        let mut stream = Vec::new();
+        let result = encode_count(0, usize::MAX, &mut stream);
+        assert!(matches!(result, Err(EncodeError::CountOverflow)));
+        assert!(stream.is_empty());
+    }
+
+    #[test]
+    fn encode_count_small_succeeds() {
+        let mut stream = Vec::new();
+        encode_count(0, 42usize, &mut stream).expect("small count should succeed");
+        assert!(!stream.is_empty());
     }
 }
 

--- a/tsp_sdk/src/cesr/error.rs
+++ b/tsp_sdk/src/cesr/error.rs
@@ -11,6 +11,8 @@ pub enum EncodeError {
     InvalidVid,
     #[error("invalid signature type")]
     InvalidSignatureType,
+    #[error("count value exceeds maximum CESR encoding limit")]
+    CountOverflow,
 }
 
 /// An error type to indicate something went wrong with decoding

--- a/tsp_sdk/src/cesr/mod.rs
+++ b/tsp_sdk/src/cesr/mod.rs
@@ -195,7 +195,7 @@ mod test {
             &mut data,
         ); // 1 lead byte
         encode_variable_data(42,  b"I always speak the truth. Not the whole truth, because there's no way, to say it all.", &mut data); // 2 lead bytes
-        encode_count(7, 2usize, &mut data);
+        encode_count(7, 2usize, &mut data).unwrap();
         encode_indexed_data(5, 57, b"DON'T PANIC!", &mut data); // 0 lead bytes
         encode_indexed_data(5, 0, b"SECRET KEY", &mut data); // 2 lead bytes
 

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -420,7 +420,7 @@ pub fn encode_payload(
         }
     }
 
-    encode_count(TSP_PAYLOAD, temp.len() / 3, output);
+    encode_count(TSP_PAYLOAD, temp.len() / 3, output)?;
     output.extend(temp.iter());
 
     Ok(())
@@ -431,7 +431,7 @@ pub fn encode_hops(
     hops: &[impl AsRef<[u8]>],
     output: &mut impl for<'a> Extend<&'a u8>,
 ) -> Result<(), EncodeError> {
-    encode_count(TSP_HOP_LIST, hops.len() as u16, output);
+    encode_count(TSP_HOP_LIST, hops.len() as u16, output)?;
     for hop in hops {
         checked_encode_variable_data(TSP_VID, hop.as_ref(), output)?;
     }
@@ -606,7 +606,7 @@ const fn encoded_version() -> u16 {
 /// Encode a TSP version marker
 pub fn encode_version(output: &mut impl for<'b> Extend<&'b u8>) {
     output.extend(&YTSP);
-    encode_count(TSP_VERSION.0, encoded_version(), output);
+    let _ = encode_count(TSP_VERSION.0, encoded_version(), output);
 }
 
 fn decode_version(stream: &mut &[u8]) -> Result<(), DecodeError> {
@@ -636,7 +636,7 @@ pub fn encode_ets_envelope<'a, Vid: AsRef<[u8]>>(
     let mut temp = Vec::new(); // temporary buffer to count the size
     encode_envelope_fields(envelope, &mut temp)?;
 
-    encode_count(TSP_ETS_WRAPPER, temp.len() / 3, output);
+    encode_count(TSP_ETS_WRAPPER, temp.len() / 3, output)?;
     output.extend(temp.iter());
     Ok(())
 }
@@ -649,7 +649,7 @@ pub fn encode_s_envelope<'a, Vid: AsRef<[u8]>>(
     let mut temp = Vec::new(); // temporary buffer to count the size
     encode_envelope_fields(envelope, &mut temp)?;
 
-    encode_count(TSP_S_WRAPPER, temp.len() / 3, output);
+    encode_count(TSP_S_WRAPPER, temp.len() / 3, output)?;
     output.extend(temp.iter());
     Ok(())
 }
@@ -690,18 +690,18 @@ impl<'a> EncodedSignature<'a> {
         match self {
             EncodedSignature::NoSignature => {}
             EncodedSignature::Ed25519(signature) => {
-                encode_count(TSP_ATTACH_GRP, signature.len().div_ceil(3), output);
-                encode_count(TSP_INDEX_SIG_GRP, signature.len().div_ceil(3), output);
+                let _ = encode_count(TSP_ATTACH_GRP, signature.len().div_ceil(3), output);
+                let _ = encode_count(TSP_INDEX_SIG_GRP, signature.len().div_ceil(3), output);
                 encode_fixed_data(ED25519_SIGNATURE, signature.as_slice(), output);
             }
             #[cfg(feature = "pq")]
             EncodedSignature::MlDsa65(signature) => {
-                encode_count(
+                let _ = encode_count(
                     TSP_ATTACH_GRP,
                     signature.len().next_multiple_of(3) / 3,
                     output,
                 );
-                encode_count(
+                let _ = encode_count(
                     TSP_INDEX_SIG_GRP,
                     signature.len().next_multiple_of(3) / 3,
                     output,


### PR DESCRIPTION
## Summary

Noticed `encode_count` in `cesr/encode.rs` had a silent time bomb: it calls
`.unwrap()` on a `usize → u32` narrowing cast. On a 64-bit host, if a caller
ever passes a count bigger than `u32::MAX`, you get a panic instead of a
graceful error. Everything downstream — `encode_payload`, the envelope
encoders, the hops list — already returns `Result<(), EncodeError>`, so
threading the error up was pretty mechanical.

## Changes

- **`cesr/error.rs`** — added `CountOverflow` variant to `EncodeError`
- **`cesr/encode.rs`** — `encode_count` now returns `Result<(), EncodeError>`; replaced `.unwrap()` with `map_err(|_| EncodeError::CountOverflow)?`
- **`cesr/packet.rs`** — propagated `?` at every call site inside a function that already returns `Result`; used `let _ =` for the three spots where the count comes from a compile-time constant (version fields, fixed signature sizes) so they're provably in-range
- **`cesr/mod.rs`** — added `.unwrap()` to the one test-only call site

## Testing

```bash
cargo test -p tsp_sdk
```

Two new tests in `encode.rs`:
- pass `usize::MAX` → expect `Err(CountOverflow)` with stream untouched
- pass `42` → expect `Ok(())` with bytes written

Nothing else regressed.

## Checklist
- [x] Panic replaced with a proper `Result` error
- [x] All call sites updated
- [x] DCO signed
- [x] New variant matches existing `EncodeError` style