### PR TITLE
fix(cesr): strip identifier bits before reconstructing long-form count in decode_count

### DIFF
--- a/tsp_sdk/src/cesr/decode.rs
+++ b/tsp_sdk/src/cesr/decode.rs
@@ -183,7 +183,7 @@ pub fn decode_count(identifier: u16, stream: &mut &[u8]) -> Option<u32> {
         let next = extract_triplet(stream.get(3..=5)?.try_into().unwrap());
         *stream = &stream[6..];
 
-        Some(index << 24 | next)
+        Some((index & 0x3F) << 24 | next)
     } else {
         None
     }

--- a/tsp_sdk/src/cesr/mod.rs
+++ b/tsp_sdk/src/cesr/mod.rs
@@ -431,4 +431,42 @@ ACTD7NDX93ZGTkZBBuSeSGsAQ7u0hngpNTZTK_Um7rUZGnLRNJvo5oOnnC1J2iBQHuxoq8PyjdT3BHS2
         assert_eq!(decode_indexed_data::<64>(0, slice).unwrap().0, 1);
         assert_eq!(decode_indexed_data::<64>(0, slice).unwrap().0, 2);
     }
+
+    #[test]
+    fn decode_count_long_form_round_trips() {
+        // All counts below 4096 use the short 3-byte form; counts >= 4096 use the
+        // long 6-byte form where the header word encodes both the identifier and the
+        // upper 6 bits of the count.  Previously, decode_count returned
+        // `index << 24 | next` where `index` still contained the identifier bits,
+        // producing an overflow / wrong result for every non-zero identifier.
+        //
+        // Identifiers mirror the real TSP framing codes used in packet.rs:
+        //   4  = TSP_ETS_WRAPPER ("E")
+        //   9  = TSP_HOP_LIST    ("J")
+        //   18 = TSP_S_WRAPPER   ("S")
+        //   25 = TSP_PAYLOAD     ("Z")
+        let cases: &[(u16, u32)] = &[
+            (4, 4096),        // TSP_ETS_WRAPPER, exact long-form boundary
+            (4, 65_536),      // TSP_ETS_WRAPPER, larger count
+            (9, 4096),        // TSP_HOP_LIST, exact long-form boundary
+            (9, 100_000),     // TSP_HOP_LIST, larger count
+            (18, 4096),       // TSP_S_WRAPPER, exact long-form boundary
+            (18, 1_000_000),  // TSP_S_WRAPPER, larger count
+            (25, 4096),       // TSP_PAYLOAD, exact long-form boundary
+            (25, 16_777_215), // TSP_PAYLOAD, max 24-bit payload count
+        ];
+        for &(identifier, count) in cases {
+            let mut stream = Vec::new();
+            encode_count(identifier, count as usize, &mut stream);
+            assert_eq!(stream.len(), 6, "identifier={identifier} count={count}: expected 6-byte long form");
+            let mut slice = stream.as_slice();
+            let decoded = decode_count(identifier, &mut slice);
+            assert_eq!(
+                decoded,
+                Some(count),
+                "identifier={identifier} count={count}: decoded {decoded:?}"
+            );
+            assert!(slice.is_empty(), "stream should be fully consumed after decode");
+        }
+    }
 }

--- a/tsp_sdk/src/cesr/mod.rs
+++ b/tsp_sdk/src/cesr/mod.rs
@@ -458,7 +458,11 @@ ACTD7NDX93ZGTkZBBuSeSGsAQ7u0hngpNTZTK_Um7rUZGnLRNJvo5oOnnC1J2iBQHuxoq8PyjdT3BHS2
         for &(identifier, count) in cases {
             let mut stream = Vec::new();
             encode_count(identifier, count as usize, &mut stream);
-            assert_eq!(stream.len(), 6, "identifier={identifier} count={count}: expected 6-byte long form");
+            assert_eq!(
+                stream.len(),
+                6,
+                "identifier={identifier} count={count}: expected 6-byte long form"
+            );
             let mut slice = stream.as_slice();
             let decoded = decode_count(identifier, &mut slice);
             assert_eq!(
@@ -466,7 +470,10 @@ ACTD7NDX93ZGTkZBBuSeSGsAQ7u0hngpNTZTK_Um7rUZGnLRNJvo5oOnnC1J2iBQHuxoq8PyjdT3BHS2
                 Some(count),
                 "identifier={identifier} count={count}: decoded {decoded:?}"
             );
-            assert!(slice.is_empty(), "stream should be fully consumed after decode");
+            assert!(
+                slice.is_empty(),
+                "stream should be fully consumed after decode"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
`decode_count` has a bug in its long-form path (counts ≥ 4096). After matching
the 6-byte header, it reconstructs the count as `index << 24 | next` — but
`index` is the raw lower-12-bits of the header word, which encodes
`(identifier << 6) | count_high_6`. The identifier bits are never stripped, so
the reconstructed count is wrong for any non-zero identifier. In debug builds
this panics (u32 overflow); in release builds it silently returns a garbage value.
Any TSP message whose encoded payload or envelope exceeds ~12 KB triggers the
long-form path and will fail to decode correctly.
## Root Cause
`tsp_sdk/src/cesr/decode.rs`, function `decode_count`, long-form branch:
```rust
// Before — index still carries identifier bits in bits[11:6]
Some(index << 24 | next)
// After — mask to count_high_6 only
Some((index & 0x3F) << 24 | next)
```
The encoder (`encode_count`) correctly packs `count >> 24` into the low 6 bits
of the header word. The decoder needs to extract exactly those 6 bits before
shifting, not the full 12-bit `index`.
## Changes
- **`tsp_sdk/src/cesr/decode.rs`** — one-character fix: `index << 24` →
  `(index & 0x3F) << 24`
- **`tsp_sdk/src/cesr/mod.rs`** — added `decode_count_long_form_round_trips`
  test covering all four TSP framing identifiers (ETS_WRAPPER, HOP_LIST,
  S_WRAPPER, PAYLOAD) at the exact long-form boundary (4096) and at larger
  values, verifying encode→decode round-trips correctly and the stream is
  fully consumed
## Testing
```bash
cargo test -p tsp_sdk
```
New test: `decode_count_long_form_round_trips` — 8 cases covering all real
TSP framing identifiers in both boundary and large-count scenarios.
## Checklist
- [x] Bug reproduced and root cause confirmed
- [x] Fix is a single targeted change
- [x] Round-trip tests added for every affected identifier
- [x] DCO signed
- [x] Follows existing code style