### PR TITLE
fix(fuzz): handle all reachable EncodeError arms and remove dead MissingReceiver variant

### DIFF
--- a/fuzz/fuzz_targets/payload_encode_decode.rs
+++ b/fuzz/fuzz_targets/payload_encode_decode.rs
@@ -11,11 +11,18 @@ fuzz_target!(|data: cesr::fuzzing::Wrapper| {
 
             assert_eq!(data, result.payload);
         }
-        Err(cesr::error::EncodeError::MissingHops) => match &data.0 {
-            cesr::Payload::RoutedMessage(route, _) => assert!(route.is_empty()),
-            _ => todo!(),
-        },
+        // MissingHops is only raised for RoutedMessage with an empty hop list
+        Err(cesr::error::EncodeError::MissingHops) => {
+            assert!(matches!(
+                &data.0,
+                cesr::Payload::RoutedMessage(route, _) if route.is_empty()
+            ));
+        }
+        // Fields that exceed the CESR variable-data size limit are legitimately rejected
+        Err(cesr::error::EncodeError::ExcessiveFieldSize) => {}
+        // Parallel-relation payloads with an empty new_vid are legitimately rejected
         Err(cesr::error::EncodeError::InvalidVid) => {}
-        _ => todo!(),
+        // Any other error is not expected from encode_payload — surface it as a finding
+        Err(e) => panic!("unexpected encode error: {e:?}"),
     }
 });

--- a/tsp_sdk/src/cesr/error.rs
+++ b/tsp_sdk/src/cesr/error.rs
@@ -5,8 +5,6 @@ pub enum EncodeError {
     ExcessiveFieldSize,
     #[error("hops field is required but missing")]
     MissingHops,
-    #[error("receiver is required but missing")]
-    MissingReceiver,
     #[error("VID is not valid for CESR encoding")]
     InvalidVid,
     #[error("invalid signature type")]


### PR DESCRIPTION
## Summary

The `payload_encode_decode` fuzz harness had two `todo!()` arms in its
`encode_payload` match block. `todo!()` panics at runtime — when the fuzzer
triggers one of those arms, the harness itself crashes, making it look like
the encoder has a bug when it actually returned a valid error. Additionally,
`EncodeError::MissingReceiver` was declared in the error enum but never raised
anywhere in the codebase, which obscured the incomplete coverage in the harness.

## Root Cause

`encode_payload` can legitimately return `Err(EncodeError::ExcessiveFieldSize)`
when any payload field exceeds the CESR variable-data size limit
(`3 * 2^24` bytes). The `Arbitrary` impl in `fuzzing.rs` generates `new_vid`
and `data` fields as unbounded `Vec<u8>`, so this path is reachable. The outer
`_ => todo!()` caught it and panicked, producing a false-positive crash report.

The inner `todo!()` (inside the `MissingHops` arm) was unreachable in practice
since `MissingHops` is only raised for `RoutedMessage`, but it was still
incorrect — `unreachable!()` or a flat assertion is the right form.

## Changes

- **`fuzz/fuzz_targets/payload_encode_decode.rs`** — replaced both `todo!()`
  arms with explicit handling: `ExcessiveFieldSize` is silently ignored (it is
  a legitimate rejection), `MissingHops` is flattened into a single `assert!`
  with a guard, and a catch-all `panic!` now surfaces genuinely unexpected errors
  as real fuzz findings
- **`tsp_sdk/src/cesr/error.rs`** — removed `MissingReceiver` from `EncodeError`;
  it was never raised by any function in the SDK

## Testing

The fuzz target itself is the test. Changes verified by:
- `git grep MissingReceiver` returns no results after the removal
- Diff reviewed against all `encode_payload` error sites in `packet.rs` to
  confirm every reachable variant is now explicitly handled

## Checklist

- [x] Follows existing code style
- [x] No new dependencies
- [x] No unrelated changes