### PR TITLE
fix(store): reject empty route in set_route_for_vid

### DIFF
--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -474,7 +474,7 @@ impl SecureStore {
         route: impl IntoIterator<Item: ToString, IntoIter: ExactSizeIterator<Item = impl Display>>,
     ) -> Result<(), Error> {
         let route = route.into_iter();
-        if route.len() == 1 {
+        if route.len() < 2 {
             return Err(Error::InvalidRoute(
                 "A route must have at least two VIDs".into(),
             ));
@@ -3344,6 +3344,39 @@ mod test {
         assert_ne!(
             message_type.signature_type,
             crate::cesr::SignatureType::NoSignature
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_set_route_for_vid_rejects_empty_route() {
+        let store = create_test_store();
+        let bob = create_test_vid();
+        store
+            .add_verified_vid(bob.vid().clone(), None)
+            .expect("should add verified vid");
+
+        let result = store.set_route_for_vid(bob.identifier(), &[] as &[&str]);
+        assert!(
+            matches!(result, Err(Error::InvalidRoute(_))),
+            "empty route must be rejected, got: {result:?}"
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_set_route_for_vid_rejects_single_hop() {
+        let store = create_test_store();
+        let bob = create_test_vid();
+        let intermediary = create_test_vid();
+        store
+            .add_verified_vid(bob.vid().clone(), None)
+            .expect("should add verified vid");
+
+        let result = store.set_route_for_vid(bob.identifier(), &[intermediary.identifier()]);
+        assert!(
+            matches!(result, Err(Error::InvalidRoute(_))),
+            "single-hop route must be rejected, got: {result:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Spotted a gap in the route validation inside `set_route_for_vid` — the guard
only checked `route.len() == 1`, so an empty route (`&[]`) slipped straight
through. Instead of getting an error back, the caller would silently have their
existing tunnel wiped because the internal `set_route` helper interprets an
empty vec as "clear the route". The function returned `Ok(())` the whole time,
so there was no way to know anything went wrong.

## Root Cause

The condition on line 477 reads `if route.len() == 1`, but the error message
already says "at least two VIDs" — so the intent was always to reject both 0
and 1. Changing `== 1` to `< 2` makes the code match what the message already
promised.

## Changes

- **`tsp_sdk/src/store.rs`** — one-character fix (`== 1` → `< 2`) plus two
  new unit tests: one for the empty-route case that was previously silently
  accepted, and one that confirms the existing single-hop rejection still works

## Testing

```bash
cargo test -p tsp-sdk test_set_route_for_vid_rejects_empty_route
cargo test -p tsp-sdk test_set_route_for_vid_rejects_single_hop
```

Both new tests assert `Err(Error::InvalidRoute(_))` is returned. All existing
routed-mode tests remain unaffected.

## Checklist

- [x] Tests added for both newly caught cases
- [x] Follows existing test style (`create_test_store`, `create_test_vid`, `#[wasm_bindgen_test]`)
- [x] No new dependencies
- [x] No unrelated changes