### PR TITLE
fix(crypto): propagate nacl encryption error instead of unwrap in seal

### DIFF
--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -125,7 +125,7 @@ pub(crate) fn seal(
     // aad not yet supported: https://github.com/RustCrypto/nacl-compat/blob/78b59261458923740724c84937459f0a6017a592/crypto_box/src/lib.rs#L227
     let tag = sender_box.encrypt_in_place_detached(&nonce, &[], &mut cesr_message);
 
-    cesr_message.extend(tag.unwrap());
+    cesr_message.extend(tag?);
     cesr_message.extend(nonce);
 
     // encode and append the ciphertext to the envelope data


### PR DESCRIPTION
## Summary

`encrypt_in_place_detached` in the NaCl `seal` path returns
`Result<Tag, aead::Error>`, but the result was unwrapped instead of propagated.
`seal` already returns `Result<_, CryptoError>` and `CryptoError` already has a
`CryptographicNacl(#[from] crypto_box::aead::Error)` variant, so the `From`
conversion was already in place — the `.unwrap()` just never got swapped out.

## Root Cause

`tsp_nacl.rs` line 128: `tag.unwrap()` in the live message encryption path.
While `ChaCha20Poly1305` encryption is practically infallible, leaving `.unwrap()`
in the crypto layer means any future change to the underlying crate that makes
this fallible would silently become a panic instead of a handled error.

## Changes

- **`tsp_sdk/src/crypto/tsp_nacl.rs`** — replaced `tag.unwrap()` with `tag?`;
  the error type already converts via the existing `CryptographicNacl` variant

## Testing

The existing `seal`/`open` round-trip tests in `crypto/mod.rs` cover this path.
No new tests needed — the change only affects the error propagation strategy,
not the happy-path behaviour.

## Checklist

- [x] Follows existing error handling style throughout the codebase
- [x] No new dependencies
- [x] No behaviour change on the happy path
- [x] No unrelated changes