### PR TITLE
fix(transport): replace println! with tracing::trace! in message send/receive paths

### DIFF
--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -625,11 +625,8 @@ impl AsyncSecureStore {
                 async move {
                     let mut message = message?;
 
-                    if tracing::enabled!(tracing::Level::TRACE) {
-                        println!(
-                            "CESR-encoded message: {}",
-                            crate::cesr::color_format(&message)?
-                        );
+                    if let Ok(colored) = crate::cesr::color_format(&message) {
+                        tracing::trace!("CESR-encoded message: {}", colored);
                     }
 
                     match db_inner.open_message(&mut message) {
@@ -695,11 +692,8 @@ impl AsyncSecureStore {
             async move {
                 let mut message = message?;
 
-                if tracing::enabled!(tracing::Level::TRACE) {
-                    println!(
-                        "CESR-encoded message: {}",
-                        crate::cesr::color_format(&message)?
-                    );
+                if let Ok(colored) = crate::cesr::color_format(&message) {
+                    tracing::trace!("CESR-encoded message: {}", colored);
                 }
 
                 match db_inner.open_message(&mut message) {

--- a/tsp_sdk/src/transport/mod.rs
+++ b/tsp_sdk/src/transport/mod.rs
@@ -14,12 +14,8 @@ pub use http::SseCursor;
 pub use http::receive_messages_tracked;
 
 pub async fn send_message(transport: &Url, tsp_message: &[u8]) -> Result<(), TransportError> {
-    if tracing::enabled!(tracing::Level::TRACE) {
-        println!(
-            "CESR-encoded message: {}",
-            crate::cesr::color_format(tsp_message)
-                .map_err(|_| TransportError::InvalidMessageReceived("DecodeError".to_string()))?
-        );
+    if let Ok(colored) = crate::cesr::color_format(tsp_message) {
+        tracing::trace!("CESR-encoded message: {}", colored);
     }
 
     match transport.scheme() {


### PR DESCRIPTION
## Summary

Three `println!` calls in the live message send and receive paths were guarded
by `tracing::enabled!(TRACE)` but wrote directly to stdout instead of going
through the tracing subscriber. In a library, `println!` bypasses log-level
filtering, formatters, and any subscriber configuration the caller has set up —
so these lines would silently spam stdout even in production binaries that had
trace disabled at the subscriber level.

The old `transport/mod.rs` path also had a secondary problem: if `color_format`
failed to decode the message, it returned `Err(InvalidMessageReceived)` and
aborted the send entirely — meaning a debug logging call could kill a real
message.

## Changes

- **`tsp_sdk/src/transport/mod.rs`** — replaced the `tracing::enabled!` +
  `println!` block with `tracing::trace!`; `color_format` errors are now
  silently ignored so a formatting failure never aborts a send
- **`tsp_sdk/src/async_store.rs`** — same replacement in both `receive_tracked`
  and `receive_with_cursor`; the `?` that could propagate a `color_format` error
  out of the receive stream is removed

## Testing

Covered by the existing send/receive integration tests. No behaviour change on
the happy path — trace output now goes through the tracing subscriber as
intended.

## Checklist

- [x] Follows existing tracing style (`debug!` already used in the same blocks)
- [x] No new dependencies
- [x] No unrelated changes