### PR TITLE
feat: intro scid impl

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -12,7 +12,16 @@ use tsp_sdk::{
     ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage, RelationshipStatus,
     SecureStorage, VerifiedVid, Vid, cesr,
     definitions::Digest,
-    vid::{VidError, did::webvh::WebvhMetadata, verify_vid, vid_to_did_document},
+    vid::{
+        ResolutionContext, VerifyVidOptions, VidError,
+        did::{
+            scid::{
+                ScidLocator, ScidMethod, ScidResolutionContext, ScidSourceMethod, ScidVidMetadata,
+            },
+            webvh::WebvhMetadata,
+        },
+        verify_vid, verify_vid_with_options, vid_to_did_document,
+    },
 };
 use url::Url;
 
@@ -25,6 +34,7 @@ enum DidType {
     Web,
     Peer,
     Webvh,
+    Scid,
 }
 
 impl FromStr for DidType {
@@ -35,6 +45,7 @@ impl FromStr for DidType {
             "web" => Ok(DidType::Web),
             "peer" => Ok(DidType::Peer),
             "webvh" => Ok(DidType::Webvh),
+            "scid" => Ok(DidType::Scid),
             _ => Err(format!("invalid did type: {s}")),
         }
     }
@@ -84,6 +95,12 @@ enum Commands {
         vid: String,
         #[arg(short, long)]
         alias: Option<String>,
+        #[arg(long)]
+        src: Option<String>,
+        #[arg(long)]
+        peer_src: Option<String>,
+        #[arg(long)]
+        source_method: Option<String>,
     },
     #[command(arg_required_else_help = true)]
     Print { alias: String },
@@ -102,6 +119,12 @@ enum Commands {
             help = "Specify a network address and port instead of HTTPS transport"
         )]
         tcp: Option<String>,
+        #[arg(long)]
+        source_method: Option<String>,
+        #[arg(long)]
+        src: Option<String>,
+        #[arg(long)]
+        peer_src: Option<String>,
     },
     #[command(about = "Update the DID:WEBVH. Currently, only a rotation of TSP keys is supported")]
     Update {
@@ -297,6 +320,230 @@ async fn ensure_vid_verified(
     }
 }
 
+fn build_scid_resolution_context(
+    vid: &str,
+    source_method: Option<String>,
+    src: Option<String>,
+    peer_src: Option<String>,
+) -> Result<Option<ScidResolutionContext>, Error> {
+    if !vid.starts_with("did:scid:") {
+        return Ok(None);
+    }
+
+    if source_method.is_none() && src.is_none() && peer_src.is_none() {
+        return tsp_sdk::vid::did::scid::query_resolution_context(vid).map_err(Error::Vid);
+    }
+
+    let did = tsp_sdk::vid::did::scid::parse(vid)?;
+    let context = build_create_scid_context(source_method, src, peer_src, None)?;
+
+    Ok(Some(canonicalize_scid_context(&did.scid, context)?))
+}
+
+fn build_create_scid_context(
+    source_method: Option<String>,
+    src: Option<String>,
+    peer_src: Option<String>,
+    default_src: Option<String>,
+) -> Result<ScidResolutionContext, Error> {
+    let source_method = match source_method {
+        Some(source_method) => parse_scid_source_method(&source_method)?,
+        None => ScidSourceMethod::Webvh,
+    };
+    let source_value = src.or(peer_src).or(default_src);
+
+    let locator = match source_method {
+        ScidSourceMethod::Webvh => ScidLocator::Src(source_value.ok_or_else(|| {
+            Error::Vid(VidError::ResolutionContextRequired(
+                "did:scid source path (--src or --peer-src) is required".to_string(),
+            ))
+        })?),
+        ScidSourceMethod::Cheqd => ScidLocator::Network(normalize_scid_cheqd_locator(
+            source_value.ok_or_else(|| {
+                Error::Vid(VidError::ResolutionContextRequired(
+                    "did:scid cheqd network (--src or --peer-src) is required".to_string(),
+                ))
+            })?,
+        )?),
+    };
+
+    Ok(ScidResolutionContext {
+        version: 1,
+        method: ScidMethod::Vh,
+        source_method,
+        locator,
+    })
+}
+
+fn parse_scid_source_method(value: &str) -> Result<ScidSourceMethod, Error> {
+    match value.to_ascii_lowercase().as_str() {
+        "webvh" => Ok(ScidSourceMethod::Webvh),
+        "cheqd" => Ok(ScidSourceMethod::Cheqd),
+        _ => Err(Error::Vid(VidError::UnsupportedScidSource(
+            value.to_string(),
+        ))),
+    }
+}
+
+fn merge_method_state(
+    vid_wallet: &AsyncSecureStore,
+    method_state: tsp_sdk::WalletMethodState,
+) -> Result<(), Error> {
+    for (kid, secret) in method_state.secret_keys {
+        vid_wallet.add_secret_key(kid, secret)?;
+    }
+
+    for (did, context) in method_state.resolution_contexts {
+        vid_wallet.register_resolution_context(did, context)?;
+    }
+
+    Ok(())
+}
+
+fn canonicalize_scid_context(
+    scid: &str,
+    context: ScidResolutionContext,
+) -> Result<ScidResolutionContext, Error> {
+    let locator = match context.locator {
+        ScidLocator::Src(src) => ScidLocator::Src(normalize_scid_webvh_locator(scid, &src)?),
+        ScidLocator::Network(network) => {
+            ScidLocator::Network(normalize_scid_cheqd_locator(network)?)
+        }
+    };
+
+    Ok(ScidResolutionContext {
+        version: context.version,
+        method: context.method,
+        source_method: context.source_method,
+        locator,
+    })
+}
+
+fn normalize_scid_webvh_locator(scid: &str, src: &str) -> Result<String, Error> {
+    if src.starts_with("did:webvh:") {
+        let parts = src.split(':').collect::<Vec<_>>();
+        match parts.get(2) {
+            Some(source_scid) if *source_scid == scid => Ok(src.to_string()),
+            _ => Err(Error::Vid(VidError::SourceDidMismatch(src.to_string()))),
+        }
+    } else {
+        let Some((host, path)) = src.split_once('/') else {
+            return Ok(format!("did:webvh:{scid}:{src}"));
+        };
+        Ok(format!(
+            "did:webvh:{scid}:{}:{}",
+            host.replace(':', "%3A"),
+            path.replace('/', ":")
+        ))
+    }
+}
+
+fn normalize_scid_cheqd_locator(src: String) -> Result<String, Error> {
+    if let Some(network) = src.strip_prefix("did:cheqd:") {
+        if network.is_empty() {
+            return Err(Error::Vid(VidError::InvalidScid(src)));
+        }
+
+        return Ok(network.to_string());
+    }
+
+    if src.starts_with("did:") {
+        return Err(Error::Vid(VidError::InvalidScid(src)));
+    }
+
+    Ok(src)
+}
+
+fn merge_scid_metadata(
+    verified_metadata: Option<serde_json::Value>,
+    private_state: Option<tsp_sdk::vid::did::scid::ScidPrivateState>,
+) -> Result<Option<serde_json::Value>, Error> {
+    let Some(metadata) = verified_metadata else {
+        return Ok(None);
+    };
+
+    let mut metadata: ScidVidMetadata =
+        serde_json::from_value(metadata).map_err(|error| Error::Vid(VidError::Serde(error)))?;
+    metadata.private_state = private_state;
+
+    Ok(Some(
+        serde_json::to_value(metadata).map_err(|error| Error::Vid(VidError::Serde(error)))?,
+    ))
+}
+
+async fn publish_scid_source(
+    client: &reqwest::Client,
+    did_server: &str,
+    source_vid: &Vid,
+    source_history: Option<&serde_json::Value>,
+    replace: bool,
+) -> Result<(), Error> {
+    let request = if replace {
+        client.put(format!("https://{did_server}/add-vid"))
+    } else {
+        client.post(format!("https://{did_server}/add-vid"))
+    };
+
+    let _: Vid = request
+        .json(source_vid)
+        .send()
+        .await
+        .inspect(|r| debug!("DID server responded with status code {}", r.status()))
+        .expect("Could not publish VID on server")
+        .error_for_status()
+        .map_err(|_| {
+            Error::Vid(VidError::InvalidVid(
+                "An error occurred while publishing the DID. Maybe this DID exists already?"
+                    .to_string(),
+            ))
+        })?
+        .json()
+        .await
+        .expect("Could not decode VID");
+
+    if let Some(source_history) = source_history {
+        let request = if replace {
+            client.put(format!(
+                "https://{did_server}/add-history/{}",
+                source_vid.identifier()
+            ))
+        } else {
+            client.post(format!(
+                "https://{did_server}/add-history/{}",
+                source_vid.identifier()
+            ))
+        };
+
+        request
+            .json(source_history)
+            .send()
+            .await
+            .inspect(|r| debug!("DID server responded with status code {}", r.status()))
+            .expect("Could not publish history on server")
+            .error_for_status()
+            .map_err(|_| {
+                Error::Vid(VidError::InvalidVid(
+                    "An error occurred while publishing the DID history.".to_string(),
+                ))
+            })?;
+    }
+
+    Ok(())
+}
+
+fn map_scid_update_error(error: VidError) -> Error {
+    match error {
+        VidError::InternalError(message)
+            if message
+                == "Server has precommit active but wallet has no matching key. Wallet may be out of sync."
+                || message == "Cannot find update keys to update the DID" =>
+        {
+            Error::MissingPrivateVid(message)
+        }
+        other => Error::Vid(other),
+    }
+}
+
 fn prompt(message: String) -> bool {
     use std::io::{self, BufRead, Write};
     print!("{message}? [y/n]");
@@ -381,8 +628,21 @@ async fn run() -> Result<(), Error> {
                 show_relations(&vids, None, &aliases)?;
             }
         }
-        Commands::Verify { vid, alias } => {
-            vid_wallet.verify_vid(&vid, alias).await?;
+        Commands::Verify {
+            vid,
+            alias,
+            src,
+            peer_src,
+            source_method,
+        } => {
+            let context = build_scid_resolution_context(&vid, source_method, src, peer_src)?;
+            let options = VerifyVidOptions {
+                resolution_context: context.clone().map(ResolutionContext::Scid),
+            };
+
+            vid_wallet
+                .verify_vid_with_options(&vid, alias, options)
+                .await?;
 
             info!("{vid} is verified and added to the wallet {}", &args.wallet);
         }
@@ -398,6 +658,9 @@ async fn run() -> Result<(), Error> {
             username,
             alias,
             tcp,
+            source_method,
+            src,
+            peer_src,
         } => {
             let transport = if let Some(address) = tcp {
                 Url::parse(&format!("tcp://{address}")).unwrap()
@@ -405,8 +668,8 @@ async fn run() -> Result<(), Error> {
                 Url::parse(&format!("https://{server}/endpoint/[vid_placeholder]",)).unwrap()
             };
 
-            let private_vid = match r#type {
-                DidType::Web => {
+            let (private_vid, metadata) = match r#type {
+                DidType::Web => (
                     create_did_web(
                         &did_server,
                         transport,
@@ -415,15 +678,16 @@ async fn run() -> Result<(), Error> {
                         alias,
                         &client,
                     )
-                    .await?
-                }
+                    .await?,
+                    None,
+                ),
                 DidType::Peer => {
                     let private_vid = OwnedVid::new_did_peer(transport);
 
                     vid_wallet.set_alias(username, private_vid.identifier().to_string())?;
 
                     info!("created peer identity {}", private_vid.identifier());
-                    private_vid
+                    (private_vid, None)
                 }
                 DidType::Webvh => {
                     let (private_vid, history, keys) = tsp_sdk::vid::did::webvh::create_webvh(
@@ -439,8 +703,6 @@ async fn run() -> Result<(), Error> {
                     vid_wallet
                         .add_secret_key(keys.next_update_kid.clone(), keys.next_update_key)
                         .expect("Cannot store next update key");
-
-                    // Store the next_update_kid in metadata so we know which key to use for next update
                     vid_wallet
                         .set_alias(
                             format!("__next_update_kid:{}", private_vid.identifier()),
@@ -502,109 +764,211 @@ async fn run() -> Result<(), Error> {
                         vid_wallet.set_alias(alias, private_vid.identifier().to_string())?;
                     }
 
-                    private_vid
+                    (private_vid, None)
+                }
+                DidType::Scid => {
+                    let default_src = format!("{did_server}/endpoint/{username}");
+                    let context =
+                        build_create_scid_context(source_method, src, peer_src, Some(default_src))?;
+                    let result =
+                        tsp_sdk::vid::did::scid::create(transport, context.clone()).await?;
+
+                    merge_method_state(&vid_wallet, result.method_state)?;
+                    publish_scid_source(
+                        &client,
+                        &did_server,
+                        &result.source_vid,
+                        result.source_history.as_ref(),
+                        false,
+                    )
+                    .await?;
+
+                    if let Some(alias) = alias {
+                        vid_wallet.set_alias(alias, result.private_vid.identifier().to_string())?;
+                    }
+
+                    let (_, verified_metadata) = verify_vid_with_options(
+                        result.private_vid.identifier(),
+                        VerifyVidOptions {
+                            resolution_context: Some(
+                                vid_wallet
+                                    .get_resolution_context(result.private_vid.identifier())?
+                                    .ok_or_else(|| {
+                                        Error::MissingVid(format!(
+                                            "Missing resolution context for {}",
+                                            result.private_vid.identifier()
+                                        ))
+                                    })?,
+                            ),
+                        },
+                    )
+                    .await
+                    .map_err(|err| Error::Vid(VidError::InvalidVid(err.to_string())))?;
+
+                    (
+                        result.private_vid,
+                        merge_scid_metadata(verified_metadata, result.metadata.private_state)?,
+                    )
                 }
             };
-            let (_, metadata) = verify_vid(private_vid.identifier())
-                .await
-                .map_err(|err| Error::Vid(VidError::InvalidVid(err.to_string())))?;
+            let metadata = match metadata {
+                Some(metadata) => Some(metadata),
+                None => {
+                    let (_, metadata) = verify_vid(private_vid.identifier())
+                        .await
+                        .map_err(|err| Error::Vid(VidError::InvalidVid(err.to_string())))?;
+                    metadata
+                }
+            };
             vid_wallet.add_private_vid(private_vid.clone(), metadata)?;
             info!("created VID {}", private_vid.identifier());
         }
         Commands::Update { vid } => {
-            let (_, _, keys) = vid_wallet.export()?;
+            let (_, _, method_state) = vid_wallet.export()?;
             let vid_alias = vid_wallet.try_resolve_alias(&vid)?;
             info!("Updating VID {vid_alias}");
-            let (resolved_vid, metadata) = tsp_sdk::vid::did::webvh::resolve(&vid_alias).await?;
-            let new_vid =
-                OwnedVid::bind(resolved_vid.identifier(), resolved_vid.endpoint().clone());
-            let metadata: WebvhMetadata = serde_json::from_value(metadata)
-                .expect("metadata should be of type 'WebvhMetadata'");
+            let exported = vid_wallet
+                .export()?
+                .0
+                .into_iter()
+                .find(|exported| exported.id == vid_alias)
+                .ok_or_else(|| Error::MissingVid(format!("Cannot find VID {vid_alias}")))?;
+            let private_vid = vid_wallet.get_private_vid(&vid_alias)?;
 
-            // Try to get the pre-committed next key first (for precommit support)
-            let next_kid_alias = format!("__next_update_kid:{}", resolved_vid.identifier());
-            let update_key = if let Ok(Some(next_kid)) = vid_wallet.resolve_alias(&next_kid_alias) {
-                // Use the pre-committed key
-                info!("Using pre-committed update key for rotation");
-                keys.get(&next_kid).ok_or_else(|| {
-                    Error::MissingPrivateVid("Pre-committed key not found in wallet".to_string())
-                })?
-            } else {
-                // No local precommit key - check if server has precommit active
-                if metadata.next_key_hashes.is_some() {
-                    error!("Server has nextKeyHashes but wallet has no precommit key");
-                    error!("This wallet may be out of sync - cannot rotate safely");
-                    return Err(Error::MissingPrivateVid(
-                        "Server has precommit active but wallet has no matching key. \
-                         Wallet may be out of sync."
-                            .to_string(),
-                    ));
-                }
+            if let Some(metadata) = exported.metadata.clone()
+                && let Ok(scid_metadata) = serde_json::from_value::<ScidVidMetadata>(metadata)
+            {
+                let update_result =
+                    tsp_sdk::vid::did::scid::update(&private_vid, scid_metadata, &method_state)
+                        .await
+                        .map_err(map_scid_update_error)?;
 
-                // Fall back to current update key (legacy DIDs without precommit)
-                let Some(update_keys) = metadata.update_keys else {
-                    error!("Cannot find update keys to update the DID");
-                    return Err(Error::MissingPrivateVid(
-                        "Cannot find update keys to update the DID".to_string(),
-                    ));
-                };
-                info!("Using current update key (migrating legacy DID to precommit)");
-                keys.get(&update_keys[0]).ok_or_else(|| {
-                    Error::MissingPrivateVid(
-                        "Cannot find update keys to update the DID".to_string(),
-                    )
-                })?
-            };
-
-            let update_result = tsp_sdk::vid::did::webvh::update(
-                vid_to_did_document(new_vid.vid()),
-                update_key.first_chunk::<32>().ok_or_else(|| {
-                    Error::Vid(VidError::WebVHError(
-                        "Couldn't get WebVH UpdateKey Secret bytes".to_string(),
-                    ))
-                })?,
-            )
-            .await?;
-
-            // Store the new next key for future precommit
-            vid_wallet
-                .add_secret_key(
-                    update_result.next_update_kid.clone(),
-                    update_result.next_update_key,
+                merge_method_state(&vid_wallet, update_result.method_state)?;
+                publish_scid_source(
+                    &client,
+                    &did_server,
+                    &update_result.source_vid,
+                    update_result.source_history_entry.as_ref(),
+                    true,
                 )
-                .expect("Cannot store new next update key");
-            vid_wallet
-                .set_alias(next_kid_alias, update_result.next_update_kid)
-                .expect("Cannot update next update key reference");
+                .await?;
 
-            client
-                .put(format!(
-                    "https://{did_server}/add-history/{}",
-                    new_vid.identifier()
-                ))
-                .json(&update_result.log_entry)
-                .send()
-                .await
-                .expect("Could not append history");
-
-            let update_response = client
-                .put(format!("https://{did_server}/add-vid"))
-                .json(new_vid.vid())
-                .send()
-                .await
-                .expect("Could not update DID")
-                .text()
-                .await
-                .expect("cannot extract text from server response");
-
-            debug!("did server responded: {}", update_response);
-
-            let (_, new_metadata) = verify_vid(new_vid.identifier())
+                let context = vid_wallet
+                    .get_resolution_context(update_result.private_vid.identifier())?
+                    .ok_or_else(|| {
+                        Error::MissingVid(format!(
+                            "Missing resolution context for {}",
+                            update_result.private_vid.identifier()
+                        ))
+                    })?;
+                let (_, new_metadata) = verify_vid_with_options(
+                    update_result.private_vid.identifier(),
+                    VerifyVidOptions {
+                        resolution_context: Some(context),
+                    },
+                )
                 .await
                 .map_err(|err| Error::Vid(VidError::InvalidVid(err.to_string())))?;
-            vid_wallet.add_private_vid(new_vid, new_metadata)?;
+                let new_metadata =
+                    merge_scid_metadata(new_metadata, update_result.metadata.private_state)?;
+                vid_wallet.add_private_vid(update_result.private_vid, new_metadata)?;
 
-            info!("VID updated with precommit - next key committed for future rotation");
+                info!("VID updated with presented/source scid flow");
+            } else {
+                let (resolved_vid, metadata) =
+                    tsp_sdk::vid::did::webvh::resolve(&vid_alias).await?;
+                let new_vid =
+                    OwnedVid::bind(resolved_vid.identifier(), resolved_vid.endpoint().clone());
+                let metadata: WebvhMetadata = serde_json::from_value(metadata)
+                    .expect("metadata should be of type 'WebvhMetadata'");
+
+                let next_kid_alias = format!("__next_update_kid:{}", resolved_vid.identifier());
+                let update_key =
+                    if let Ok(Some(next_kid)) = vid_wallet.resolve_alias(&next_kid_alias) {
+                        info!("Using pre-committed update key for rotation");
+                        method_state.secret_keys.get(&next_kid).ok_or_else(|| {
+                            Error::MissingPrivateVid(
+                                "Pre-committed key not found in wallet".to_string(),
+                            )
+                        })?
+                    } else {
+                        if metadata.next_key_hashes.is_some() {
+                            error!("Server has nextKeyHashes but wallet has no precommit key");
+                            error!("This wallet may be out of sync - cannot rotate safely");
+                            return Err(Error::MissingPrivateVid(
+                                "Server has precommit active but wallet has no matching key. \
+                             Wallet may be out of sync."
+                                    .to_string(),
+                            ));
+                        }
+
+                        let Some(update_keys) = metadata.update_keys else {
+                            error!("Cannot find update keys to update the DID");
+                            return Err(Error::MissingPrivateVid(
+                                "Cannot find update keys to update the DID".to_string(),
+                            ));
+                        };
+
+                        info!("Using current update key (migrating legacy DID to precommit)");
+                        method_state
+                            .secret_keys
+                            .get(&update_keys[0])
+                            .ok_or_else(|| {
+                                Error::MissingPrivateVid(
+                                    "Cannot find update keys to update the DID".to_string(),
+                                )
+                            })?
+                    };
+
+                let update_result = tsp_sdk::vid::did::webvh::update(
+                    vid_to_did_document(new_vid.vid()),
+                    update_key.first_chunk::<32>().ok_or_else(|| {
+                        Error::Vid(VidError::WebVHError(
+                            "Couldn't get WebVH UpdateKey Secret bytes".to_string(),
+                        ))
+                    })?,
+                )
+                .await?;
+
+                vid_wallet
+                    .add_secret_key(
+                        update_result.next_update_kid.clone(),
+                        update_result.next_update_key,
+                    )
+                    .expect("Cannot store new next update key");
+                vid_wallet
+                    .set_alias(next_kid_alias, update_result.next_update_kid)
+                    .expect("Cannot update next update key reference");
+
+                client
+                    .put(format!(
+                        "https://{did_server}/add-history/{}",
+                        new_vid.identifier()
+                    ))
+                    .json(&update_result.log_entry)
+                    .send()
+                    .await
+                    .expect("Could not append history");
+
+                let update_response = client
+                    .put(format!("https://{did_server}/add-vid"))
+                    .json(new_vid.vid())
+                    .send()
+                    .await
+                    .expect("Could not update DID")
+                    .text()
+                    .await
+                    .expect("cannot extract text from server response");
+
+                debug!("did server responded: {}", update_response);
+
+                let (_, new_metadata) = verify_vid(new_vid.identifier())
+                    .await
+                    .map_err(|err| Error::Vid(VidError::InvalidVid(err.to_string())))?;
+                vid_wallet.add_private_vid(new_vid, new_metadata)?;
+
+                info!("VID updated with precommit - next key committed for future rotation");
+            }
         }
         Commands::ImportPiv { file, alias } => {
             let private_vid = OwnedVid::from_file(file).await?;
@@ -1353,4 +1717,42 @@ async fn main() -> Result<(), ()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scid_peer_source_method_is_rejected() {
+        assert!(matches!(
+            parse_scid_source_method("peer"),
+            Err(Error::Vid(VidError::UnsupportedScidSource(method))) if method == "peer"
+        ));
+    }
+
+    #[test]
+    fn scid_peer_src_is_treated_as_external_webvh_source_value() {
+        let context = build_create_scid_context(
+            None,
+            None,
+            Some("example.com/users/alice".to_string()),
+            None,
+        )
+        .expect("context should build");
+
+        assert_eq!(context.source_method, ScidSourceMethod::Webvh);
+        assert_eq!(
+            context.locator,
+            ScidLocator::Src("example.com/users/alice".to_string())
+        );
+    }
+
+    #[test]
+    fn scid_webvh_locator_escapes_host_port() {
+        let locator = normalize_scid_webvh_locator("testscid", "localhost:3000/vid/path")
+            .expect("locator should normalize");
+
+        assert_eq!(locator, "did:webvh:testscid:localhost%3A3000:vid:path");
+    }
 }

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -32,7 +32,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tsp_sdk::{
     SecureStore, cesr,
     definitions::{Payload, VerifiedVid},
-    vid::{OwnedVid, Vid},
+    vid::{OwnedVid, Vid, did::scid::ScidVidMetadata},
 };
 
 #[derive(Debug, Parser)]
@@ -191,8 +191,15 @@ fn render_vid_page(did: &str, vid: &Vid, metadata: Option<&serde_json::Value>) -
         did.to_string()
     };
 
-    // Extract webvh-specific metadata if available
-    let (created, updated, version, update_keys) = if let Some(meta) = metadata {
+    let scid_metadata = metadata
+        .cloned()
+        .and_then(|meta| serde_json::from_value::<ScidVidMetadata>(meta).ok());
+    let source_metadata = scid_metadata
+        .as_ref()
+        .and_then(|meta| meta.source_metadata.as_ref())
+        .or(metadata);
+
+    let (created, updated, version, update_keys) = if let Some(meta) = source_metadata {
         let webvh_meta = meta.get("webvh_meta_data");
         let created = webvh_meta
             .and_then(|m| m.get("created"))
@@ -221,8 +228,11 @@ fn render_vid_page(did: &str, vid: &Vid, metadata: Option<&serde_json::Value>) -
     };
 
     let endpoint = vid.endpoint().to_string();
-    let is_webvh = did.starts_with("did:webvh:");
-    let did_type = if is_webvh {
+    let is_scid = scid_metadata.is_some();
+    let is_webvh = did.starts_with("did:webvh:") || is_scid;
+    let did_type = if is_scid {
+        "did:scid"
+    } else if did.starts_with("did:webvh:") {
         "did:webvh"
     } else if did.starts_with("did:web:") {
         "did:web"
@@ -283,6 +293,22 @@ fn render_vid_page(did: &str, vid: &Vid, metadata: Option<&serde_json::Value>) -
             {keys_html}
         </div>
         "#
+        )
+    } else {
+        String::new()
+    };
+
+    let source_section = if let Some(metadata) = scid_metadata.as_ref() {
+        format!(
+            r#"
+        <div class="section">
+            <div class="section-title">SCID SOURCE</div>
+            <div class="detail-row"><span>Presented DID</span><code>{}</code></div>
+            <div class="detail-row"><span>Source DID</span><code>{}</code></div>
+            <div class="detail-row"><span>Source Method</span><code>{:?}</code></div>
+        </div>
+        "#,
+            metadata.scid.presented_id, metadata.scid.source_did, metadata.scid.source_method
         )
     } else {
         String::new()
@@ -394,6 +420,20 @@ fn render_vid_page(did: &str, vid: &Vid, metadata: Option<&serde_json::Value>) -
             color: #666;
             word-break: break-all;
         }}
+        .detail-row {{
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 12px;
+        }}
+        .detail-row span {{
+            font-size: 12px;
+            color: #666;
+        }}
+        .detail-row code {{
+            font-size: 12px;
+            word-break: break-all;
+        }}
         .timeline {{
             position: relative;
             padding-left: 25px;
@@ -503,6 +543,7 @@ fn render_vid_page(did: &str, vid: &Vid, metadata: Option<&serde_json::Value>) -
                 <div class="endpoint">{endpoint}</div>
             </div>
 
+            {source_section}
             {history_section}
             {update_keys_section}
         </div>

--- a/examples/tests/cli_tests.rs
+++ b/examples/tests/cli_tests.rs
@@ -143,8 +143,7 @@ fn remove_next_update_alias(wallet_name: &str, did: &str) {
         let vault = AskarSecureStorage::open(&url, b"unsecure")
             .await
             .expect("Failed to open wallet storage");
-        let (vids, mut aliases, keys) = vault.read().await.expect("Failed to read wallet");
-
+        let (vids, mut aliases, method_state) = vault.read().await.expect("Failed to read wallet");
         let next_kid_alias = format!("__next_update_kid:{did}");
         let removed = aliases.remove(&next_kid_alias);
         assert!(
@@ -153,7 +152,7 @@ fn remove_next_update_alias(wallet_name: &str, did: &str) {
         );
 
         let db = AsyncSecureStore::new();
-        db.import(vids, aliases, keys)
+        db.import(vids, aliases, method_state)
             .expect("Failed to import wallet state");
         vault
             .persist(db.export().expect("Failed to export wallet state"))

--- a/tsp_sdk/benches/common/report.rs
+++ b/tsp_sdk/benches/common/report.rs
@@ -22,10 +22,10 @@ pub fn project_root() -> anyhow::Result<PathBuf> {
 }
 
 pub fn git_sha(project_root: &Path) -> anyhow::Result<String> {
-    if let Ok(sha) = env::var("GITHUB_SHA") {
-        if !sha.trim().is_empty() {
-            return Ok(sha);
-        }
+    if let Ok(sha) = env::var("GITHUB_SHA")
+        && !sha.trim().is_empty()
+    {
+        return Ok(sha);
     }
     let out = Command::new("git")
         .current_dir(project_root)
@@ -86,10 +86,10 @@ pub fn read_lock_version(project_root: &Path, package_name: &str) -> Option<Stri
             name = rest.trim().trim_matches('"').into();
             continue;
         }
-        if name == Some(package_name) {
-            if let Some(rest) = line.strip_prefix("version = ") {
-                return Some(rest.trim().trim_matches('"').to_string());
-            }
+        if name == Some(package_name)
+            && let Some(rest) = line.strip_prefix("version = ")
+        {
+            return Some(rest.trim().trim_matches('"').to_string());
         }
     }
     None

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -5,7 +5,8 @@ use crate::{
     crypto::CryptoError,
     definitions::{Digest, ReceivedTspMessage, TSPStream, VerifiedVid},
     error::Error,
-    store::{Aliases, SecureStore, WebvhUpdateKeys},
+    store::{Aliases, SecureStore, WalletMethodState},
+    vid::{ResolutionContext, VerifyVidOptions},
 };
 use bytes::BytesMut;
 use futures::StreamExt;
@@ -52,7 +53,7 @@ impl AsyncSecureStore {
     }
 
     /// Export the wallet to serializable default types
-    pub fn export(&self) -> Result<(Vec<ExportVid>, Aliases, WebvhUpdateKeys), Error> {
+    pub fn export(&self) -> Result<(Vec<ExportVid>, Aliases, WalletMethodState), Error> {
         self.inner.export()
     }
 
@@ -66,9 +67,9 @@ impl AsyncSecureStore {
         &self,
         vids: Vec<ExportVid>,
         aliases: Aliases,
-        keys: WebvhUpdateKeys,
+        method_state: WalletMethodState,
     ) -> Result<(), Error> {
-        self.inner.import(vids, aliases, keys)
+        self.inner.import(vids, aliases, method_state)
     }
 
     /// Get the current relationship status for a VID pair
@@ -135,6 +136,11 @@ impl AsyncSecureStore {
         self.inner.has_private_vid(vid)
     }
 
+    /// Retrieve the [OwnedVid] identified by `vid` from the wallet if it exists.
+    pub fn get_private_vid(&self, vid: &str) -> Result<OwnedVid, Error> {
+        self.inner.get_owned_private_vid(vid)
+    }
+
     /// Check whether the [VerifiedVid] identified by `vid` exists in the wallet
     pub fn has_verified_vid(&self, vid: &str) -> Result<bool, Error> {
         self.inner.has_verified_vid(vid)
@@ -147,12 +153,29 @@ impl AsyncSecureStore {
 
     /// Resolve and verify public key material for a VID identified by `vid` and add it to the wallet as a relationship
     pub async fn verify_vid(&self, vid: &str, alias: Option<String>) -> Result<(), Error> {
-        let (verified_vid, metadata) = crate::vid::verify_vid(vid).await?;
+        self.verify_vid_with_options(vid, alias, VerifyVidOptions::default())
+            .await
+    }
 
+    /// Resolve and verify public key material for a VID identified by `vid` and add it to the wallet as a relationship
+    pub async fn verify_vid_with_options(
+        &self,
+        vid: &str,
+        alias: Option<String>,
+        options: VerifyVidOptions,
+    ) -> Result<(), Error> {
+        let resolution_context = verification_resolution_context(vid, &options)?;
+        let (verified_vid, metadata) = crate::vid::verify_vid_with_options(vid, options).await?;
+
+        let verified_vid_id = verified_vid.identifier().to_string();
         self.inner.add_verified_vid(verified_vid, metadata)?;
 
+        if let Some(context) = resolution_context {
+            self.register_resolution_context(verified_vid_id.clone(), context)?;
+        }
+
         if let Some(alias) = alias {
-            self.set_alias(alias, vid.to_owned())?;
+            self.set_alias(alias, verified_vid_id)?;
         }
 
         Ok(())
@@ -179,6 +202,18 @@ impl AsyncSecureStore {
 
     pub fn get_secret_key(&self, kid: &str) -> Result<Option<Vec<u8>>, Error> {
         self.inner.get_secret_key(kid)
+    }
+
+    pub fn register_resolution_context(
+        &self,
+        did: String,
+        context: ResolutionContext,
+    ) -> Result<(), Error> {
+        self.inner.register_resolution_context(did, context)
+    }
+
+    pub fn get_resolution_context(&self, did: &str) -> Result<Option<ResolutionContext>, Error> {
+        self.inner.get_resolution_context(did)
     }
 
     /// Seal a TSP message.
@@ -571,12 +606,23 @@ impl AsyncSecureStore {
                     match db_inner.open_message(&mut message) {
                         Err(Error::UnverifiedSource(unknown_vid, _)) => {
                             debug!("Verifying VID: {}", unknown_vid);
-                            self_inner.verify_vid(&unknown_vid, None).await?;
+                            let options = VerifyVidOptions {
+                                resolution_context: self_inner
+                                    .get_resolution_context(&unknown_vid)?,
+                            };
+                            self_inner
+                                .verify_vid_with_options(&unknown_vid, None, options)
+                                .await?;
                             db_inner.open_message(&mut message)
                         }
                         Err(Error::Crypto(CryptoError::Verify(vid, _))) => {
                             debug!("Re-verifying VID: {}", vid);
-                            self_inner.verify_vid(&vid, None).await?;
+                            let options = VerifyVidOptions {
+                                resolution_context: self_inner.get_resolution_context(&vid)?,
+                            };
+                            self_inner
+                                .verify_vid_with_options(&vid, None, options)
+                                .await?;
                             db_inner.open_message(&mut message)
                         }
                         maybe_message => maybe_message,
@@ -641,7 +687,12 @@ impl AsyncSecureStore {
                 match db_inner.open_message(&mut message) {
                     Err(Error::UnverifiedSource(unknown_vid, _)) => {
                         debug!("Verifying VID: {}", unknown_vid);
-                        self_inner.verify_vid(&unknown_vid, None).await?;
+                        let options = VerifyVidOptions {
+                            resolution_context: self_inner.get_resolution_context(&unknown_vid)?,
+                        };
+                        self_inner
+                            .verify_vid_with_options(&unknown_vid, None, options)
+                            .await?;
                         db_inner.open_message(&mut message)
                     }
                     Err(Error::UnverifiedVid(unknown_vid)) => {
@@ -651,7 +702,12 @@ impl AsyncSecureStore {
                     }
                     Err(Error::Crypto(CryptoError::Verify(vid, _))) => {
                         debug!("Re-verifying VID: {}", vid);
-                        self_inner.verify_vid(&vid, None).await?;
+                        let options = VerifyVidOptions {
+                            resolution_context: self_inner.get_resolution_context(&vid)?,
+                        };
+                        self_inner
+                            .verify_vid_with_options(&vid, None, options)
+                            .await?;
                         db_inner.open_message(&mut message)
                     }
                     maybe_message => maybe_message,
@@ -691,8 +747,93 @@ impl AsyncSecureStore {
         vid: &str,
         mut payload: BytesMut,
     ) -> Result<ReceivedTspMessage, Error> {
-        self.verify_vid(vid, None).await?;
+        let options = VerifyVidOptions {
+            resolution_context: self.get_resolution_context(vid)?,
+        };
+        self.verify_vid_with_options(vid, None, options).await?;
 
         Ok(self.inner.open_message(&mut payload)?.into_owned())
+    }
+}
+
+fn verification_resolution_context(
+    vid: &str,
+    options: &VerifyVidOptions,
+) -> Result<Option<ResolutionContext>, Error> {
+    if !vid.starts_with("did:scid:") {
+        return Ok(None);
+    }
+
+    if let Some(context) = options.resolution_context.clone() {
+        return Ok(Some(context));
+    }
+
+    Ok(crate::vid::did::scid::query_resolution_context(vid)?.map(ResolutionContext::Scid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vid::did::scid::{ScidLocator, ScidMethod, ScidResolutionContext, ScidSourceMethod};
+
+    #[test]
+    fn verification_context_prefers_explicit_options() {
+        let context = ResolutionContext::Scid(ScidResolutionContext {
+            version: 1,
+            method: ScidMethod::Vh,
+            source_method: ScidSourceMethod::Webvh,
+            locator: ScidLocator::Src("did:webvh:testscid:example.com:explicit".to_string()),
+        });
+        let options = VerifyVidOptions {
+            resolution_context: Some(context),
+        };
+
+        let resolved = verification_resolution_context(
+            "did:scid:vh:1:testscid?src=example.com/query",
+            &options,
+        )
+        .expect("context should resolve");
+
+        match resolved {
+            Some(ResolutionContext::Scid(context)) => assert_eq!(
+                context.locator,
+                ScidLocator::Src("did:webvh:testscid:example.com:explicit".to_string())
+            ),
+            _ => panic!("expected scid context"),
+        }
+    }
+
+    #[test]
+    fn verification_context_ignores_non_scid_vids() {
+        let options = VerifyVidOptions {
+            resolution_context: Some(ResolutionContext::Scid(ScidResolutionContext {
+                version: 1,
+                method: ScidMethod::Vh,
+                source_method: ScidSourceMethod::Webvh,
+                locator: ScidLocator::Src("did:webvh:testscid:example.com:explicit".to_string()),
+            })),
+        };
+
+        let resolved = verification_resolution_context("did:web:example.com:alice", &options)
+            .expect("non-scid context check should not fail");
+
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn verification_context_derives_query_src() {
+        let resolved = verification_resolution_context(
+            "did:scid:vh:1:testscid?src=localhost:3000/vid/path",
+            &VerifyVidOptions::default(),
+        )
+        .expect("context should resolve");
+
+        match resolved {
+            Some(ResolutionContext::Scid(context)) => assert_eq!(
+                context.locator,
+                ScidLocator::Src("did:webvh:testscid:localhost%3A3000:vid:path".to_string())
+            ),
+            _ => panic!("expected scid context"),
+        }
     }
 }

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -177,5 +177,5 @@ pub use definitions::{
     VerifiedVid,
 };
 pub use error::Error;
-pub use store::{Aliases, SecureStore};
-pub use vid::{ExportVid, OwnedVid, Vid};
+pub use store::{Aliases, SecureStore, WalletMethodState};
+pub use vid::{ExportVid, OwnedVid, ResolutionContext, VerifyVidOptions, Vid};

--- a/tsp_sdk/src/secure_storage.rs
+++ b/tsp_sdk/src/secure_storage.rs
@@ -6,7 +6,7 @@ use crate::definitions::{
 use crate::{
     Error, ExportVid, PendingIncomingParallelRelationship, PendingParallelRelationship,
     RelationshipStatus,
-    store::{Aliases, WebvhUpdateKeys},
+    store::{Aliases, WalletMethodState},
 };
 use aries_askar::{ErrorKind, StoreKeyMethod, entry::EntryOperation};
 use async_trait::async_trait;
@@ -24,11 +24,11 @@ pub trait SecureStorage: Sized {
     /// Write data from memory to secure storage
     async fn persist(
         &self,
-        (vids, aliases, update_keys): (Vec<ExportVid>, Aliases, WebvhUpdateKeys),
+        state: (Vec<ExportVid>, Aliases, WalletMethodState),
     ) -> Result<(), Error>;
 
     /// Read data from secure storage to memory
-    async fn read(&self) -> Result<(Vec<ExportVid>, Aliases, WebvhUpdateKeys), Error>;
+    async fn read(&self) -> Result<(Vec<ExportVid>, Aliases, WalletMethodState), Error>;
 
     /// Close the secure storage
     async fn close(self) -> Result<(), Error>;
@@ -187,7 +187,7 @@ impl SecureStorage for AskarSecureStorage {
 
     async fn persist(
         &self,
-        (vids, aliases, keys): (Vec<ExportVid>, Aliases, WebvhUpdateKeys),
+        (vids, aliases, method_state): (Vec<ExportVid>, Aliases, WalletMethodState),
     ) -> Result<(), Error> {
         let mut conn = self.inner.session(None).await?;
 
@@ -338,23 +338,51 @@ impl SecureStorage for AskarSecureStorage {
             }
         }
 
-        if let Ok(update_keys) = serde_json::to_value(&keys)
-            && let Err(e) = conn
-                .insert(
-                    "webvh_update_keys",
-                    "all",
-                    update_keys.to_string().as_bytes(),
-                    None,
-                    None,
-                )
-                .await
+        let secret_keys = serde_json::to_value(&method_state.secret_keys)
+            .map_err(|_| Error::DecodeState("could not encode secret keys for storage"))?;
+        if let Err(e) = conn
+            .insert(
+                "method_state",
+                "secret_keys",
+                secret_keys.to_string().as_bytes(),
+                None,
+                None,
+            )
+            .await
         {
             if e.kind() == ErrorKind::Duplicate {
                 conn.update(
                     EntryOperation::Replace,
-                    "webvh_update_keys",
-                    "all",
-                    Some(update_keys.to_string().as_bytes()),
+                    "method_state",
+                    "secret_keys",
+                    Some(secret_keys.to_string().as_bytes()),
+                    None,
+                    None,
+                )
+                .await?;
+            } else {
+                Err(Error::from(e))?;
+            }
+        }
+
+        let resolution_contexts = serde_json::to_value(&method_state.resolution_contexts)
+            .map_err(|_| Error::DecodeState("could not encode resolution contexts for storage"))?;
+        if let Err(e) = conn
+            .insert(
+                "method_state",
+                "resolution_contexts",
+                resolution_contexts.to_string().as_bytes(),
+                None,
+                None,
+            )
+            .await
+        {
+            if e.kind() == ErrorKind::Duplicate {
+                conn.update(
+                    EntryOperation::Replace,
+                    "method_state",
+                    "resolution_contexts",
+                    Some(resolution_contexts.to_string().as_bytes()),
                     None,
                     None,
                 )
@@ -369,7 +397,7 @@ impl SecureStorage for AskarSecureStorage {
         Ok(())
     }
 
-    async fn read(&self) -> Result<(Vec<ExportVid>, Aliases, WebvhUpdateKeys), Error> {
+    async fn read(&self) -> Result<(Vec<ExportVid>, Aliases, WalletMethodState), Error> {
         let mut vids = Vec::new();
 
         let mut conn = self.inner.session(None).await?;
@@ -446,15 +474,36 @@ impl SecureStorage for AskarSecureStorage {
             None => HashMap::new(),
         };
 
-        let keys = match conn.fetch("webvh_update_keys", "all", false).await? {
+        let secret_keys = match conn.fetch("method_state", "secret_keys", false).await? {
             Some(data) => serde_json::from_slice(&data.value)
-                .map_err(|_| Error::DecodeState("could not webvh keys from storage"))?,
+                .map_err(|_| Error::DecodeState("could not decode secret keys from storage"))?,
+            None => match conn.fetch("webvh_update_keys", "all", false).await? {
+                Some(data) => serde_json::from_slice(&data.value)
+                    .map_err(|_| Error::DecodeState("could not webvh keys from storage"))?,
+                None => HashMap::new(),
+            },
+        };
+
+        let resolution_contexts = match conn
+            .fetch("method_state", "resolution_contexts", false)
+            .await?
+        {
+            Some(data) => serde_json::from_slice(&data.value).map_err(|_| {
+                Error::DecodeState("could not decode resolution contexts from storage")
+            })?,
             None => HashMap::new(),
         };
 
         conn.commit().await?;
 
-        Ok((vids, aliases, keys))
+        Ok((
+            vids,
+            aliases,
+            WalletMethodState {
+                secret_keys,
+                resolution_contexts,
+            },
+        ))
     }
 
     async fn close(self) -> Result<(), Error> {

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -22,6 +22,9 @@ use std::{
 };
 use url::Url;
 
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Clone)]
 pub(crate) struct VidContext {
     vid: Arc<dyn VerifiedVid>,
@@ -215,7 +218,19 @@ fn random_nonce_bytes() -> [u8; 32] {
 }
 
 pub type Aliases = HashMap<String, String>;
-pub type WebvhUpdateKeys = HashMap<String, Vec<u8>>;
+pub type MethodSecretKeys = HashMap<String, Vec<u8>>;
+pub type ResolutionContexts = HashMap<String, crate::vid::ResolutionContext>;
+
+#[cfg_attr(
+    feature = "serialize",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[derive(Clone, Debug, Default)]
+pub struct WalletMethodState {
+    pub secret_keys: MethodSecretKeys,
+    pub resolution_contexts: ResolutionContexts,
+}
 
 /// Holds private and verified VIDs
 ///
@@ -228,7 +243,7 @@ pub type WebvhUpdateKeys = HashMap<String, Vec<u8>>;
 pub struct SecureStore {
     pub(crate) vids: Arc<RwLock<HashMap<String, VidContext>>>,
     pub(crate) aliases: Arc<RwLock<Aliases>>,
-    pub(crate) keys: Arc<RwLock<WebvhUpdateKeys>>,
+    pub(crate) method_state: Arc<RwLock<WalletMethodState>>,
 }
 
 /// This wallet is used to store and resolve VIDs
@@ -239,7 +254,7 @@ impl SecureStore {
     }
 
     /// Export the wallet to serializable default types
-    pub fn export(&self) -> Result<(Vec<ExportVid>, Aliases, WebvhUpdateKeys), Error> {
+    pub fn export(&self) -> Result<(Vec<ExportVid>, Aliases, WalletMethodState), Error> {
         let vids = self
             .vids
             .read()?
@@ -268,7 +283,7 @@ impl SecureStore {
         Ok((
             vids,
             self.aliases.read()?.clone(),
-            self.keys.read()?.clone(),
+            self.method_state.read()?.clone(),
         ))
     }
 
@@ -277,7 +292,7 @@ impl SecureStore {
         &self,
         vids: Vec<ExportVid>,
         aliases: Aliases,
-        keys: WebvhUpdateKeys,
+        method_state: WalletMethodState,
     ) -> Result<(), Error> {
         vids.into_iter().try_for_each(|vid| {
             self.vids.write()?.insert(
@@ -300,10 +315,7 @@ impl SecureStore {
             Ok::<(), Error>(())
         })?;
 
-        keys.into_iter().try_for_each(|(k, v)| {
-            self.add_secret_key(k, v)?;
-            Ok::<(), Error>(())
-        })?;
+        *self.method_state.write()? = method_state;
 
         aliases.into_iter().try_for_each(|(k, v)| {
             self.set_alias(k, v)?;
@@ -312,12 +324,39 @@ impl SecureStore {
     }
 
     pub fn add_secret_key(&self, kid: String, secret_key: Vec<u8>) -> Result<(), Error> {
-        self.keys.write()?.insert(kid, secret_key);
+        self.method_state
+            .write()?
+            .secret_keys
+            .insert(kid, secret_key);
         Ok(())
     }
 
     pub fn get_secret_key(&self, kid: &str) -> Result<Option<Vec<u8>>, Error> {
-        Ok(self.keys.read()?.get(kid).cloned())
+        Ok(self.method_state.read()?.secret_keys.get(kid).cloned())
+    }
+
+    pub fn register_resolution_context(
+        &self,
+        did: String,
+        context: crate::vid::ResolutionContext,
+    ) -> Result<(), Error> {
+        self.method_state
+            .write()?
+            .resolution_contexts
+            .insert(did, context);
+        Ok(())
+    }
+
+    pub fn get_resolution_context(
+        &self,
+        did: &str,
+    ) -> Result<Option<crate::vid::ResolutionContext>, Error> {
+        Ok(self
+            .method_state
+            .read()?
+            .resolution_contexts
+            .get(did)
+            .cloned())
     }
 
     /// Add the already resolved `verified_vid` to the wallet as a relationship
@@ -516,6 +555,19 @@ impl SecureStore {
             Some(private) => Ok(private),
             None => Err(Error::MissingPrivateVid(vid.to_string())),
         }
+    }
+
+    pub fn get_owned_private_vid(&self, vid: &str) -> Result<OwnedVid, Error> {
+        let context = self.get_vid(vid)?;
+        let Some(private) = context.private else {
+            return Err(Error::MissingPrivateVid(vid.to_string()));
+        };
+
+        Ok(OwnedVid::from_parts(
+            crate::vid::Vid::from_verified(context.vid.as_ref()),
+            private.signing_key().clone(),
+            private.decryption_key().clone(),
+        ))
     }
 
     /// Check whether the [VerifiedVid] identified by `vid` exists in the wallet

--- a/tsp_sdk/src/test.rs
+++ b/tsp_sdk/src/test.rs
@@ -791,6 +791,94 @@ async fn test_persisted_store_roundtrip_reopens_dirty_wallet() {
     assert!(!sealed_message.is_empty());
 }
 
+#[tokio::test]
+async fn test_resolution_context_export_import_roundtrip() {
+    let store = create_async_test_store();
+    let presented_did = "did:scid:vh:1:testscid";
+    let context = create_test_scid_context(presented_did);
+
+    store
+        .register_resolution_context(presented_did.to_string(), context.clone())
+        .unwrap();
+
+    let (vids, aliases, method_state) = store.export().unwrap();
+    let reopened = create_async_test_store();
+    reopened.import(vids, aliases, method_state).unwrap();
+
+    assert!(
+        reopened
+            .get_resolution_context(presented_did)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        format!(
+            "{:?}",
+            reopened.get_resolution_context(presented_did).unwrap()
+        ),
+        format!("{:?}", Some(context))
+    );
+}
+
+#[test]
+fn test_resolution_context_json_roundtrip() {
+    let presented_did = "did:scid:vh:1:testscid";
+    let context = create_test_scid_context(presented_did);
+
+    let json = serde_json::to_value(&context).expect("resolution context should serialize");
+    let decoded: crate::ResolutionContext =
+        serde_json::from_value(json).expect("resolution context should deserialize");
+
+    assert_eq!(format!("{decoded:?}"), format!("{context:?}"));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn test_persisted_store_roundtrip_preserves_resolution_contexts() {
+    let presented_did = "did:scid:vh:1:testscid";
+    let store = create_async_test_store();
+    store
+        .add_private_vid(
+            OwnedVid::bind(
+                presented_did,
+                "tcp://127.0.0.1:45123"
+                    .parse()
+                    .expect("test transport should parse"),
+            ),
+            None,
+        )
+        .unwrap();
+    store
+        .register_resolution_context(
+            presented_did.to_string(),
+            create_test_scid_context(presented_did),
+        )
+        .unwrap();
+
+    let fixture = create_persisted_store().await;
+    fixture.persist_from(&store).await;
+
+    let storage = AskarSecureStorage::open(fixture.storage_url(), fixture.password())
+        .await
+        .expect("persisted wallet should reopen");
+    let (_vids, _aliases, method_state) =
+        storage.read().await.expect("persisted wallet should read");
+    storage
+        .close()
+        .await
+        .expect("persisted wallet should close");
+
+    assert!(method_state.resolution_contexts.contains_key(presented_did));
+
+    let reopened = fixture.reopen_into_store().await;
+
+    assert!(
+        reopened
+            .get_resolution_context(presented_did)
+            .unwrap()
+            .is_some()
+    );
+}
 fn setup_transition_pair() -> (AsyncSecureStore, String, AsyncSecureStore, String) {
     let a_store = create_async_test_store();
     let b_store = create_async_test_store();

--- a/tsp_sdk/src/test_utils.rs
+++ b/tsp_sdk/src/test_utils.rs
@@ -3,7 +3,12 @@
 use crate::{
     ExportVid, OwnedVid, RelationshipStatus, SecureStore,
     definitions::{Digest, PendingNestedRelationship, VerifiedVid},
-    store::{Aliases, WebvhUpdateKeys},
+    store::{Aliases, WalletMethodState},
+};
+#[cfg(feature = "resolve")]
+use crate::{
+    ResolutionContext,
+    vid::did::scid::{ScidLocator, ScidMethod, ScidResolutionContext, ScidSourceMethod},
 };
 use once_cell::sync::Lazy;
 use std::{
@@ -93,6 +98,21 @@ pub async fn create_vid_from_file(path: &str) -> OwnedVid {
 /// Create a test SecureStore.
 pub fn create_test_store() -> SecureStore {
     SecureStore::new()
+}
+
+/// Create a test did:scid resolution context for WebVH-backed identities.
+#[cfg(feature = "resolve")]
+pub fn create_test_scid_context(presented_did: &str) -> ResolutionContext {
+    let scid = crate::vid::did::scid::parse(presented_did)
+        .expect("presented did:scid should parse")
+        .scid;
+
+    ResolutionContext::Scid(ScidResolutionContext {
+        version: 1,
+        method: ScidMethod::Vh,
+        source_method: ScidSourceMethod::Webvh,
+        locator: ScidLocator::Src(format!("did:webvh:{scid}:example.com:test")),
+    })
 }
 
 /// Create a test AsyncSecureStore.
@@ -254,7 +274,7 @@ pub fn relationship_status_signature(status: RelationshipStatus) -> String {
 fn export_snapshot_parts(
     vids: Vec<ExportVid>,
     aliases: Aliases,
-    keys: WebvhUpdateKeys,
+    method_state: WalletMethodState,
 ) -> StoreExportSnapshot {
     let mut vid_rows = vids
         .into_iter()
@@ -277,10 +297,17 @@ fn export_snapshot_parts(
         .collect::<Vec<_>>();
     vid_rows.sort();
 
-    let key_rows = keys
+    let mut key_rows = method_state
+        .secret_keys
         .into_iter()
         .map(|(k, v)| (k, format!("{v:?}")))
         .collect::<BTreeMap<_, _>>();
+    key_rows.extend(
+        method_state
+            .resolution_contexts
+            .into_iter()
+            .map(|(k, v)| (format!("resolution_context:{k}"), format!("{v:?}"))),
+    );
 
     (
         aliases.into_iter().collect::<BTreeMap<_, _>>(),
@@ -979,10 +1006,12 @@ mod tests {
     async fn test_repo_wallet_fixture_roundtrip() {
         let fixture = create_repo_wallet_fixture(RepoWalletFixture::CurrentDirtySmall);
         let reopened = fixture.reopen_into_store().await;
-        let (vids, aliases, keys) = reopened.export().unwrap();
+        let (vids, aliases, method_state) = reopened.export().unwrap();
         assert!(!vids.is_empty());
         assert!(
-            !aliases.is_empty() || !keys.is_empty(),
+            !aliases.is_empty()
+                || !method_state.secret_keys.is_empty()
+                || !method_state.resolution_contexts.is_empty(),
             "repo wallet fixture should carry dirty wallet state"
         );
     }

--- a/tsp_sdk/src/vid/did/mod.rs
+++ b/tsp_sdk/src/vid/did/mod.rs
@@ -9,4 +9,7 @@ pub mod web;
 pub mod webvh;
 
 #[cfg(feature = "resolve")]
+pub mod scid;
+
+#[cfg(feature = "resolve")]
 pub use web::get_resolve_url;

--- a/tsp_sdk/src/vid/did/scid.rs
+++ b/tsp_sdk/src/vid/did/scid.rs
@@ -1,0 +1,572 @@
+use crate::{
+    OwnedVid,
+    definitions::VerifiedVid,
+    store::WalletMethodState,
+    vid::{
+        ResolutionContext, VerifyVidOptions, VidError,
+        did::{web, webvh},
+    },
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+pub(crate) const SCHEME: &str = "scid";
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum ScidMethod {
+    Vh,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum ScidSourceMethod {
+    Webvh,
+    Cheqd,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "type", content = "value", rename_all = "camelCase")]
+pub enum ScidLocator {
+    Src(String),
+    Network(String),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScidDid {
+    pub presented_id: String,
+    pub method: ScidMethod,
+    pub version: u8,
+    pub scid: String,
+    pub src: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScidResolutionContext {
+    pub version: u8,
+    pub method: ScidMethod,
+    pub source_method: ScidSourceMethod,
+    pub locator: ScidLocator,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScidResolvedSource {
+    pub presented_id: String,
+    pub source_did: String,
+    pub source_method: ScidSourceMethod,
+    pub resolve_url: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScidVidMetadata {
+    pub scid: ScidResolvedSource,
+    pub source_metadata: Option<serde_json::Value>,
+    pub private_state: Option<ScidPrivateState>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScidPrivateState {
+    pub source_did: String,
+    pub source_method: ScidSourceMethod,
+    pub current_update_kid: Option<String>,
+    pub next_update_kid: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ScidCreateResult {
+    pub private_vid: crate::OwnedVid,
+    pub source_vid: crate::Vid,
+    pub source_history: Option<serde_json::Value>,
+    pub metadata: ScidVidMetadata,
+    pub method_state: crate::store::WalletMethodState,
+}
+
+#[derive(Clone, Debug)]
+pub struct ScidUpdateResult {
+    pub private_vid: crate::OwnedVid,
+    pub source_vid: crate::Vid,
+    pub source_history_entry: Option<serde_json::Value>,
+    pub metadata: ScidVidMetadata,
+    pub method_state: crate::store::WalletMethodState,
+}
+
+pub fn parse(id: &str) -> Result<ScidDid, VidError> {
+    let (base, src) = parse_scid_query(id)?;
+
+    let parts = base.split(':').collect::<Vec<_>>();
+    let [did, scheme, method, version, scid] = parts.as_slice() else {
+        return Err(VidError::InvalidScid(id.to_string()));
+    };
+
+    if *did != "did" || *scheme != SCHEME {
+        return Err(VidError::InvalidScid(id.to_string()));
+    }
+
+    let method = match *method {
+        "vh" => ScidMethod::Vh,
+        _ => return Err(VidError::InvalidScid(id.to_string())),
+    };
+
+    let version = version
+        .parse::<u8>()
+        .map_err(|_| VidError::InvalidScid(id.to_string()))?;
+
+    if version != 1 || scid.is_empty() {
+        return Err(VidError::InvalidScid(id.to_string()));
+    }
+
+    Ok(ScidDid {
+        presented_id: base.clone(),
+        method,
+        version,
+        scid: (*scid).to_string(),
+        src,
+    })
+}
+
+pub fn resolve_source(
+    did: &ScidDid,
+    context: Option<&ScidResolutionContext>,
+) -> Result<ScidResolvedSource, VidError> {
+    let context = context
+        .cloned()
+        .map(Ok)
+        .or_else(|| {
+            did.src
+                .as_deref()
+                .map(|src| context_from_src(&did.scid, src))
+        })
+        .transpose()?
+        .ok_or_else(|| VidError::ResolutionContextRequired(did.presented_id.clone()))?;
+
+    if context.version != did.version || context.method != did.method {
+        return Err(VidError::InvalidScid(did.presented_id.clone()));
+    }
+
+    match (context.source_method, &context.locator) {
+        (ScidSourceMethod::Webvh, ScidLocator::Src(src)) => {
+            let source_did = normalize_webvh_source(src, &did.scid)?;
+
+            Ok(ScidResolvedSource {
+                presented_id: did.presented_id.clone(),
+                resolve_url: Some(web::get_resolve_url(&source_did)?.to_string()),
+                source_did,
+                source_method: ScidSourceMethod::Webvh,
+            })
+        }
+        (ScidSourceMethod::Cheqd, ScidLocator::Network(network)) => {
+            let source_did = format!("did:cheqd:{network}:{}", did.scid);
+
+            Ok(ScidResolvedSource {
+                presented_id: did.presented_id.clone(),
+                resolve_url: None,
+                source_did,
+                source_method: ScidSourceMethod::Cheqd,
+            })
+        }
+        _ => Err(VidError::InvalidScid(did.presented_id.clone())),
+    }
+}
+
+pub async fn resolve(
+    id: &str,
+    options: VerifyVidOptions,
+) -> Result<(crate::Vid, serde_json::Value), VidError> {
+    let did = parse(id)?;
+    let resolved = resolve_source(&did, options.resolution_context.as_ref().and_then(as_scid))?;
+
+    match resolved.source_method {
+        ScidSourceMethod::Webvh => {
+            let (source_vid, source_metadata) = webvh::resolve(&resolved.source_did).await?;
+
+            if source_vid.identifier() != resolved.source_did {
+                return Err(VidError::SourceDidMismatch(resolved.source_did));
+            }
+
+            let metadata = ScidVidMetadata {
+                scid: resolved.clone(),
+                source_metadata: Some(source_metadata),
+                private_state: None,
+            };
+
+            Ok((
+                source_vid.with_identifier(did.presented_id),
+                serde_json::to_value(metadata)?,
+            ))
+        }
+        ScidSourceMethod::Cheqd => Err(VidError::UnsupportedScidSource("cheqd".to_string())),
+    }
+}
+
+pub fn resolve_offline(id: &str, options: VerifyVidOptions) -> Result<crate::Vid, VidError> {
+    let did = parse(id)?;
+    let resolved = resolve_source(&did, options.resolution_context.as_ref().and_then(as_scid))?;
+
+    match resolved.source_method {
+        ScidSourceMethod::Webvh => Err(VidError::ResolveVid(
+            "did:scid source method is not available offline",
+        )),
+        ScidSourceMethod::Cheqd => Err(VidError::UnsupportedScidSource("cheqd".to_string())),
+    }
+}
+
+pub async fn create(
+    transport: Url,
+    context: ScidResolutionContext,
+) -> Result<ScidCreateResult, VidError> {
+    match (&context.source_method, &context.locator) {
+        (ScidSourceMethod::Webvh, ScidLocator::Src(src)) => {
+            let (source_private_vid, source_history, keys) =
+                webvh::create_webvh(src, transport).await?;
+            let source_did = source_private_vid.identifier().to_string();
+            let presented_id = presented_did_from_source(&source_did)?;
+            let source_vid = source_private_vid.vid().clone();
+            let private_vid = source_private_vid.with_identifier(presented_id.clone());
+            let resolution_context = ScidResolutionContext {
+                version: context.version,
+                method: context.method,
+                source_method: ScidSourceMethod::Webvh,
+                locator: ScidLocator::Src(source_did.clone()),
+            };
+
+            let metadata = ScidVidMetadata {
+                scid: ScidResolvedSource {
+                    presented_id: presented_id.clone(),
+                    resolve_url: Some(web::get_resolve_url(&source_did)?.to_string()),
+                    source_did: source_did.clone(),
+                    source_method: ScidSourceMethod::Webvh,
+                },
+                source_metadata: None,
+                private_state: Some(ScidPrivateState {
+                    source_did: source_did.clone(),
+                    source_method: ScidSourceMethod::Webvh,
+                    current_update_kid: Some(keys.update_kid.clone()),
+                    next_update_kid: Some(keys.next_update_kid.clone()),
+                }),
+            };
+
+            let mut method_state = WalletMethodState::default();
+            method_state
+                .secret_keys
+                .insert(keys.update_kid.clone(), keys.update_key);
+            method_state
+                .secret_keys
+                .insert(keys.next_update_kid.clone(), keys.next_update_key);
+            method_state
+                .resolution_contexts
+                .insert(presented_id, ResolutionContext::Scid(resolution_context));
+
+            Ok(ScidCreateResult {
+                private_vid,
+                source_vid,
+                source_history: Some(source_history),
+                metadata,
+                method_state,
+            })
+        }
+        (ScidSourceMethod::Cheqd, _) => Err(VidError::UnsupportedScidSource("cheqd".to_string())),
+        _ => Err(VidError::InvalidScid(
+            "invalid did:scid create context".to_string(),
+        )),
+    }
+}
+
+pub async fn update(
+    private_vid: &OwnedVid,
+    metadata: ScidVidMetadata,
+    method_state: &WalletMethodState,
+) -> Result<ScidUpdateResult, VidError> {
+    let private_state = metadata
+        .private_state
+        .clone()
+        .ok_or_else(|| VidError::InternalError("missing did:scid private state".to_string()))?;
+
+    match private_state.source_method {
+        ScidSourceMethod::Webvh => {
+            let update_key = select_webvh_update_key(&metadata, method_state, &private_state)?;
+            let source_private_vid = OwnedVid::bind(
+                private_state.source_did.clone(),
+                private_vid.endpoint().clone(),
+            );
+            let update_result = webvh::update(
+                crate::vid::vid_to_did_document(source_private_vid.vid()),
+                update_key.first_chunk::<32>().ok_or_else(|| {
+                    VidError::WebVHError("Couldn't get WebVH UpdateKey Secret bytes".to_string())
+                })?,
+            )
+            .await?;
+
+            let updated_metadata = ScidVidMetadata {
+                scid: metadata.scid,
+                source_metadata: metadata.source_metadata,
+                private_state: Some(ScidPrivateState {
+                    source_did: private_state.source_did.clone(),
+                    source_method: private_state.source_method,
+                    current_update_kid: Some(update_result.current_update_kid.clone()),
+                    next_update_kid: Some(update_result.next_update_kid.clone()),
+                }),
+            };
+
+            let mut next_method_state = WalletMethodState::default();
+            next_method_state.secret_keys.insert(
+                update_result.next_update_kid.clone(),
+                update_result.next_update_key,
+            );
+
+            Ok(ScidUpdateResult {
+                private_vid: source_private_vid.with_identifier(private_vid.identifier()),
+                source_vid: source_private_vid.vid().clone(),
+                source_history_entry: Some(serde_json::to_value(update_result.log_entry)?),
+                metadata: updated_metadata,
+                method_state: next_method_state,
+            })
+        }
+        ScidSourceMethod::Cheqd => Err(VidError::UnsupportedScidSource("cheqd".to_string())),
+    }
+}
+
+pub fn query_resolution_context(id: &str) -> Result<Option<ScidResolutionContext>, VidError> {
+    let did = parse(id)?;
+    did.src
+        .as_deref()
+        .map(|src| context_from_src(&did.scid, src))
+        .transpose()
+}
+
+fn as_scid(context: &ResolutionContext) -> Option<&ScidResolutionContext> {
+    match context {
+        ResolutionContext::Scid(context) => Some(context),
+    }
+}
+
+fn parse_scid_query(id: &str) -> Result<(String, Option<String>), VidError> {
+    let Some((base, query)) = id.split_once('?') else {
+        return Ok((id.to_string(), None));
+    };
+
+    let mut src = None;
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "src" if !value.is_empty() => src = Some(value.into_owned()),
+            _ => return Err(VidError::InvalidScid(id.to_string())),
+        }
+    }
+
+    Ok((base.to_string(), src))
+}
+
+fn context_from_src(scid: &str, src: &str) -> Result<ScidResolutionContext, VidError> {
+    if src.starts_with("did:cheqd:") {
+        let network = src
+            .strip_prefix("did:cheqd:")
+            .ok_or_else(|| VidError::InvalidScid(src.to_string()))?;
+
+        Ok(ScidResolutionContext {
+            version: 1,
+            method: ScidMethod::Vh,
+            source_method: ScidSourceMethod::Cheqd,
+            locator: ScidLocator::Network(network.to_string()),
+        })
+    } else if src.starts_with("did:") && !src.starts_with("did:webvh:") {
+        Err(VidError::InvalidScid(src.to_string()))
+    } else {
+        Ok(ScidResolutionContext {
+            version: 1,
+            method: ScidMethod::Vh,
+            source_method: ScidSourceMethod::Webvh,
+            locator: ScidLocator::Src(normalize_webvh_source(src, scid)?),
+        })
+    }
+}
+
+fn normalize_webvh_source(src: &str, scid: &str) -> Result<String, VidError> {
+    if src.starts_with("did:webvh:") {
+        let parts = src.split(':').collect::<Vec<_>>();
+        match parts.get(2) {
+            Some(source_scid) if *source_scid == scid => Ok(src.to_string()),
+            _ => Err(VidError::SourceDidMismatch(src.to_string())),
+        }
+    } else if src.starts_with("did:") {
+        Err(VidError::InvalidScid(src.to_string()))
+    } else {
+        let Some((host, path)) = src.split_once('/') else {
+            return Ok(format!("did:webvh:{scid}:{src}"));
+        };
+        Ok(format!(
+            "did:webvh:{scid}:{}:{}",
+            host.replace(':', "%3A"),
+            path.replace('/', ":")
+        ))
+    }
+}
+
+fn presented_did_from_source(source_did: &str) -> Result<String, VidError> {
+    let parts = source_did.split(':').collect::<Vec<_>>();
+
+    match parts.as_slice() {
+        ["did", "webvh", scid, ..] => Ok(format!("did:scid:vh:1:{scid}")),
+        _ => Err(VidError::InvalidScid(source_did.to_string())),
+    }
+}
+
+fn select_webvh_update_key<'a>(
+    metadata: &'a ScidVidMetadata,
+    method_state: &'a WalletMethodState,
+    private_state: &ScidPrivateState,
+) -> Result<&'a Vec<u8>, VidError> {
+    if let Some(next_update_kid) = private_state.next_update_kid.as_deref() {
+        if let Some(secret) = method_state.secret_keys.get(next_update_kid) {
+            return Ok(secret);
+        }
+    }
+
+    let source_metadata = metadata
+        .source_metadata
+        .clone()
+        .map(serde_json::from_value::<webvh::WebvhMetadata>)
+        .transpose()?;
+
+    if source_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.next_key_hashes.as_ref())
+        .is_some()
+    {
+        return Err(VidError::InternalError(
+            "Server has precommit active but wallet has no matching key. Wallet may be out of sync."
+                .to_string(),
+        ));
+    }
+
+    if let Some(current_update_kid) = private_state.current_update_kid.as_deref() {
+        if let Some(secret) = method_state.secret_keys.get(current_update_kid) {
+            return Ok(secret);
+        }
+    }
+
+    if let Some(update_kid) = source_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.update_keys.as_ref())
+        .and_then(|update_keys| update_keys.first())
+    {
+        if let Some(secret) = method_state.secret_keys.get(update_kid) {
+            return Ok(secret);
+        }
+    }
+
+    Err(VidError::InternalError(
+        "Cannot find update keys to update the DID".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_scid() {
+        let parsed = parse("did:scid:vh:1:testscid").expect("scid should parse");
+
+        assert_eq!(parsed.method, ScidMethod::Vh);
+        assert_eq!(parsed.version, 1);
+        assert_eq!(parsed.scid, "testscid");
+        assert!(parsed.src.is_none());
+    }
+
+    #[test]
+    fn parse_scid_with_src_query() {
+        let parsed =
+            parse("did:scid:vh:1:testscid?src=example.com/vid").expect("scid should parse");
+
+        assert_eq!(parsed.presented_id, "did:scid:vh:1:testscid");
+        assert_eq!(parsed.src.as_deref(), Some("example.com/vid"));
+    }
+
+    #[test]
+    fn query_src_builds_webvh_context() {
+        let context = query_resolution_context("did:scid:vh:1:testscid?src=example.com/vid/path")
+            .expect("query context should parse")
+            .expect("query context should exist");
+
+        assert_eq!(context.source_method, ScidSourceMethod::Webvh);
+        assert_eq!(
+            context.locator,
+            ScidLocator::Src("did:webvh:testscid:example.com:vid:path".to_string())
+        );
+    }
+
+    #[test]
+    fn query_src_escapes_webvh_host_port() {
+        let context =
+            query_resolution_context("did:scid:vh:1:testscid?src=localhost:3000/vid/path")
+                .expect("query context should parse")
+                .expect("query context should exist");
+
+        assert_eq!(
+            context.locator,
+            ScidLocator::Src("did:webvh:testscid:localhost%3A3000:vid:path".to_string())
+        );
+    }
+
+    #[test]
+    fn query_src_builds_cheqd_context() {
+        let context = query_resolution_context("did:scid:vh:1:testscid?src=did:cheqd:testnet")
+            .expect("query context should parse")
+            .expect("query context should exist");
+
+        assert_eq!(context.source_method, ScidSourceMethod::Cheqd);
+        assert_eq!(context.locator, ScidLocator::Network("testnet".to_string()));
+    }
+
+    #[test]
+    fn parse_invalid_scid() {
+        assert!(matches!(
+            parse("did:scid:vh:testscid"),
+            Err(VidError::InvalidScid(_))
+        ));
+    }
+
+    #[test]
+    fn peer_style_requires_context() {
+        let did = parse("did:scid:vh:1:testscid").expect("scid should parse");
+
+        assert!(matches!(
+            resolve_source(&did, None),
+            Err(VidError::ResolutionContextRequired(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_source_builds_webvh_did() {
+        let did = parse("did:scid:vh:1:testscid").expect("scid should parse");
+        let resolved = resolve_source(
+            &did,
+            Some(&ScidResolutionContext {
+                version: 1,
+                method: ScidMethod::Vh,
+                source_method: ScidSourceMethod::Webvh,
+                locator: ScidLocator::Src("example.com:users:alice".to_string()),
+            }),
+        )
+        .expect("source should resolve");
+
+        assert_eq!(
+            resolved.source_did,
+            "did:webvh:testscid:example.com:users:alice"
+        );
+    }
+
+    #[test]
+    fn resolve_source_builds_cheqd_did_from_external_context() {
+        let did = parse("did:scid:vh:1:testscid").expect("scid should parse");
+        let resolved = resolve_source(
+            &did,
+            Some(&ScidResolutionContext {
+                version: 1,
+                method: ScidMethod::Vh,
+                source_method: ScidSourceMethod::Cheqd,
+                locator: ScidLocator::Network("testnet".to_string()),
+            }),
+        )
+        .expect("source should resolve");
+
+        assert_eq!(resolved.source_did, "did:cheqd:testnet:testscid");
+    }
+}

--- a/tsp_sdk/src/vid/did/scid.rs
+++ b/tsp_sdk/src/vid/did/scid.rs
@@ -412,10 +412,10 @@ fn select_webvh_update_key<'a>(
     method_state: &'a WalletMethodState,
     private_state: &ScidPrivateState,
 ) -> Result<&'a Vec<u8>, VidError> {
-    if let Some(next_update_kid) = private_state.next_update_kid.as_deref() {
-        if let Some(secret) = method_state.secret_keys.get(next_update_kid) {
-            return Ok(secret);
-        }
+    if let Some(next_update_kid) = private_state.next_update_kid.as_deref()
+        && let Some(secret) = method_state.secret_keys.get(next_update_kid)
+    {
+        return Ok(secret);
     }
 
     let source_metadata = metadata
@@ -435,20 +435,19 @@ fn select_webvh_update_key<'a>(
         ));
     }
 
-    if let Some(current_update_kid) = private_state.current_update_kid.as_deref() {
-        if let Some(secret) = method_state.secret_keys.get(current_update_kid) {
-            return Ok(secret);
-        }
+    if let Some(current_update_kid) = private_state.current_update_kid.as_deref()
+        && let Some(secret) = method_state.secret_keys.get(current_update_kid)
+    {
+        return Ok(secret);
     }
 
     if let Some(update_kid) = source_metadata
         .as_ref()
         .and_then(|metadata| metadata.update_keys.as_ref())
         .and_then(|update_keys| update_keys.first())
+        && let Some(secret) = method_state.secret_keys.get(update_kid)
     {
-        if let Some(secret) = method_state.secret_keys.get(update_kid) {
-            return Ok(secret);
-        }
+        return Ok(secret);
     }
 
     Err(VidError::InternalError(

--- a/tsp_sdk/src/vid/error.rs
+++ b/tsp_sdk/src/vid/error.rs
@@ -16,8 +16,16 @@ pub enum VidError {
     Connection(String, std::io::Error),
     #[error("invalid VID '{0}'")]
     InvalidVid(String),
+    #[error("resolution context required for '{0}'")]
+    ResolutionContextRequired(String),
     #[error("could not resolve VID '{0}'")]
     ResolveVid(&'static str),
+    #[error("unsupported did:scid source method '{0}'")]
+    UnsupportedScidSource(String),
+    #[error("invalid did:scid '{0}'")]
+    InvalidScid(String),
+    #[error("source DID mismatch for '{0}'")]
+    SourceDidMismatch(String),
     #[error("{0}")]
     InternalError(String),
     #[error("{0}")]

--- a/tsp_sdk/src/vid/mod.rs
+++ b/tsp_sdk/src/vid/mod.rs
@@ -30,7 +30,30 @@ use url::Url;
 
 use crate::definitions::{VidEncryptionKeyType, VidSignatureKeyType};
 #[cfg(feature = "resolve")]
-pub use resolve::verify_vid;
+pub use resolve::{
+    verify_vid, verify_vid_offline, verify_vid_offline_with_options, verify_vid_with_options,
+};
+
+#[cfg_attr(
+    feature = "serialize",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[derive(Clone, Debug, Default)]
+pub struct VerifyVidOptions {
+    pub resolution_context: Option<ResolutionContext>,
+}
+
+#[cfg_attr(
+    feature = "serialize",
+    derive(Serialize, Deserialize),
+    serde(tag = "kind", content = "value", rename_all = "camelCase")
+)]
+#[derive(Clone, Debug)]
+pub enum ResolutionContext {
+    #[cfg(feature = "resolve")]
+    Scid(did::scid::ScidResolutionContext),
+}
 
 /// A Vid represents a *verified* Identifier
 /// (so it doesn't carry any information that allows to verify it)
@@ -203,6 +226,50 @@ impl OwnedVid {
 
     pub fn into_vid(self) -> Vid {
         self.vid
+    }
+
+    pub(crate) fn from_parts(
+        vid: Vid,
+        sigkey: PrivateSigningKeyData,
+        enckey: PrivateKeyData,
+    ) -> Self {
+        Self {
+            vid,
+            sigkey,
+            enckey,
+        }
+    }
+
+    pub(crate) fn with_identifier(&self, id: impl Into<String>) -> Self {
+        Self {
+            vid: self.vid.with_identifier(id),
+            sigkey: self.sigkey.clone(),
+            enckey: self.enckey.clone(),
+        }
+    }
+}
+
+impl Vid {
+    pub(crate) fn from_verified(vid: &dyn VerifiedVid) -> Self {
+        Self {
+            id: vid.identifier().to_string(),
+            transport: vid.endpoint().clone(),
+            sig_key_type: vid.signature_key_type(),
+            public_sigkey: vid.verifying_key().clone(),
+            enc_key_type: vid.encryption_key_type(),
+            public_enckey: vid.encryption_key().clone(),
+        }
+    }
+
+    pub(crate) fn with_identifier(&self, id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            transport: self.transport.clone(),
+            sig_key_type: self.sig_key_type,
+            public_sigkey: self.public_sigkey.clone(),
+            enc_key_type: self.enc_key_type,
+            public_enckey: self.public_enckey.clone(),
+        }
     }
 }
 

--- a/tsp_sdk/src/vid/resolve.rs
+++ b/tsp_sdk/src/vid/resolve.rs
@@ -1,5 +1,6 @@
-use super::did::webvh;
+use super::did::{scid, webvh};
 use super::{
+    VerifyVidOptions,
     did::{self, peer, web},
     error::VidError,
 };
@@ -8,6 +9,15 @@ use crate::Vid;
 #[cfg(feature = "resolve")]
 /// Resolve and verify the vid identified by `id`, by using online and offline methods
 pub async fn verify_vid(id: &str) -> Result<(Vid, Option<serde_json::Value>), VidError> {
+    verify_vid_with_options(id, VerifyVidOptions::default()).await
+}
+
+#[cfg(feature = "resolve")]
+/// Resolve and verify the vid identified by `id`, by using online and offline methods
+pub async fn verify_vid_with_options(
+    id: &str,
+    options: VerifyVidOptions,
+) -> Result<(Vid, Option<serde_json::Value>), VidError> {
     let parts = id.split(':').collect::<Vec<&str>>();
 
     match parts.get(0..2) {
@@ -16,16 +26,28 @@ pub async fn verify_vid(id: &str) -> Result<(Vid, Option<serde_json::Value>), Vi
         Some([did::SCHEME, webvh::SCHEME]) => webvh::resolve(id)
             .await
             .map(|(vid, metadata)| (vid, Some(metadata))),
+        Some([did::SCHEME, scid::SCHEME]) => scid::resolve(id, options)
+            .await
+            .map(|(vid, metadata)| (vid, Some(metadata))),
         _ => Err(VidError::InvalidVid(id.to_string())),
     }
 }
 
 /// Resolve and verify the vid identified by `id`, but only using offline methods
 pub fn verify_vid_offline(id: &str) -> Result<Vid, VidError> {
+    verify_vid_offline_with_options(id, VerifyVidOptions::default())
+}
+
+/// Resolve and verify the vid identified by `id`, but only using offline methods
+pub fn verify_vid_offline_with_options(
+    id: &str,
+    options: VerifyVidOptions,
+) -> Result<Vid, VidError> {
     let parts = id.split(':').collect::<Vec<&str>>();
 
     match parts.get(0..2) {
         Some([did::SCHEME, peer::SCHEME]) => peer::verify_did_peer(&parts),
+        Some([did::SCHEME, scid::SCHEME]) => scid::resolve_offline(id, options),
         _ => Err(VidError::InvalidVid(id.to_string())),
     }
 }


### PR DESCRIPTION
## Summary

This PR adds and hardens `did:scid` support for the TSP SDK and CLI, using Affinidi's `did-scid` implementation as the external behavioral reference.

The implementation supports WebVH-backed `did:scid:vh:1:<scid>` resolution, query-form `?src=...` resolution, peer-style resolution via stored context, and wallet persistence of the resolution context needed for later re-verification.

## What Changed

- Added `did:scid` parsing and resolution support for WebVH-backed SCIDs.
- Added SCID resolution context storage in wallet method state.
- Persist resolution context after successful `verify_vid_with_options`, keyed by the canonical presented SCID.
- Added CLI support for `did:scid` verify/create/update flows.
- Normalized WebVH source locators consistently, including encoding host ports such as:
  - `localhost:3000/vid/path`
  - `did:webvh:<scid>:localhost%3A3000:vid:path`
- Added tests for SCID parsing, query-derived context, context export/import, persistence, and CLI locator normalization.

## Reference Implementation

This was compared against Affinidi's `did-scid` crate:

- https://github.com/affinidi/affinidi-tdk-rs/blob/574668e650e89aa5ee94b5313160fcbcb9e6662c/crates/identity/did-methods/did-scid/src/lib.rs
- https://github.com/affinidi/affinidi-tdk-rs/blob/574668e650e89aa5ee94b5313160fcbcb9e6662c/crates/identity/did-methods/did-scid/README.md

Affinidi's implementation is a thin, stateless resolver adapter: it converts `did:scid` into an underlying `did:webvh` or `did:cheqd` DID, then delegates to the corresponding resolver.

## Notable Differences From Affinidi

This PR intentionally keeps the implementation TSP-wallet-oriented rather than copying Affinidi's resolver shape directly.

- Affinidi returns a generic DID Document; this SDK resolves into a TSP `Vid` and stores SCID metadata.
- Affinidi is stateless; this SDK persists resolution context so later re-verification of bare `did:scid` identifiers works.
- Affinidi supports Cheqd resolution behind its `did-cheqd` feature; this PR models Cheqd as a source method but still returns `UnsupportedScidSource("cheqd")`.
- Affinidi accepts an optional timeout; this SDK does not currently expose timeout through `VerifyVidOptions`.
- This SDK encodes WebVH host ports during source normalization. Affinidi currently does a simple `/` to `:` replacement, which can mis-handle `localhost:3000/...`.

## Verification

```bash
cargo fmt
cargo test -p tsp_sdk verification_context
cargo test -p examples scid_webvh_locator_escapes_host_port
cargo test -p tsp_sdk query_src_escapes_webvh_host_port
cargo test -p tsp_sdk --no-run
```