### PR TITLE
feat(crypto): select outbound crypto at runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ed25519-dalek = { version = "2.2", default-features = false, features = [
 ] }
 hpke = { version = "0.12.0", features = ["std"] }
 hpke_pq = { version = "0.11.1", features = ["alloc", "std", "xyber768d00"] }
-ml-dsa = { version = "0.0.4", features = ["rand_core"] }
+ml-dsa = { version = "0.1.0-rc.3", features = ["rand_core"] }
 rand = { version = "0.8" }
 rand_core = "0.6.4"
 sha2 = "0.11.0-pre.5"

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -51,6 +51,19 @@ impl FromStr for DidType {
     }
 }
 
+fn parse_crypto_type(value: &str) -> Result<cesr::CryptoType, String> {
+    let normalized = value.to_ascii_lowercase().replace('_', "-");
+    match normalized.as_str() {
+        "hpke-auth" => Ok(cesr::CryptoType::HpkeAuth),
+        "hpke-essr" => Ok(cesr::CryptoType::HpkeEssr),
+        "nacl-auth" => Ok(cesr::CryptoType::NaclAuth),
+        "nacl-essr" => Ok(cesr::CryptoType::NaclEssr),
+        "pq" | "x25519-kyber768-draft00" => Ok(cesr::CryptoType::X25519Kyber768Draft00),
+        "plaintext" => Err("plaintext is not valid for confidential send".to_string()),
+        _ => Err(format!("invalid crypto type: {value}")),
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(name = "tsp", version)]
 #[command(about = "Send and receive TSP messages", long_about = None)]
@@ -161,6 +174,12 @@ enum Commands {
             help = "Ask for confirmation before interacting with unknown end-points"
         )]
         ask: bool,
+        #[arg(
+            long,
+            value_parser = parse_crypto_type,
+            help = "Override outbound crypto: hpke-auth, hpke-essr, nacl-auth, nacl-essr, pq"
+        )]
+        crypto: Option<cesr::CryptoType>,
     },
     #[command(arg_required_else_help = true, about = "listen for messages")]
     Receive {
@@ -1030,6 +1049,7 @@ async fn run() -> Result<(), Error> {
             receiver_vid,
             non_confidential_data,
             ask,
+            crypto,
         } => {
             let non_confidential_data = non_confidential_data.as_deref().map(|s| s.as_bytes());
             let receiver_vid = vid_wallet.try_resolve_alias(&receiver_vid)?;
@@ -1042,10 +1062,23 @@ async fn run() -> Result<(), Error> {
                 .await
                 .expect("Could not read message from stdin");
 
-            match vid_wallet
-                .send(&sender_vid, &receiver_vid, non_confidential_data, &message)
-                .await
-            {
+            let send_result = if let Some(crypto_type) = crypto {
+                vid_wallet
+                    .send_with_crypto_type(
+                        &sender_vid,
+                        &receiver_vid,
+                        non_confidential_data,
+                        &message,
+                        crypto_type,
+                    )
+                    .await
+            } else {
+                vid_wallet
+                    .send(&sender_vid, &receiver_vid, non_confidential_data, &message)
+                    .await
+            };
+
+            match send_result {
                 Ok(()) => {}
                 Err(e) => {
                     tracing::error!(
@@ -1101,13 +1134,11 @@ async fn run() -> Result<(), Error> {
                                 cesr::CryptoType::HpkeEssr => "HPKE ESSR",
                                 cesr::CryptoType::NaclAuth => "NaCl Auth",
                                 cesr::CryptoType::NaclEssr => "NaCl ESSR",
-                                #[cfg(feature = "pq")]
                                 cesr::CryptoType::X25519Kyber768Draft00 => "X25519Kyber768Draft00",
                             };
                             let signature_type = match message_type.signature_type {
                                 cesr::SignatureType::NoSignature => "no signature",
                                 cesr::SignatureType::Ed25519 => "Ed25519 signature",
-                                #[cfg(feature = "pq")]
                                 cesr::SignatureType::MlDsa65 => "ML-DSA-65 signature",
                             };
                             info!(

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -718,13 +718,11 @@ fn open_message(message: &[u8], payload: Option<&[u8]>) -> Option<serde_json::Va
             cesr::CryptoType::HpkeEssr => "HPKE ESSR",
             cesr::CryptoType::NaclAuth => "NaCl Auth",
             cesr::CryptoType::NaclEssr => "NaCl ESSR",
-            #[cfg(feature = "pq")]
             cesr::CryptoType::X25519Kyber768Draft00 => "X25519 Kyber768 Draft 00",
         },
         "signatureType": match parts.signature_type {
             cesr::SignatureType::NoSignature => "No Signature",
             cesr::SignatureType::Ed25519 => "Ed25519",
-            #[cfg(feature = "pq")]
             cesr::SignatureType::MlDsa65 => "MlDsa65",
         }
     }))

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -477,7 +477,6 @@ pub enum CryptoType {
     X25519Kyber768Draft00 = 5,
 }
 
-#[cfg(feature = "pq")]
 #[wasm_bindgen]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -485,15 +484,6 @@ pub enum SignatureType {
     NoSignature = 0,
     Ed25519 = 1,
     MlDsa65 = 2,
-}
-
-#[cfg(not(feature = "pq"))]
-#[wasm_bindgen]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[non_exhaustive]
-pub enum SignatureType {
-    NoSignature = 0,
-    Ed25519 = 1,
 }
 
 #[wasm_bindgen(inspectable)]
@@ -693,7 +683,6 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                     tsp_sdk::cesr::CryptoType::HpkeEssr => Some(CryptoType::HpkeEssr),
                     tsp_sdk::cesr::CryptoType::NaclAuth => Some(CryptoType::NaclAuth),
                     tsp_sdk::cesr::CryptoType::NaclEssr => Some(CryptoType::NaclEssr),
-                    #[cfg(feature = "pq")]
                     tsp_sdk::cesr::CryptoType::X25519Kyber768Draft00 => {
                         Some(CryptoType::X25519Kyber768Draft00)
                     }
@@ -701,7 +690,6 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.signature_type = match message_type.signature_type {
                     tsp_sdk::cesr::SignatureType::NoSignature => Some(SignatureType::NoSignature),
                     tsp_sdk::cesr::SignatureType::Ed25519 => Some(SignatureType::Ed25519),
-                    #[cfg(feature = "pq")]
                     tsp_sdk::cesr::SignatureType::MlDsa65 => Some(SignatureType::MlDsa65),
                 };
             }

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -437,7 +437,6 @@ pub enum CryptoType {
 pub enum SignatureType {
     NoSignature = 0,
     Ed25519 = 1,
-    #[cfg(feature = "pq")]
     MlDsa65 = 2,
 }
 
@@ -555,7 +554,6 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                     tsp_sdk::cesr::CryptoType::HpkeEssr => Some(CryptoType::HpkeEssr),
                     tsp_sdk::cesr::CryptoType::NaclAuth => Some(CryptoType::NaclAuth),
                     tsp_sdk::cesr::CryptoType::NaclEssr => Some(CryptoType::NaclEssr),
-                    #[cfg(feature = "pq")]
                     tsp_sdk::cesr::CryptoType::X25519Kyber768Draft00 => {
                         Some(CryptoType::X25519Kyber768Draft00)
                     }
@@ -563,7 +561,6 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.signature_type = match message_type.signature_type {
                     tsp_sdk::cesr::SignatureType::NoSignature => Some(SignatureType::NoSignature),
                     tsp_sdk::cesr::SignatureType::Ed25519 => Some(SignatureType::Ed25519),
-                    #[cfg(feature = "pq")]
                     tsp_sdk::cesr::SignatureType::MlDsa65 => Some(SignatureType::MlDsa65),
                 };
             }

--- a/tsp_sdk/Cargo.toml
+++ b/tsp_sdk/Cargo.toml
@@ -20,7 +20,7 @@ fuzzing = ["dep:arbitrary"]
 demo = []
 test-utils = ["dep:tempfile"]
 nacl = ["essr"]
-pq = ["dep:hpke_pq", "dep:ml-dsa", "essr"]
+pq = ["essr"]
 bench-callgrind = ["dep:gungraun"]
 bench-criterion = ["dep:criterion"]
 bench-network-timings = []
@@ -56,8 +56,8 @@ once_cell = { workspace = true }
 # crypto
 ed25519-dalek = { workspace = true }
 hpke = { workspace = true }
-hpke_pq = { workspace = true, optional = true }
-ml-dsa = { version = "0.0.4", features = ["rand_core"], optional = true }
+hpke_pq = { workspace = true }
+ml-dsa = { version = "0.0.4", features = ["rand_core"] }
 rand = { workspace = true }
 rand_core = { workspace = true }
 sha2 = { workspace = true }

--- a/tsp_sdk/Cargo.toml
+++ b/tsp_sdk/Cargo.toml
@@ -103,6 +103,9 @@ criterion = { version = "0.5.1", optional = true }
 # required for compiling to wasm32-unknown-unknown
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
+getrandom_04 = { package = "getrandom", version = "0.4.2", features = [
+  "wasm_js",
+] }
 [dependencies.getrandom]
 version = "0.2"
 features = ["js"]

--- a/tsp_sdk/Cargo.toml
+++ b/tsp_sdk/Cargo.toml
@@ -57,7 +57,7 @@ once_cell = { workspace = true }
 ed25519-dalek = { workspace = true }
 hpke = { workspace = true }
 hpke_pq = { workspace = true }
-ml-dsa = { version = "0.0.4", features = ["rand_core"] }
+ml-dsa = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
 sha2 = { workspace = true }

--- a/tsp_sdk/benches/bench_utils.rs
+++ b/tsp_sdk/benches/bench_utils.rs
@@ -52,13 +52,17 @@ pub fn deterministic_owned_vid_mldsa65_x25519kyber768(
     use base64ct::{Base64UrlUnpadded, Encoding as _};
     use hpke_pq::Kem as _;
     use hpke_pq::Serializable as _;
-    use ml_dsa::{KeyGen, MlDsa65};
+    use ml_dsa::MlDsa65;
 
-    use rand::SeedableRng as _;
+    use rand::{RngCore as _, SeedableRng as _};
     let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(seed ^ 0x4D4C44534136355Fu64);
-    let sig = MlDsa65::key_gen(&mut rng);
-    let sigkey = sig.signing_key().encode();
-    let public_sigkey = sig.verifying_key().encode();
+    let mut sig_seed = [0u8; 32];
+    rng.fill_bytes(&mut sig_seed);
+    let sig = ml_dsa::SigningKey::<MlDsa65>::from_seed(&ml_dsa::Seed::from(sig_seed));
+    #[allow(deprecated)]
+    let sigkey = sig.expanded_key().to_expanded();
+    let public_sigkey =
+        <ml_dsa::SigningKey<MlDsa65> as ml_dsa::Keypair>::verifying_key(&sig).encode();
 
     let ikm = seeded_bytes(seed ^ 0x454E435F4B594245u64, 32);
     let (enckey, public_enckey) =

--- a/tsp_sdk/benches/common/bench.rs
+++ b/tsp_sdk/benches/common/bench.rs
@@ -122,18 +122,18 @@ pub fn cesr_decode_envelope(message: &mut [u8]) -> usize {
 }
 
 pub enum VidVerifyInput {
-    DidPeer(String),
-    DidWeb {
+    Peer(String),
+    Web {
         did: String,
         doc_json: String,
     },
-    DidWebvh {
+    Webvh {
         log_entry: didwebvh_rs::log_entry::LogEntry,
     },
 }
 
 fn setup_did_peer() -> VidVerifyInput {
-    VidVerifyInput::DidPeer(
+    VidVerifyInput::Peer(
         "did:peer:2.Vz6MurhTjqX5uhQ5bJbAaoEwSDFcKDwVJTvoii51JBtSPpKzX.Ez6LbvBvy92yWENk8xKYmaX9X9nzMtQCQ2EqgdLKv2YkcpHo7.SeyJzIjp7InVyaSI6InRzcDovLyJ9LCJ0IjoidHNwIn0"
             .to_string(),
     )
@@ -146,7 +146,7 @@ fn setup_did_web() -> VidVerifyInput {
     let doc_value = tsp_sdk::vid::did::web::vid_to_did_document(alice.vid());
     let doc_json = serde_json::to_string(&doc_value).unwrap();
 
-    VidVerifyInput::DidWeb { did, doc_json }
+    VidVerifyInput::Web { did, doc_json }
 }
 
 fn setup_did_webvh() -> VidVerifyInput {
@@ -207,7 +207,7 @@ fn setup_did_webvh() -> VidVerifyInput {
         )
         .unwrap();
 
-    VidVerifyInput::DidWebvh {
+    VidVerifyInput::Webvh {
         log_entry: log_entry_state.log_entry.clone(),
     }
 }
@@ -229,16 +229,16 @@ pub fn setup_vid_verify(benchmark_id: &'static str) -> VidVerifyInput {
 
 pub fn vid_verify(input: &VidVerifyInput) -> usize {
     match input {
-        VidVerifyInput::DidPeer(did) => {
+        VidVerifyInput::Peer(did) => {
             let vid = verify_vid_offline(black_box(did)).unwrap();
             black_box(vid.identifier().len())
         }
-        VidVerifyInput::DidWeb { did, doc_json } => {
+        VidVerifyInput::Web { did, doc_json } => {
             let did_doc: DidDocument = serde_json::from_str(doc_json).unwrap();
             let vid = tsp_sdk::vid::did::web::resolve_document(did_doc, did).unwrap();
             black_box(vid.identifier().len())
         }
-        VidVerifyInput::DidWebvh { log_entry } => {
+        VidVerifyInput::Webvh { log_entry } => {
             use didwebvh_rs::log_entry::LogEntryMethods;
             let state = log_entry.get_state().to_owned();
             let did_doc: DidDocument = serde_json::from_value(state).unwrap();

--- a/tsp_sdk/benches/throughput_transport.rs
+++ b/tsp_sdk/benches/throughput_transport.rs
@@ -122,8 +122,7 @@ fn bench_oneway(c: &mut Criterion, scheme: &'static str, host: &'static str, pay
                     sample_attempts,
                     sample_failures,
                 );
-                let elapsed = start.elapsed();
-                elapsed
+                start.elapsed()
             })
         });
 
@@ -218,8 +217,7 @@ fn bench_roundtrip(
                     sample_attempts,
                     sample_failures,
                 );
-                let elapsed = start.elapsed();
-                elapsed
+                start.elapsed()
             })
         });
 

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     ExportVid, OwnedVid, PrivateVid, RelationshipStatus,
+    cesr::CryptoType,
     crypto::CryptoError,
     definitions::{Digest, ReceivedTspMessage, TSPStream, VerifiedVid},
     error::Error,
@@ -301,6 +302,48 @@ impl AsyncSecureStore {
         Ok(())
     }
 
+    pub async fn send_with_crypto_type(
+        &self,
+        sender: &str,
+        receiver: &str,
+        nonconfidential_data: Option<&[u8]>,
+        message: &[u8],
+        crypto_type: CryptoType,
+    ) -> Result<(), Error> {
+        match self.inner.relation_status_for_vid_pair(sender, receiver) {
+            Ok(relation) => {
+                if matches!(relation, RelationshipStatus::Unrelated) {
+                    self.send_relationship_request_with_crypto_type(
+                        sender,
+                        receiver,
+                        None,
+                        crypto_type,
+                    )
+                    .await?
+                }
+            }
+            Err(Error::Relationship(_)) => {
+                self.send_relationship_request_with_crypto_type(sender, receiver, None, crypto_type)
+                    .await?
+            }
+            Err(e) => return Err(e),
+        };
+
+        let (endpoint, message) = self.inner.seal_message_with_crypto_type(
+            sender,
+            receiver,
+            nonconfidential_data,
+            message,
+            crypto_type,
+        )?;
+
+        tracing::info!("sending message to {endpoint}");
+
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
     /// Build a relationship request message without transmitting it.
     ///
     /// Returns `(endpoint, message)` where `endpoint` is the receiver's transport
@@ -355,6 +398,27 @@ impl AsyncSecureStore {
         let (endpoint, message) = self
             .inner
             .make_relationship_request(sender, receiver, route)?;
+
+        tracing::info!("sending message to {endpoint}");
+
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
+    pub async fn send_relationship_request_with_crypto_type(
+        &self,
+        sender: &str,
+        receiver: &str,
+        route: Option<&[&str]>,
+        crypto_type: CryptoType,
+    ) -> Result<(), Error> {
+        let (endpoint, message) = self.inner.make_relationship_request_with_crypto_type(
+            sender,
+            receiver,
+            route,
+            crypto_type,
+        )?;
 
         tracing::info!("sending message to {endpoint}");
 

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -9,13 +9,11 @@ const TSP_NACL_CIPHERTEXT: u32 = cesr!("C");
 const TSP_NACLAUTH_CIPHERTEXT: u32 = cesr!("NCL");
 const TSP_HPKEBASE_CIPHERTEXT: u32 = cesr!("F");
 const TSP_HPKEAUTH_CIPHERTEXT: u32 = cesr!("G");
-#[cfg(feature = "pq")]
 const TSP_HPKEPQ_CIPHERTEXT: u32 = cesr!("PQC");
 const TSP_VID: u32 = cesr!("B");
 
 /// Constants that determine the specific CESR types for "fixed length data"
 const ED25519_SIGNATURE: u32 = cesr!("B");
-#[cfg(feature = "pq")]
 const ML_DSA_65_SIGNATURE: u32 = cesr!("QDM");
 #[allow(clippy::eq_op)]
 const TSP_NONCE: u32 = cesr!("A");
@@ -55,8 +53,6 @@ use super::{
     encode::{encode_count, encode_fixed_data},
     error::{DecodeError, EncodeError},
 };
-#[cfg(not(feature = "pq"))]
-use hpke::kem;
 use std::fmt::Debug;
 
 /// A type to enforce that a random nonce contains enough bits of security
@@ -149,7 +145,7 @@ impl<Bytes: AsRef<[u8]>, Vid: AsRef<[u8]>> Payload<'_, Bytes, Vid> {
 #[cfg(feature = "fuzzing")]
 pub mod fuzzing;
 
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 #[repr(u8)]
 pub enum CryptoType {
     Plaintext = 0,
@@ -157,7 +153,6 @@ pub enum CryptoType {
     HpkeEssr = 2,
     NaclAuth = 3,
     NaclEssr = 4,
-    #[cfg(feature = "pq")]
     X25519Kyber768Draft00 = 5,
 }
 
@@ -165,14 +160,13 @@ pub trait AsCryptoType {
     fn crypto_type() -> CryptoType;
 }
 
-#[cfg(feature = "pq")]
-impl AsCryptoType for kem::X25519Kyber768Draft00 {
+impl AsCryptoType for hpke_pq::kem::X25519Kyber768Draft00 {
     fn crypto_type() -> CryptoType {
         CryptoType::X25519Kyber768Draft00
     }
 }
 
-impl AsCryptoType for kem::X25519HkdfSha256 {
+impl AsCryptoType for hpke::kem::X25519HkdfSha256 {
     fn crypto_type() -> CryptoType {
         if cfg!(feature = "essr") {
             CryptoType::HpkeEssr
@@ -193,7 +187,6 @@ impl CryptoType {
 pub enum SignatureType {
     NoSignature = 0,
     Ed25519 = 1,
-    #[cfg(feature = "pq")]
     MlDsa65 = 2,
 }
 
@@ -229,7 +222,6 @@ fn encoded_signature_from_raw<'a>(
         return Ok(EncodedSignature::Ed25519(signature));
     }
 
-    #[cfg(feature = "pq")]
     if let Ok(signature) = <&[u8; 3309]>::try_from(signature) {
         return Ok(EncodedSignature::MlDsa65(signature));
     }
@@ -253,7 +245,6 @@ fn decoded_signature_from_stream(
     let signature_len = match EncodedSignature::decode(&mut immutable_stream)? {
         EncodedSignature::NoSignature => return Err(DecodeError::InvalidSignatureType),
         EncodedSignature::Ed25519(signature) => signature.len(),
-        #[cfg(feature = "pq")]
         EncodedSignature::MlDsa65(signature) => signature.len(),
     };
 
@@ -681,7 +672,6 @@ fn encode_envelope_fields<'a, Vid: AsRef<[u8]>>(
 enum EncodedSignature<'a> {
     NoSignature,
     Ed25519(&'a [u8; 64]),
-    #[cfg(feature = "pq")]
     MlDsa65(&'a [u8; 3309]),
 }
 
@@ -694,18 +684,9 @@ impl<'a> EncodedSignature<'a> {
                 encode_count(TSP_INDEX_SIG_GRP, signature.len().div_ceil(3), output);
                 encode_fixed_data(ED25519_SIGNATURE, signature.as_slice(), output);
             }
-            #[cfg(feature = "pq")]
             EncodedSignature::MlDsa65(signature) => {
-                encode_count(
-                    TSP_ATTACH_GRP,
-                    signature.len().next_multiple_of(3) / 3,
-                    output,
-                );
-                encode_count(
-                    TSP_INDEX_SIG_GRP,
-                    signature.len().next_multiple_of(3) / 3,
-                    output,
-                );
+                encode_count(TSP_ATTACH_GRP, signature.len().div_ceil(3), output);
+                encode_count(TSP_INDEX_SIG_GRP, signature.len().div_ceil(3), output);
                 encode_fixed_data(ML_DSA_65_SIGNATURE, signature.as_slice(), output);
             }
         }
@@ -723,20 +704,17 @@ impl<'a> EncodedSignature<'a> {
             }
             Ok(EncodedSignature::Ed25519(sig))
         } else {
-            #[cfg(feature = "pq")]
             if let Some(sig) = decode_fixed_data(ML_DSA_65_SIGNATURE, stream) {
-                if a_size != (sig.len() as u32).next_multiple_of(3) / 3 {
+                if a_size != (sig.len() as u32).div_ceil(3) {
                     return Err(DecodeError::InvalidSignatureType);
                 }
-                if i_size != (sig.len() as u32).next_multiple_of(3) / 3 {
+                if i_size != (sig.len() as u32).div_ceil(3) {
                     return Err(DecodeError::InvalidSignatureType);
                 }
                 Ok(EncodedSignature::MlDsa65(sig))
             } else {
-                return Err(DecodeError::InvalidSignatureType);
+                Err(DecodeError::InvalidSignatureType)
             }
-            #[cfg(not(feature = "pq"))]
-            return Err(DecodeError::InvalidSignatureType);
         }
     }
 }
@@ -752,7 +730,6 @@ pub fn encode_signature(
         SignatureType::Ed25519 => {
             EncodedSignature::Ed25519(signature.try_into().expect("signature has incorrect size"))
         }
-        #[cfg(feature = "pq")]
         SignatureType::MlDsa65 => {
             EncodedSignature::MlDsa65(signature.try_into().expect("signature has incorrect size"))
         }
@@ -767,7 +744,6 @@ impl CryptoType {
             CryptoType::HpkeEssr => TSP_HPKEBASE_CIPHERTEXT,
             CryptoType::HpkeAuth => TSP_HPKEAUTH_CIPHERTEXT,
             CryptoType::NaclAuth => TSP_NACLAUTH_CIPHERTEXT,
-            #[cfg(feature = "pq")]
             CryptoType::X25519Kyber768Draft00 => TSP_HPKEPQ_CIPHERTEXT,
             _ => return Err(DecodeError::InvalidCrypto),
         })
@@ -834,16 +810,9 @@ pub(super) fn detected_tsp_header_size_and_confidentiality(
         CryptoType::NaclEssr
     } else if decode_variable_data(TSP_NACLAUTH_CIPHERTEXT, &mut stream).is_some() {
         CryptoType::NaclAuth
+    } else if decode_variable_data(TSP_HPKEPQ_CIPHERTEXT, &mut stream).is_some() {
+        CryptoType::X25519Kyber768Draft00
     } else {
-        #[cfg(feature = "pq")]
-        if decode_variable_data(TSP_HPKEPQ_CIPHERTEXT, &mut stream).is_some() {
-            CryptoType::X25519Kyber768Draft00
-        } else if encrypted {
-            return Err(DecodeError::UnknownCrypto);
-        } else {
-            CryptoType::Plaintext
-        }
-        #[cfg(not(feature = "pq"))]
         if encrypted {
             return Err(DecodeError::UnknownCrypto);
         } else {
@@ -857,7 +826,6 @@ pub(super) fn detected_tsp_header_size_and_confidentiality(
 
     let signature_type = match EncodedSignature::decode(&mut stream) {
         Ok(EncodedSignature::Ed25519(_)) => SignatureType::Ed25519,
-        #[cfg(feature = "pq")]
         Ok(EncodedSignature::MlDsa65(_)) => SignatureType::MlDsa65,
         _ => SignatureType::NoSignature,
     };
@@ -893,8 +861,6 @@ pub fn decode_sender_receiver<'a, Vid: TryFrom<&'a [u8]>>(
     Ok((sender, receiver, crypto_type, signature_type))
 }
 
-#[cfg(feature = "pq")]
-use hpke_pq::kem;
 use std::ops::Range;
 
 #[derive(Debug)]
@@ -1006,7 +972,6 @@ pub fn decode_envelope<'a>(stream: &'a mut [u8]) -> Result<CipherView<'a>, Decod
         SignatureType::NoSignature => [].as_slice(),
         _ => match EncodedSignature::decode(&mut sigdata)? {
             EncodedSignature::Ed25519(sig) => sig.as_slice(),
-            #[cfg(feature = "pq")]
             EncodedSignature::MlDsa65(sig) => sig.as_slice(),
             _ => [].as_slice(),
         },
@@ -1142,7 +1107,6 @@ pub fn open_message_into_parts(data: &[u8]) -> Result<MessageParts<'_>, DecodeEr
     let signature = match EncodedSignature::decode(&mut &data[pos..])? {
         EncodedSignature::NoSignature => &[],
         EncodedSignature::Ed25519(sig) => sig.as_slice(),
-        #[cfg(feature = "pq")]
         EncodedSignature::MlDsa65(sig) => sig.as_slice(),
     };
 
@@ -1176,7 +1140,7 @@ pub struct Message<'a, Vid, Bytes: AsRef<[u8]>> {
 
 /// Convenience interface which illustrates encoding as a single operation
 #[cfg(all(feature = "demo", test))]
-pub fn encode_tsp_message<Vid: AsRef<[u8]>>(
+pub fn encode_tsp_message<Vid: AsRef<[u8]>, Sig: AsRef<[u8]>>(
     Message {
         ref sender,
         ref receiver,
@@ -1184,7 +1148,7 @@ pub fn encode_tsp_message<Vid: AsRef<[u8]>>(
         message,
     }: Message<Vid, impl AsRef<[u8]>>,
     encrypt: impl FnOnce(&Vid, Vec<u8>) -> Vec<u8>,
-    sign: impl FnOnce(&Vid, &[u8]) -> Signature,
+    sign: impl FnOnce(&Vid, &[u8]) -> Sig,
 ) -> Result<Vec<u8>, EncodeError> {
     let mut cesr = encode_ets_envelope_vec(Envelope {
         crypto_type: CryptoType::HpkeAuth,
@@ -1196,8 +1160,9 @@ pub fn encode_tsp_message<Vid: AsRef<[u8]>>(
 
     let ciphertext = &encrypt(receiver, encode_payload_vec(&message)?);
 
-    encode_ciphertext(ciphertext, &mut cesr)?;
-    encode_signature(&sign(sender, &cesr), &mut cesr, SignatureType::Ed25519);
+    encode_ciphertext(ciphertext, CryptoType::HpkeAuth, &mut cesr)?;
+    let signature = sign(sender, &cesr);
+    encode_signature(signature.as_ref(), &mut cesr, SignatureType::Ed25519);
 
     Ok(cesr)
 }
@@ -1480,7 +1445,7 @@ mod test {
         let tsp = decode_tsp_message(
             &mut data,
             |_: &&[u8], x| x.to_vec(),
-            |_, _, sig| sig == &[5u8; 64],
+            |_, _, sig| sig == [5u8; 64],
         )
         .unwrap();
 

--- a/tsp_sdk/src/crypto/error.rs
+++ b/tsp_sdk/src/crypto/error.rs
@@ -17,7 +17,7 @@ pub enum CryptoError {
     #[error("Wrong key length")]
     Key(#[from] TryFromSliceError),
     #[error("could not verify signature for sender VID {0}: {1}")]
-    Verify(String, ed25519_dalek::ed25519::Error),
+    Verify(String, String),
     #[error("unexpected recipient")]
     UnexpectedRecipient,
     #[error("no ciphertext found in encrypted message")]

--- a/tsp_sdk/src/crypto/error.rs
+++ b/tsp_sdk/src/crypto/error.rs
@@ -1,12 +1,13 @@
 use std::array::TryFromSliceError;
 
+use crate::{cesr::CryptoType, definitions::VidEncryptionKeyType};
+
 #[derive(thiserror::Error, Debug)]
 pub enum CryptoError {
     #[error("failed to encode message {0}")]
     Encode(#[from] crate::cesr::error::EncodeError),
     #[error("failed to decode message {0}")]
     Decode(#[from] crate::cesr::error::DecodeError),
-    #[cfg(feature = "pq")]
     #[error("encryption or decryption failed: {0}")]
     CryptographicHpkePq(#[from] hpke_pq::HpkeError),
     #[error("encryption or decryption failed: {0}")]
@@ -25,4 +26,13 @@ pub enum CryptoError {
     UnexpectedSender,
     #[error("no sender identity found in encrypted message")]
     MissingSender,
+    #[error("invalid outbound crypto selection {0:?}")]
+    InvalidCryptoSelection(CryptoType),
+    #[error(
+        "outbound crypto selection {crypto_type:?} is incompatible with receiver encryption key type {key_type:?}"
+    )]
+    IncompatibleCryptoSelection {
+        crypto_type: CryptoType,
+        key_type: VidEncryptionKeyType,
+    },
 }

--- a/tsp_sdk/src/crypto/error.rs
+++ b/tsp_sdk/src/crypto/error.rs
@@ -35,4 +35,11 @@ pub enum CryptoError {
         crypto_type: CryptoType,
         key_type: VidEncryptionKeyType,
     },
+    #[error(
+        "outbound crypto selection {crypto_type:?} is incompatible with sender encryption key type {key_type:?}"
+    )]
+    IncompatibleSenderCryptoSelection {
+        crypto_type: CryptoType,
+        key_type: VidEncryptionKeyType,
+    },
 }

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -69,22 +69,26 @@ impl RelationshipDigestAlgorithm {
 }
 
 pub(crate) fn default_outbound_crypto_selection(
+    sender: &dyn VerifiedVid,
     receiver: &dyn VerifiedVid,
 ) -> OutboundCryptoSelection {
+    let sender_key_type = sender.encryption_key_type();
+    let receiver_key_type = receiver.encryption_key_type();
     let crypto_type = if matches!(
-        receiver.encryption_key_type(),
+        receiver_key_type,
         VidEncryptionKeyType::X25519Kyber768Draft00
     ) {
         CryptoType::X25519Kyber768Draft00
     } else if cfg!(feature = "nacl")
-        && matches!(receiver.encryption_key_type(), VidEncryptionKeyType::X25519)
+        && matches!(sender_key_type, VidEncryptionKeyType::X25519)
+        && matches!(receiver_key_type, VidEncryptionKeyType::X25519)
     {
         if cfg!(feature = "essr") {
             CryptoType::NaclEssr
         } else {
             CryptoType::NaclAuth
         }
-    } else if cfg!(feature = "essr") {
+    } else if cfg!(feature = "essr") || !matches!(sender_key_type, VidEncryptionKeyType::X25519) {
         CryptoType::HpkeEssr
     } else {
         CryptoType::HpkeAuth
@@ -480,7 +484,7 @@ pub(crate) fn seal_and_hash_with_relationship_nonce(
         payload,
         digest,
         request_nonce_override,
-        default_outbound_crypto_selection(receiver),
+        default_outbound_crypto_selection(sender, receiver),
     )
 }
 
@@ -493,7 +497,7 @@ pub(crate) fn seal_with_selection(
     request_nonce_override: Option<[u8; 32]>,
     selection: OutboundCryptoSelection,
 ) -> Result<TSPMessage, CryptoError> {
-    ensure_selection_matches_receiver(receiver, selection.crypto_type)?;
+    ensure_selection_matches_key_types(sender, receiver, selection.crypto_type)?;
 
     match selection.crypto_type {
         CryptoType::NaclAuth | CryptoType::NaclEssr => tsp_nacl::seal(
@@ -526,11 +530,12 @@ pub(crate) fn seal_with_selection(
     }
 }
 
-fn ensure_selection_matches_receiver(
+fn ensure_selection_matches_key_types(
+    sender: &dyn VerifiedVid,
     receiver: &dyn VerifiedVid,
     crypto_type: CryptoType,
 ) -> Result<(), CryptoError> {
-    let expected = match crypto_type {
+    let expected_receiver = match crypto_type {
         CryptoType::NaclAuth
         | CryptoType::NaclEssr
         | CryptoType::HpkeAuth
@@ -539,15 +544,27 @@ fn ensure_selection_matches_receiver(
         CryptoType::Plaintext => return Err(CryptoError::InvalidCryptoSelection(crypto_type)),
     };
 
-    let actual = receiver.encryption_key_type();
-    if actual == expected {
-        Ok(())
-    } else {
-        Err(CryptoError::IncompatibleCryptoSelection {
+    let receiver_key_type = receiver.encryption_key_type();
+    if receiver_key_type != expected_receiver {
+        return Err(CryptoError::IncompatibleCryptoSelection {
             crypto_type,
-            key_type: actual,
-        })
+            key_type: receiver_key_type,
+        });
     }
+
+    let sender_requires_x25519 = matches!(
+        crypto_type,
+        CryptoType::NaclAuth | CryptoType::NaclEssr | CryptoType::HpkeAuth
+    );
+    let sender_key_type = sender.encryption_key_type();
+    if sender_requires_x25519 && !matches!(sender_key_type, VidEncryptionKeyType::X25519) {
+        return Err(CryptoError::IncompatibleSenderCryptoSelection {
+            crypto_type,
+            key_type: sender_key_type,
+        });
+    }
+
+    Ok(())
 }
 
 pub type MessageContents<'a> = (
@@ -833,6 +850,28 @@ mod tests {
     }
 
     #[test]
+    fn default_selection_avoids_nacl_for_pq_sender_to_x25519_receiver() {
+        let alice = OwnedVid::bind_with_key_types(
+            "did:test:alice-pq-to-x25519-default",
+            Url::parse("tcp://127.0.0.1:13388").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519Kyber768Draft00,
+        );
+        let bob = OwnedVid::bind_with_key_types(
+            "did:test:bob-x25519-from-pq-default",
+            Url::parse("tcp://127.0.0.1:13389").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519,
+        );
+
+        let mut message = seal(&alice, &bob, None, Payload::Content(b"default hpke essr")).unwrap();
+        let (_, payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
+
+        assert_eq!(payload, Payload::Content(b"default hpke essr" as &[u8]));
+        assert_eq!(opened_crypto_type, CryptoType::HpkeEssr);
+    }
+
+    #[test]
     fn explicit_crypto_selection_rejects_incompatible_receiver_key() {
         let alice = OwnedVid::bind_with_key_types(
             "did:test:alice-incompatible",
@@ -876,6 +915,39 @@ mod tests {
         assert!(matches!(
             err,
             CryptoError::InvalidCryptoSelection(CryptoType::Plaintext)
+        ));
+    }
+
+    #[test]
+    fn explicit_crypto_selection_rejects_incompatible_sender_key() {
+        let alice = OwnedVid::bind_with_key_types(
+            "did:test:alice-pq-incompatible",
+            Url::parse("tcp://127.0.0.1:13390").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519Kyber768Draft00,
+        );
+        let bob = OwnedVid::bind_with_key_types(
+            "did:test:bob-x25519-incompatible",
+            Url::parse("tcp://127.0.0.1:13391").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519,
+        );
+
+        let err = seal_with_crypto_type(
+            &alice,
+            &bob,
+            None,
+            Payload::Content(b"selected backend"),
+            CryptoType::NaclAuth,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            CryptoError::IncompatibleSenderCryptoSelection {
+                crypto_type: CryptoType::NaclAuth,
+                key_type: VidEncryptionKeyType::X25519Kyber768Draft00,
+            }
         ));
     }
 }

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -1,16 +1,9 @@
-#[cfg(not(feature = "nacl"))]
-use crate::definitions::VidEncryptionKeyType;
 use crate::definitions::{
     Digest, MessageType, NonConfidentialData, Payload, PrivateKeyData, PrivateSigningKeyData,
     PrivateVid, PublicKeyData, PublicVerificationKeyData, RelationshipForm, TSPMessage,
-    VerifiedVid,
+    VerifiedVid, VidEncryptionKeyType, VidSignatureKeyType,
 };
 use ed25519_dalek::Signer;
-#[cfg(not(feature = "pq"))]
-use hpke::kem;
-#[cfg(feature = "pq")]
-use hpke_pq::kem;
-#[cfg(feature = "pq")]
 use ml_dsa::{EncodedVerifyingKey, KeyGen, MlDsa65, signature::Verifier};
 use rand_core::OsRng;
 #[cfg(feature = "bench-network-timings")]
@@ -37,7 +30,11 @@ pub(crate) struct ParallelSignatureInfo<'a> {
     pub signed_data: Vec<u8>,
 }
 
-// Which digest algorithm is active depends on the crypto backend feature set.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct OutboundCryptoSelection {
+    pub crypto_type: CryptoType,
+}
+
 #[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub(crate) enum RelationshipDigestAlgorithm {
@@ -46,19 +43,95 @@ pub(crate) enum RelationshipDigestAlgorithm {
 }
 
 impl RelationshipDigestAlgorithm {
-    fn field<'a>(self, digest: &'a Digest) -> crate::cesr::Digest<'a> {
+    pub(crate) fn for_crypto_type(crypto_type: CryptoType) -> Result<Self, CryptoError> {
+        Ok(match crypto_type {
+            CryptoType::NaclAuth | CryptoType::NaclEssr => RelationshipDigestAlgorithm::Blake2b256,
+            CryptoType::HpkeAuth | CryptoType::HpkeEssr | CryptoType::X25519Kyber768Draft00 => {
+                RelationshipDigestAlgorithm::Sha2_256
+            }
+            CryptoType::Plaintext => return Err(CryptoError::InvalidCryptoSelection(crypto_type)),
+        })
+    }
+
+    pub(crate) fn field<'a>(self, digest: &'a Digest) -> crate::cesr::Digest<'a> {
         match self {
             RelationshipDigestAlgorithm::Sha2_256 => crate::cesr::Digest::Sha2_256(digest),
             RelationshipDigestAlgorithm::Blake2b256 => crate::cesr::Digest::Blake2b256(digest),
         }
     }
 
-    fn hash(self, bytes: &[u8]) -> Digest {
+    pub(crate) fn hash(self, bytes: &[u8]) -> Digest {
         match self {
             RelationshipDigestAlgorithm::Sha2_256 => sha256(bytes),
             RelationshipDigestAlgorithm::Blake2b256 => blake2b256(bytes),
         }
     }
+}
+
+pub(crate) fn default_outbound_crypto_selection(
+    receiver: &dyn VerifiedVid,
+) -> OutboundCryptoSelection {
+    let crypto_type = if matches!(
+        receiver.encryption_key_type(),
+        VidEncryptionKeyType::X25519Kyber768Draft00
+    ) {
+        CryptoType::X25519Kyber768Draft00
+    } else if cfg!(feature = "nacl")
+        && matches!(receiver.encryption_key_type(), VidEncryptionKeyType::X25519)
+    {
+        if cfg!(feature = "essr") {
+            CryptoType::NaclEssr
+        } else {
+            CryptoType::NaclAuth
+        }
+    } else if cfg!(feature = "essr") {
+        CryptoType::HpkeEssr
+    } else {
+        CryptoType::HpkeAuth
+    };
+
+    OutboundCryptoSelection { crypto_type }
+}
+
+pub(crate) fn signature_type(sender: &dyn VerifiedVid) -> SignatureType {
+    match sender.signature_key_type() {
+        VidSignatureKeyType::Ed25519 => SignatureType::Ed25519,
+        VidSignatureKeyType::MlDsa65 => SignatureType::MlDsa65,
+    }
+}
+
+pub(crate) fn append_signature(
+    sender: &dyn PrivateVid,
+    data: &mut Vec<u8>,
+) -> Result<(), CryptoError> {
+    match sender.signature_key_type() {
+        VidSignatureKeyType::Ed25519 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
+            let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
+                sender.signing_key().as_slice(),
+            )?);
+            let signature = sign_key.sign(data).to_bytes();
+            crate::cesr::encode_signature(&signature, data, SignatureType::Ed25519);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
+        }
+        VidSignatureKeyType::MlDsa65 => {
+            #[cfg(feature = "bench-network-timings")]
+            let signature_started = std::time::Instant::now();
+            let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(&ml_dsa::EncodedSigningKey::<
+                MlDsa65,
+            >::try_from(
+                sender.signing_key().as_slice(),
+            )?);
+            let signature = sign_key.sign(data).encode();
+            crate::cesr::encode_signature(signature.as_slice(), data, SignatureType::MlDsa65);
+            #[cfg(feature = "bench-network-timings")]
+            crate::bench::record_signature(signature_started);
+        }
+    }
+
+    Ok(())
 }
 
 fn encode_hashed_payload(
@@ -277,7 +350,6 @@ pub(crate) fn sign_detached(sender: &dyn PrivateVid, data: &[u8]) -> Result<Vec<
             )?);
             sign_key.sign(data).to_bytes().to_vec()
         }
-        #[cfg(feature = "pq")]
         crate::definitions::VidSignatureKeyType::MlDsa65 => {
             use ml_dsa::EncodedSigningKey;
             let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
@@ -304,7 +376,6 @@ pub(crate) fn verify_detached(
                 .verify_strict(signed_data, &signature)
                 .map_err(|err| Verify(sender.identifier().to_string(), err))?;
         }
-        #[cfg(feature = "pq")]
         crate::definitions::VidSignatureKeyType::MlDsa65 => {
             let signature: ml_dsa::Signature<MlDsa65> = ml_dsa::Signature::try_from(signature)
                 .map_err(|err| Verify(sender.identifier().to_string(), err))?;
@@ -319,24 +390,6 @@ pub(crate) fn verify_detached(
 
     Ok(())
 }
-
-#[cfg(not(feature = "pq"))]
-pub type Aead = hpke::aead::ChaCha20Poly1305;
-
-#[cfg(not(feature = "pq"))]
-pub type Kdf = hpke::kdf::HkdfSha256;
-
-#[cfg(not(feature = "pq"))]
-pub type Kem = kem::X25519HkdfSha256;
-
-#[cfg(feature = "pq")]
-pub type Aead = hpke_pq::aead::ChaCha20Poly1305;
-
-#[cfg(feature = "pq")]
-pub type Kdf = hpke_pq::kdf::HkdfSha256;
-
-#[cfg(feature = "pq")]
-pub type Kem = kem::X25519Kyber768Draft00;
 
 /// Encrypt, authenticate and sign and CESR encode a TSP message
 pub fn seal(
@@ -376,6 +429,42 @@ pub fn seal_and_hash(
     )
 }
 
+pub fn seal_with_crypto_type(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    nonconfidential_data: Option<NonConfidentialData>,
+    payload: Payload<&[u8]>,
+    crypto_type: CryptoType,
+) -> Result<TSPMessage, CryptoError> {
+    seal_and_hash_with_crypto_type(
+        sender,
+        receiver,
+        nonconfidential_data,
+        payload,
+        None,
+        crypto_type,
+    )
+}
+
+pub fn seal_and_hash_with_crypto_type(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    nonconfidential_data: Option<NonConfidentialData>,
+    payload: Payload<&[u8]>,
+    digest: Option<&mut Digest>,
+    crypto_type: CryptoType,
+) -> Result<TSPMessage, CryptoError> {
+    seal_with_selection(
+        sender,
+        receiver,
+        nonconfidential_data,
+        payload,
+        digest,
+        None,
+        OutboundCryptoSelection { crypto_type },
+    )
+}
+
 pub(crate) fn seal_and_hash_with_relationship_nonce(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
@@ -384,9 +473,48 @@ pub(crate) fn seal_and_hash_with_relationship_nonce(
     digest: Option<&mut Digest>,
     request_nonce_override: Option<[u8; 32]>,
 ) -> Result<TSPMessage, CryptoError> {
-    #[cfg(not(feature = "nacl"))]
-    let msg = match receiver.encryption_key_type() {
-        VidEncryptionKeyType::X25519 => tsp_hpke::seal::<Aead, Kdf, kem::X25519HkdfSha256>(
+    seal_with_selection(
+        sender,
+        receiver,
+        nonconfidential_data,
+        payload,
+        digest,
+        request_nonce_override,
+        default_outbound_crypto_selection(receiver),
+    )
+}
+
+pub(crate) fn seal_with_selection(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    nonconfidential_data: Option<NonConfidentialData>,
+    payload: Payload<&[u8]>,
+    digest: Option<&mut Digest>,
+    request_nonce_override: Option<[u8; 32]>,
+    selection: OutboundCryptoSelection,
+) -> Result<TSPMessage, CryptoError> {
+    ensure_selection_matches_receiver(receiver, selection.crypto_type)?;
+
+    match selection.crypto_type {
+        CryptoType::NaclAuth | CryptoType::NaclEssr => tsp_nacl::seal(
+            sender,
+            receiver,
+            nonconfidential_data,
+            payload,
+            digest,
+            request_nonce_override,
+            selection.crypto_type,
+        ),
+        CryptoType::HpkeAuth | CryptoType::HpkeEssr => tsp_hpke::seal_x25519(
+            sender,
+            receiver,
+            nonconfidential_data,
+            payload,
+            digest,
+            request_nonce_override,
+            selection.crypto_type,
+        ),
+        CryptoType::X25519Kyber768Draft00 => tsp_hpke::seal_pq(
             sender,
             receiver,
             nonconfidential_data,
@@ -394,30 +522,32 @@ pub(crate) fn seal_and_hash_with_relationship_nonce(
             digest,
             request_nonce_override,
         ),
-        #[cfg(feature = "pq")]
-        VidEncryptionKeyType::X25519Kyber768Draft00 => {
-            tsp_hpke::seal::<Aead, Kdf, kem::X25519Kyber768Draft00>(
-                sender,
-                receiver,
-                nonconfidential_data,
-                payload,
-                digest,
-                request_nonce_override,
-            )
-        }
-    }?;
+        CryptoType::Plaintext => Err(CryptoError::InvalidCryptoSelection(selection.crypto_type)),
+    }
+}
 
-    #[cfg(feature = "nacl")]
-    let msg = tsp_nacl::seal(
-        sender,
-        receiver,
-        nonconfidential_data,
-        payload,
-        digest,
-        request_nonce_override,
-    )?;
+fn ensure_selection_matches_receiver(
+    receiver: &dyn VerifiedVid,
+    crypto_type: CryptoType,
+) -> Result<(), CryptoError> {
+    let expected = match crypto_type {
+        CryptoType::NaclAuth
+        | CryptoType::NaclEssr
+        | CryptoType::HpkeAuth
+        | CryptoType::HpkeEssr => VidEncryptionKeyType::X25519,
+        CryptoType::X25519Kyber768Draft00 => VidEncryptionKeyType::X25519Kyber768Draft00,
+        CryptoType::Plaintext => return Err(CryptoError::InvalidCryptoSelection(crypto_type)),
+    };
 
-    Ok(msg)
+    let actual = receiver.encryption_key_type();
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(CryptoError::IncompatibleCryptoSelection {
+            crypto_type,
+            key_type: actual,
+        })
+    }
 }
 
 pub type MessageContents<'a> = (
@@ -482,16 +612,11 @@ pub(crate) fn open_with_signature_info<'a>(
     }
 
     let result = match envelope.crypto_type {
-        #[cfg(feature = "pq")]
         CryptoType::X25519Kyber768Draft00 => {
-            tsp_hpke::open::<Aead, Kdf, kem::X25519Kyber768Draft00>(
-                receiver, sender, raw_header, envelope, ciphertext,
-            )
+            tsp_hpke::open_pq(receiver, sender, raw_header, envelope, ciphertext)
         }
         CryptoType::HpkeAuth | CryptoType::HpkeEssr => {
-            tsp_hpke::open::<Aead, Kdf, kem::X25519HkdfSha256>(
-                receiver, sender, raw_header, envelope, ciphertext,
-            )
+            tsp_hpke::open_x25519(receiver, sender, raw_header, envelope, ciphertext)
         }
         CryptoType::NaclAuth | CryptoType::NaclEssr => {
             tsp_nacl::open(receiver, sender, raw_header, envelope, ciphertext)
@@ -521,77 +646,97 @@ pub fn verify<'a>(
     nonconfidential::verify(sender, tsp_message)
 }
 
-#[cfg(all(not(feature = "nacl"), not(feature = "pq")))]
-/// Generate a new encryption / decryption key pair
-pub fn gen_encrypt_keypair() -> (PrivateKeyData, PublicKeyData) {
-    use hpke::Serializable;
-
-    let (private, public) = <Kem as hpke::Kem>::gen_keypair(&mut OsRng);
-
-    (
-        private.to_bytes().to_vec().into(),
-        public.to_bytes().to_vec().into(),
-    )
+pub fn default_encryption_key_type() -> VidEncryptionKeyType {
+    if cfg!(feature = "pq") {
+        VidEncryptionKeyType::X25519Kyber768Draft00
+    } else {
+        VidEncryptionKeyType::X25519
+    }
 }
 
-#[cfg(feature = "pq")]
-/// Generate a new encryption / decryption key pair
-pub fn gen_encrypt_keypair() -> (PrivateKeyData, PublicKeyData) {
-    use hpke_pq::Serializable;
-
-    let (private, public) = <Kem as hpke_pq::Kem>::gen_keypair(&mut OsRng);
-
-    let private = private.to_bytes();
-    let public = public.to_bytes();
-
-    (
-        private.as_slice().to_vec().into(),
-        public.as_slice().to_vec().into(),
-    )
+pub fn default_signature_key_type() -> VidSignatureKeyType {
+    if cfg!(feature = "pq") {
+        VidSignatureKeyType::MlDsa65
+    } else {
+        VidSignatureKeyType::Ed25519
+    }
 }
 
-#[cfg(all(feature = "nacl", not(feature = "pq")))]
-/// Generate a new encryption / decryption key pair
+/// Generate a new encryption / decryption key pair with the default key type.
 pub fn gen_encrypt_keypair() -> (PrivateKeyData, PublicKeyData) {
-    let private_key = crypto_box::SecretKey::generate(&mut OsRng);
-
-    (
-        private_key.to_bytes().to_vec().into(),
-        crypto_box::PublicKey::from(&private_key)
-            .to_bytes()
-            .to_vec()
-            .into(),
-    )
+    gen_encrypt_keypair_for(default_encryption_key_type())
 }
 
-/// Generate a new signing / verification key pair
-#[cfg(not(feature = "pq"))]
+/// Generate a new encryption / decryption key pair for an explicit key type.
+pub fn gen_encrypt_keypair_for(key_type: VidEncryptionKeyType) -> (PrivateKeyData, PublicKeyData) {
+    match key_type {
+        VidEncryptionKeyType::X25519 => {
+            let private_key = crypto_box::SecretKey::generate(&mut OsRng);
+
+            (
+                private_key.to_bytes().to_vec().into(),
+                crypto_box::PublicKey::from(&private_key)
+                    .to_bytes()
+                    .to_vec()
+                    .into(),
+            )
+        }
+        VidEncryptionKeyType::X25519Kyber768Draft00 => {
+            use hpke_pq::Serializable;
+
+            let (private, public) =
+                <hpke_pq::kem::X25519Kyber768Draft00 as hpke_pq::Kem>::gen_keypair(&mut OsRng);
+
+            let private = private.to_bytes();
+            let public = public.to_bytes();
+
+            (
+                private.as_slice().to_vec().into(),
+                public.as_slice().to_vec().into(),
+            )
+        }
+    }
+}
+
+/// Generate a new signing / verification key pair with the default key type.
 pub fn gen_sign_keypair() -> (PrivateSigningKeyData, PublicVerificationKeyData) {
-    let sigkey = ed25519_dalek::SigningKey::generate(&mut OsRng);
-
-    (
-        sigkey.to_bytes().to_vec().into(),
-        sigkey.verifying_key().to_bytes().to_vec().into(),
-    )
+    gen_sign_keypair_for(default_signature_key_type())
 }
 
-/// Generate a new signing / verification key pair
-#[cfg(feature = "pq")]
-pub fn gen_sign_keypair() -> (PrivateSigningKeyData, PublicVerificationKeyData) {
-    let sigkey = MlDsa65::key_gen(&mut OsRng);
+/// Generate a new signing / verification key pair for an explicit key type.
+pub fn gen_sign_keypair_for(
+    key_type: VidSignatureKeyType,
+) -> (PrivateSigningKeyData, PublicVerificationKeyData) {
+    match key_type {
+        VidSignatureKeyType::Ed25519 => {
+            let sigkey = ed25519_dalek::SigningKey::generate(&mut OsRng);
 
-    (
-        sigkey.signing_key().encode().to_vec().into(),
-        sigkey.verifying_key().encode().to_vec().into(),
-    )
+            (
+                sigkey.to_bytes().to_vec().into(),
+                sigkey.verifying_key().to_bytes().to_vec().into(),
+            )
+        }
+        VidSignatureKeyType::MlDsa65 => {
+            let sigkey = MlDsa65::key_gen(&mut OsRng);
+
+            (
+                sigkey.signing_key().encode().to_vec().into(),
+                sigkey.verifying_key().encode().to_vec().into(),
+            )
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{definitions::Payload, vid::OwnedVid};
+    use crate::{
+        cesr::CryptoType,
+        definitions::{Payload, VidEncryptionKeyType, VidSignatureKeyType},
+        vid::OwnedVid,
+    };
     use url::Url;
 
-    use super::{open, seal};
+    use super::{CryptoError, open, seal, seal_with_crypto_type};
 
     #[test]
     fn seal_open_message() {
@@ -617,5 +762,116 @@ mod tests {
 
         assert_eq!(received_nonconfidential_data.unwrap(), nonconfidential_data);
         assert_eq!(received_secret_message, Payload::Content(secret_message));
+    }
+
+    #[test]
+    fn explicit_crypto_selection_supports_multiple_backends() {
+        let alice = OwnedVid::bind_with_key_types(
+            "did:test:alice-explicit",
+            Url::parse("tcp://127.0.0.1:13381").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519,
+        );
+        let bob_x25519 = OwnedVid::bind_with_key_types(
+            "did:test:bob-x25519-explicit",
+            Url::parse("tcp://127.0.0.1:13382").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519,
+        );
+        let bob_pq = OwnedVid::bind_with_key_types(
+            "did:test:bob-pq-explicit",
+            Url::parse("tcp://127.0.0.1:13383").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519Kyber768Draft00,
+        );
+
+        for (receiver, crypto_type) in [
+            (&bob_x25519, CryptoType::HpkeAuth),
+            (&bob_x25519, CryptoType::NaclAuth),
+            (&bob_pq, CryptoType::X25519Kyber768Draft00),
+        ] {
+            let mut message = seal_with_crypto_type(
+                &alice,
+                receiver,
+                None,
+                Payload::Content(b"selected backend"),
+                crypto_type,
+            )
+            .unwrap();
+
+            let (_, payload, opened_crypto_type, _) = open(receiver, &alice, &mut message).unwrap();
+
+            assert_eq!(payload, Payload::Content(b"selected backend" as &[u8]));
+            assert_eq!(opened_crypto_type, crypto_type);
+        }
+    }
+
+    #[test]
+    fn default_selection_uses_pq_for_pq_receiver() {
+        let alice = OwnedVid::bind_with_key_types(
+            "did:test:alice-default-pq",
+            Url::parse("tcp://127.0.0.1:13386").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519,
+        );
+        let bob = OwnedVid::bind_with_key_types(
+            "did:test:bob-default-pq",
+            Url::parse("tcp://127.0.0.1:13387").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519Kyber768Draft00,
+        );
+
+        let mut message = seal(&alice, &bob, None, Payload::Content(b"default pq")).unwrap();
+        let (_, payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
+
+        assert_eq!(payload, Payload::Content(b"default pq" as &[u8]));
+        assert_eq!(opened_crypto_type, CryptoType::X25519Kyber768Draft00);
+    }
+
+    #[test]
+    fn explicit_crypto_selection_rejects_incompatible_receiver_key() {
+        let alice = OwnedVid::bind_with_key_types(
+            "did:test:alice-incompatible",
+            Url::parse("tcp://127.0.0.1:13384").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519,
+        );
+        let bob = OwnedVid::bind_with_key_types(
+            "did:test:bob-incompatible",
+            Url::parse("tcp://127.0.0.1:13385").unwrap(),
+            VidSignatureKeyType::Ed25519,
+            VidEncryptionKeyType::X25519,
+        );
+
+        let err = seal_with_crypto_type(
+            &alice,
+            &bob,
+            None,
+            Payload::Content(b"selected backend"),
+            CryptoType::X25519Kyber768Draft00,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            CryptoError::IncompatibleCryptoSelection {
+                crypto_type: CryptoType::X25519Kyber768Draft00,
+                key_type: VidEncryptionKeyType::X25519,
+            }
+        ));
+
+        let err = seal_with_crypto_type(
+            &alice,
+            &bob,
+            None,
+            Payload::Content(b"selected backend"),
+            CryptoType::Plaintext,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            CryptoError::InvalidCryptoSelection(CryptoType::Plaintext)
+        ));
     }
 }

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -4,7 +4,7 @@ use crate::definitions::{
     VerifiedVid, VidEncryptionKeyType, VidSignatureKeyType,
 };
 use ed25519_dalek::Signer;
-use ml_dsa::{EncodedVerifyingKey, KeyGen, MlDsa65, signature::Verifier};
+use ml_dsa::{EncodedVerifyingKey, ExpandedSigningKey, ExpandedSigningKeyBytes, MlDsa65};
 use rand_core::OsRng;
 #[cfg(feature = "bench-network-timings")]
 use std::time::Instant;
@@ -119,12 +119,8 @@ pub(crate) fn append_signature(
         VidSignatureKeyType::MlDsa65 => {
             #[cfg(feature = "bench-network-timings")]
             let signature_started = std::time::Instant::now();
-            let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(&ml_dsa::EncodedSigningKey::<
-                MlDsa65,
-            >::try_from(
-                sender.signing_key().as_slice(),
-            )?);
-            let signature = sign_key.sign(data).encode();
+            let sign_key = mldsa65_signing_key_from_bytes(sender.signing_key().as_slice())?;
+            let signature = ml_dsa::Signer::sign(&sign_key, data).encode();
             crate::cesr::encode_signature(signature.as_slice(), data, SignatureType::MlDsa65);
             #[cfg(feature = "bench-network-timings")]
             crate::bench::record_signature(signature_started);
@@ -132,6 +128,14 @@ pub(crate) fn append_signature(
     }
 
     Ok(())
+}
+
+fn mldsa65_signing_key_from_bytes(
+    signing_key: &[u8],
+) -> Result<ExpandedSigningKey<MlDsa65>, CryptoError> {
+    let signing_key = ExpandedSigningKeyBytes::<MlDsa65>::try_from(signing_key)?;
+    #[allow(deprecated)]
+    Ok(ExpandedSigningKey::<MlDsa65>::from_expanded(&signing_key))
 }
 
 fn encode_hashed_payload(
@@ -351,11 +355,8 @@ pub(crate) fn sign_detached(sender: &dyn PrivateVid, data: &[u8]) -> Result<Vec<
             sign_key.sign(data).to_bytes().to_vec()
         }
         crate::definitions::VidSignatureKeyType::MlDsa65 => {
-            use ml_dsa::EncodedSigningKey;
-            let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
-                &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
-            );
-            sign_key.sign(data).encode().to_vec()
+            let sign_key = mldsa65_signing_key_from_bytes(sender.signing_key().as_slice())?;
+            ml_dsa::Signer::sign(&sign_key, data).encode().to_vec()
         }
     })
 }
@@ -368,23 +369,22 @@ pub(crate) fn verify_detached(
     match sender.signature_key_type() {
         crate::definitions::VidSignatureKeyType::Ed25519 => {
             let signature = ed25519_dalek::Signature::from_slice(signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
             let verifying_key =
                 ed25519_dalek::VerifyingKey::try_from(sender.verifying_key().as_slice())
-                    .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                    .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
             verifying_key
                 .verify_strict(signed_data, &signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
         }
         crate::definitions::VidSignatureKeyType::MlDsa65 => {
             let signature: ml_dsa::Signature<MlDsa65> = ml_dsa::Signature::try_from(signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
             let verifying_key = ml_dsa::VerifyingKey::decode(
                 &EncodedVerifyingKey::<MlDsa65>::try_from(sender.verifying_key().as_slice())?,
             );
-            verifying_key
-                .verify(signed_data, &signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+            ml_dsa::Verifier::verify(&verifying_key, signed_data, &signature)
+                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
         }
     }
 
@@ -717,11 +717,15 @@ pub fn gen_sign_keypair_for(
             )
         }
         VidSignatureKeyType::MlDsa65 => {
-            let sigkey = MlDsa65::key_gen(&mut OsRng);
+            let sigkey = <ml_dsa::SigningKey<MlDsa65> as ml_dsa::Generate>::generate();
+            let verifying_key =
+                <ml_dsa::SigningKey<MlDsa65> as ml_dsa::Keypair>::verifying_key(&sigkey);
+            #[allow(deprecated)]
+            let signing_key = sigkey.expanded_key().to_expanded();
 
             (
-                sigkey.signing_key().encode().to_vec().into(),
-                sigkey.verifying_key().encode().to_vec().into(),
+                signing_key.to_vec().into(),
+                verifying_key.encode().to_vec().into(),
             )
         }
     }

--- a/tsp_sdk/src/crypto/nonconfidential.rs
+++ b/tsp_sdk/src/crypto/nonconfidential.rs
@@ -4,7 +4,6 @@ use crate::{
     cesr::{CryptoType, DecodedEnvelope, Envelope, SignatureType},
     definitions::{MessageType, PrivateVid, TSPMessage, VerifiedVid},
 };
-use ed25519_dalek::Verifier;
 use ml_dsa::{EncodedVerifyingKey, MlDsa65};
 
 /// Construct and sign a non-confidential TSP message
@@ -50,24 +49,27 @@ pub fn verify<'a>(
         SignatureType::NoSignature => {}
         SignatureType::Ed25519 => {
             let signature = ed25519_dalek::Signature::from_slice(verification_challenge.signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
             let verifying_key =
                 ed25519_dalek::VerifyingKey::try_from(sender.verifying_key().as_slice())
-                    .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                    .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
             verifying_key
                 .verify_strict(verification_challenge.signed_data, &signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
         }
         SignatureType::MlDsa65 => {
             let signature: ml_dsa::Signature<MlDsa65> =
                 ml_dsa::Signature::try_from(verification_challenge.signature)
-                    .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+                    .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
             let verifying_key = ml_dsa::VerifyingKey::decode(
                 &EncodedVerifyingKey::<MlDsa65>::try_from(sender.verifying_key().as_slice())?,
             );
-            verifying_key
-                .verify(verification_challenge.signed_data, &signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err))?;
+            ml_dsa::Verifier::verify(
+                &verifying_key,
+                verification_challenge.signed_data,
+                &signature,
+            )
+            .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
         }
     }
     #[cfg(feature = "bench-network-timings")]

--- a/tsp_sdk/src/crypto/nonconfidential.rs
+++ b/tsp_sdk/src/crypto/nonconfidential.rs
@@ -1,15 +1,11 @@
-use super::CryptoError;
+use super::{CryptoError, append_signature, signature_type};
 use crate::crypto::CryptoError::Verify;
-use crate::definitions::VidSignatureKeyType;
 use crate::{
     cesr::{CryptoType, DecodedEnvelope, Envelope, SignatureType},
     definitions::{MessageType, PrivateVid, TSPMessage, VerifiedVid},
 };
-#[cfg(feature = "pq")]
 use ed25519_dalek::Verifier;
-use ed25519_dalek::ed25519::signature::Signer;
-#[cfg(feature = "pq")]
-use ml_dsa::{EncodedSigningKey, EncodedVerifyingKey, MlDsa65};
+use ml_dsa::{EncodedVerifyingKey, MlDsa65};
 
 /// Construct and sign a non-confidential TSP message
 pub fn sign(
@@ -19,16 +15,10 @@ pub fn sign(
 ) -> Result<TSPMessage, CryptoError> {
     let mut data = Vec::with_capacity(64);
 
-    let signature_type = match sender.signature_key_type() {
-        VidSignatureKeyType::Ed25519 => SignatureType::Ed25519,
-        #[cfg(feature = "pq")]
-        VidSignatureKeyType::MlDsa65 => SignatureType::MlDsa65,
-    };
-
     crate::cesr::encode_s_envelope(
         crate::cesr::Envelope {
             crypto_type: CryptoType::Plaintext,
-            signature_type,
+            signature_type: signature_type(sender),
             sender: sender.identifier(),
             receiver: receiver.map(|r| r.identifier()),
             nonconfidential_data: Some(payload),
@@ -36,32 +26,7 @@ pub fn sign(
         &mut data,
     )?;
 
-    // create and append signature
-    match sender.signature_key_type() {
-        VidSignatureKeyType::Ed25519 => {
-            #[cfg(feature = "bench-network-timings")]
-            let signature_started = std::time::Instant::now();
-            let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
-                sender.signing_key().as_slice(),
-            )?);
-            let signature = sign_key.sign(&data).to_bytes();
-            crate::cesr::encode_signature(&signature, &mut data, SignatureType::Ed25519);
-            #[cfg(feature = "bench-network-timings")]
-            crate::bench::record_signature(signature_started);
-        }
-        #[cfg(feature = "pq")]
-        VidSignatureKeyType::MlDsa65 => {
-            #[cfg(feature = "bench-network-timings")]
-            let signature_started = std::time::Instant::now();
-            let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
-                &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
-            );
-            let signature = sign_key.sign(&data).encode();
-            crate::cesr::encode_signature(signature.as_slice(), &mut data, SignatureType::MlDsa65);
-            #[cfg(feature = "bench-network-timings")]
-            crate::bench::record_signature(signature_started);
-        }
-    }
+    append_signature(sender, &mut data)?;
 
     Ok(data)
 }
@@ -93,7 +58,6 @@ pub fn verify<'a>(
                 .verify_strict(verification_challenge.signed_data, &signature)
                 .map_err(|err| Verify(sender.identifier().to_string(), err))?;
         }
-        #[cfg(feature = "pq")]
         SignatureType::MlDsa65 => {
             let signature: ml_dsa::Signature<MlDsa65> =
                 ml_dsa::Signature::try_from(verification_challenge.signature)

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -1,89 +1,48 @@
 use crate::{
     cesr::{CryptoType, DecodedPayload, Envelope},
-    definitions::{Payload, PrivateVid, VerifiedVid},
+    definitions::{NonConfidentialData, Payload, PrivateVid, TSPMessage, VerifiedVid},
 };
-
-#[cfg(not(feature = "nacl"))]
-use crate::{
-    cesr::SignatureType,
-    definitions::{NonConfidentialData, TSPMessage, VidSignatureKeyType},
+use hpke::{
+    Deserializable, OpModeR, OpModeS, Serializable, single_shot_open_in_place_detached,
+    single_shot_seal_in_place_detached,
 };
-
-#[cfg(not(feature = "nacl"))]
-use ed25519_dalek::Signer;
-#[cfg(not(feature = "nacl"))]
+use hpke_pq::{
+    Deserializable as PqDeserializable, OpModeR as PqOpModeR, OpModeS as PqOpModeS,
+    Serializable as PqSerializable,
+    single_shot_open_in_place_detached as pq_single_shot_open_in_place_detached,
+    single_shot_seal_in_place_detached as pq_single_shot_seal_in_place_detached,
+};
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 
-#[cfg(not(feature = "pq"))]
-use hpke::{
-    Deserializable, OpModeR, Serializable, aead, kdf, kem, single_shot_open_in_place_detached,
-};
-
-#[cfg(all(not(feature = "nacl"), not(feature = "pq")))]
-use hpke::{OpModeS, single_shot_seal_in_place_detached};
-
 use super::{
-    CryptoError, MessageContents, ParallelSignatureInfo, open_relationship_accept,
-    open_relationship_request,
+    CryptoError, MessageContents, ParallelSignatureInfo, RelationshipDigestAlgorithm,
+    append_signature, build_relationship_accept_payload, build_relationship_request_payload,
+    open_relationship_accept, open_relationship_request, signature_type,
 };
-#[cfg(not(feature = "nacl"))]
-use super::{
-    RelationshipDigestAlgorithm, build_relationship_accept_payload,
-    build_relationship_request_payload,
-};
-#[cfg(feature = "pq")]
-use hpke_pq::{
-    Deserializable, OpModeR, OpModeS, Serializable, aead, kdf, kem,
-    single_shot_open_in_place_detached, single_shot_seal_in_place_detached,
-};
-#[cfg(feature = "pq")]
-use ml_dsa::{EncodedSigningKey, MlDsa65};
 
-#[cfg(not(feature = "nacl"))]
-pub(crate) fn seal<A, Kdf, Kem>(
-    sender: &dyn PrivateVid,
-    receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
-    secret_payload: Payload<&[u8]>,
-    digest: Option<&mut super::Digest>,
+type X25519Aead = hpke::aead::ChaCha20Poly1305;
+type X25519Kdf = hpke::kdf::HkdfSha256;
+type X25519Kem = hpke::kem::X25519HkdfSha256;
+
+type PqAead = hpke_pq::aead::ChaCha20Poly1305;
+type PqKdf = hpke_pq::kdf::HkdfSha256;
+type PqKem = hpke_pq::kem::X25519Kyber768Draft00;
+type SealPayload<'a> = crate::cesr::Payload<'a, &'a [u8], &'a [u8]>;
+type PreparedPayload<'a> = (SealPayload<'a>, Option<super::Digest>);
+
+fn payload_for_seal<'a>(
+    secret_payload: &'a Payload<'a, &'a [u8]>,
+    sender_in_payload: Option<&'a [u8]>,
+    digest_algorithm: RelationshipDigestAlgorithm,
     request_nonce_override: Option<[u8; 32]>,
-) -> Result<TSPMessage, CryptoError>
-where
-    A: aead::Aead,
-    Kdf: kdf::Kdf,
-    Kem: kem::Kem + crate::cesr::AsCryptoType,
-{
-    let mut csprng = StdRng::from_entropy();
-
-    let mut data = Vec::with_capacity(64);
-
-    let signature_type = match sender.signature_key_type() {
-        VidSignatureKeyType::Ed25519 => SignatureType::Ed25519,
-        #[cfg(feature = "pq")]
-        VidSignatureKeyType::MlDsa65 => SignatureType::MlDsa65,
-    };
-
-    let crypto_type = Kem::crypto_type();
-
-    crate::cesr::encode_ets_envelope(
-        crate::cesr::Envelope {
-            crypto_type,
-            signature_type,
-            sender: sender.identifier(),
-            receiver: Some(receiver.identifier()),
-            nonconfidential_data,
-        },
-        &mut data,
-    )?;
-
-    let sender_in_payload = Some(sender.identifier().as_bytes());
-
-    let mut request_digest_storage = [0_u8; 32];
-    let mut reply_digest_storage = [0_u8; 32];
+    csprng: &mut StdRng,
+    request_digest_storage: &'a mut super::Digest,
+    reply_digest_storage: &'a mut super::Digest,
+) -> Result<PreparedPayload<'a>, CryptoError> {
     let mut payload_digest_override = None;
 
-    let secret_payload = match secret_payload {
-        Payload::Content(data) => crate::cesr::Payload::GenericMessage(data),
+    let payload = match secret_payload {
+        Payload::Content(data) => crate::cesr::Payload::GenericMessage(*data),
         Payload::RequestRelationship {
             thread_id: _ignored,
             form,
@@ -95,72 +54,179 @@ where
             });
 
             let (payload, payload_digest) = build_relationship_request_payload(
-                &form,
+                form,
                 sender_in_payload,
-                RelationshipDigestAlgorithm::Sha2_256,
+                digest_algorithm,
                 nonce_bytes,
-                &mut request_digest_storage,
+                request_digest_storage,
             )?;
             payload_digest_override = Some(payload_digest);
             payload
         }
         Payload::AcceptRelationship {
-            ref thread_id,
+            thread_id,
             reply_thread_id: _ignored,
             form,
         } => {
             let (payload, payload_digest) = build_relationship_accept_payload(
                 thread_id,
-                &form,
+                form,
                 sender_in_payload,
-                RelationshipDigestAlgorithm::Sha2_256,
-                &mut reply_digest_storage,
+                digest_algorithm,
+                reply_digest_storage,
             )?;
             payload_digest_override = Some(payload_digest);
             payload
         }
-        Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
-            reply: crate::cesr::Digest::Sha2_256(thread_id),
+        Payload::CancelRelationship { thread_id } => crate::cesr::Payload::RelationshipCancel {
+            reply: digest_algorithm.field(thread_id),
         },
-        Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(data),
-        Payload::RoutedMessage(hops, data) => crate::cesr::Payload::RoutedMessage(hops, data),
+        Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(*data),
+        Payload::RoutedMessage(hops, data) => {
+            crate::cesr::Payload::RoutedMessage(hops.clone(), *data)
+        }
     };
 
-    // prepare CESR-encoded ciphertext
-    let mut cesr_message = Vec::with_capacity(
-        // plaintext size
-        secret_payload.calculate_size(sender_in_payload)
-        // authenticated encryption tag length
-        + aead::AeadTag::<A>::size()
-        // encapsulated key length
-        + Kem::EncappedKey::size(),
-    );
+    Ok((payload, payload_digest_override))
+}
 
+pub(crate) fn seal_x25519(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    nonconfidential_data: Option<NonConfidentialData>,
+    secret_payload: Payload<&[u8]>,
+    digest: Option<&mut super::Digest>,
+    request_nonce_override: Option<[u8; 32]>,
+    crypto_type: CryptoType,
+) -> Result<TSPMessage, CryptoError> {
+    if !matches!(crypto_type, CryptoType::HpkeAuth | CryptoType::HpkeEssr) {
+        return Err(CryptoError::InvalidCryptoSelection(crypto_type));
+    }
+
+    let mut csprng = StdRng::from_entropy();
+    let mut data = Vec::with_capacity(64);
+
+    crate::cesr::encode_ets_envelope(
+        crate::cesr::Envelope {
+            crypto_type,
+            signature_type: signature_type(sender),
+            sender: sender.identifier(),
+            receiver: Some(receiver.identifier()),
+            nonconfidential_data,
+        },
+        &mut data,
+    )?;
+
+    let sender_in_payload = Some(sender.identifier().as_bytes());
+    let mut request_digest_storage = [0_u8; 32];
+    let mut reply_digest_storage = [0_u8; 32];
+    let digest_algorithm = RelationshipDigestAlgorithm::for_crypto_type(crypto_type)?;
+    let (secret_payload, payload_digest_override) = payload_for_seal(
+        &secret_payload,
+        sender_in_payload,
+        digest_algorithm,
+        request_nonce_override,
+        &mut csprng,
+        &mut request_digest_storage,
+        &mut reply_digest_storage,
+    )?;
+
+    let mut cesr_message = Vec::with_capacity(
+        secret_payload.calculate_size(sender_in_payload)
+            + hpke::aead::AeadTag::<X25519Aead>::size()
+            + <X25519Kem as hpke::Kem>::EncappedKey::size(),
+    );
     crate::cesr::encode_payload(&secret_payload, sender_in_payload, &mut cesr_message)?;
 
-    // HPKE sender mode: "Auth" for ESSR and PQ features
-    #[cfg(all(not(feature = "essr"), not(feature = "pq")))]
-    let mode = {
-        let sender_decryption_key = Kem::PrivateKey::from_bytes(sender.decryption_key().as_ref())?;
-        let sender_encryption_key = Kem::PublicKey::from_bytes(sender.encryption_key().as_ref())?;
+    let mode = if crypto_type == CryptoType::HpkeEssr {
+        OpModeS::Base
+    } else {
+        let sender_decryption_key =
+            <X25519Kem as hpke::Kem>::PrivateKey::from_bytes(sender.decryption_key().as_ref())?;
+        let sender_encryption_key =
+            <X25519Kem as hpke::Kem>::PublicKey::from_bytes(sender.encryption_key().as_ref())?;
 
         OpModeS::Auth((sender_decryption_key, sender_encryption_key))
     };
 
-    #[cfg(any(feature = "essr", feature = "pq"))]
-    let mode = OpModeS::Base;
+    let message_receiver =
+        <X25519Kem as hpke::Kem>::PublicKey::from_bytes(receiver.encryption_key().as_ref())?;
 
-    // recipient public key
-    let message_receiver = Kem::PublicKey::from_bytes(receiver.encryption_key().as_ref())?;
-
-    // hash the raw bytes of the plaintext before encryption
     if let Some(digest) = digest {
-        *digest = payload_digest_override.unwrap_or_else(|| crate::crypto::sha256(&cesr_message));
+        *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
     }
 
-    // perform encryption
-    let (encapped_key, tag) = single_shot_seal_in_place_detached::<A, Kdf, Kem, StdRng>(
-        &mode,
+    let (encapped_key, tag) =
+        single_shot_seal_in_place_detached::<X25519Aead, X25519Kdf, X25519Kem, StdRng>(
+            &mode,
+            &message_receiver,
+            &data,
+            &mut cesr_message,
+            &[],
+            &mut csprng,
+        )?;
+
+    cesr_message.extend(tag.to_bytes());
+    cesr_message.extend(encapped_key.to_bytes());
+    crate::cesr::encode_ciphertext(&cesr_message, crypto_type, &mut data)?;
+    append_signature(sender, &mut data)?;
+
+    Ok(data)
+}
+
+pub(crate) fn seal_pq(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    nonconfidential_data: Option<NonConfidentialData>,
+    secret_payload: Payload<&[u8]>,
+    digest: Option<&mut super::Digest>,
+    request_nonce_override: Option<[u8; 32]>,
+) -> Result<TSPMessage, CryptoError> {
+    let crypto_type = CryptoType::X25519Kyber768Draft00;
+    let mut csprng = StdRng::from_entropy();
+    let mut data = Vec::with_capacity(64);
+
+    crate::cesr::encode_ets_envelope(
+        crate::cesr::Envelope {
+            crypto_type,
+            signature_type: signature_type(sender),
+            sender: sender.identifier(),
+            receiver: Some(receiver.identifier()),
+            nonconfidential_data,
+        },
+        &mut data,
+    )?;
+
+    let sender_in_payload = Some(sender.identifier().as_bytes());
+    let mut request_digest_storage = [0_u8; 32];
+    let mut reply_digest_storage = [0_u8; 32];
+    let digest_algorithm = RelationshipDigestAlgorithm::for_crypto_type(crypto_type)?;
+    let (secret_payload, payload_digest_override) = payload_for_seal(
+        &secret_payload,
+        sender_in_payload,
+        digest_algorithm,
+        request_nonce_override,
+        &mut csprng,
+        &mut request_digest_storage,
+        &mut reply_digest_storage,
+    )?;
+
+    let mut cesr_message = Vec::with_capacity(
+        secret_payload.calculate_size(sender_in_payload)
+            + hpke_pq::aead::AeadTag::<PqAead>::size()
+            + <PqKem as hpke_pq::Kem>::EncappedKey::size(),
+    );
+    crate::cesr::encode_payload(&secret_payload, sender_in_payload, &mut cesr_message)?;
+
+    let message_receiver =
+        <PqKem as hpke_pq::Kem>::PublicKey::from_bytes(receiver.encryption_key().as_ref())?;
+
+    if let Some(digest) = digest {
+        *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
+    }
+
+    let (encapped_key, tag) = pq_single_shot_seal_in_place_detached::<PqAead, PqKdf, PqKem, StdRng>(
+        &PqOpModeS::Base,
         &message_receiver,
         &data,
         &mut cesr_message,
@@ -168,78 +234,43 @@ where
         &mut csprng,
     )?;
 
-    // append the authentication tag and encapsulated key to the end of the ciphertext
     cesr_message.extend(tag.to_bytes());
     cesr_message.extend(encapped_key.to_bytes());
-
-    // encode and append the ciphertext to the envelope data
     crate::cesr::encode_ciphertext(&cesr_message, crypto_type, &mut data)?;
-
-    // create and append signature
-    match sender.signature_key_type() {
-        VidSignatureKeyType::Ed25519 => {
-            #[cfg(feature = "bench-network-timings")]
-            let signature_started = std::time::Instant::now();
-            let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
-                sender.signing_key().as_slice(),
-            )?);
-            let signature = sign_key.sign(&data).to_bytes();
-            crate::cesr::encode_signature(&signature, &mut data, SignatureType::Ed25519);
-            #[cfg(feature = "bench-network-timings")]
-            crate::bench::record_signature(signature_started);
-        }
-        #[cfg(feature = "pq")]
-        VidSignatureKeyType::MlDsa65 => {
-            #[cfg(feature = "bench-network-timings")]
-            let signature_started = std::time::Instant::now();
-            let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
-                &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
-            );
-            let signature = sign_key.sign(&data).encode();
-            crate::cesr::encode_signature(signature.as_slice(), &mut data, SignatureType::MlDsa65);
-            #[cfg(feature = "bench-network-timings")]
-            crate::bench::record_signature(signature_started);
-        }
-    }
+    append_signature(sender, &mut data)?;
 
     Ok(data)
 }
 
-pub(crate) fn open<'a, A, Kdf, Kem>(
+pub(crate) fn open_x25519<'a>(
     receiver: &dyn PrivateVid,
     sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
     envelope: Envelope<'a, &[u8]>,
     ciphertext: &'a mut [u8],
-) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError>
-where
-    A: aead::Aead,
-    Kdf: kdf::Kdf,
-    Kem: kem::Kem,
-{
-    // split encapsulated key and authenticated encryption tag length
-    let (ciphertext, footer) = ciphertext
-        .split_at_mut(ciphertext.len() - aead::AeadTag::<A>::size() - Kem::EncappedKey::size());
-    let (tag, encapped_key) = footer.split_at(footer.len() - Kem::EncappedKey::size());
+) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
+    let (ciphertext, footer) = ciphertext.split_at_mut(
+        ciphertext.len()
+            - hpke::aead::AeadTag::<X25519Aead>::size()
+            - <X25519Kem as hpke::Kem>::EncappedKey::size(),
+    );
+    let (tag, encapped_key) =
+        footer.split_at(footer.len() - <X25519Kem as hpke::Kem>::EncappedKey::size());
 
-    // construct correct key types
-    let receiver_decryption_key = Kem::PrivateKey::from_bytes(receiver.decryption_key().as_ref())?;
-    let encapped_key = Kem::EncappedKey::from_bytes(encapped_key)?;
-    let tag = aead::AeadTag::from_bytes(tag)?;
+    let receiver_decryption_key =
+        <X25519Kem as hpke::Kem>::PrivateKey::from_bytes(receiver.decryption_key().as_ref())?;
+    let encapped_key = <X25519Kem as hpke::Kem>::EncappedKey::from_bytes(encapped_key)?;
+    let tag = hpke::aead::AeadTag::<X25519Aead>::from_bytes(tag)?;
 
-    #[cfg(feature = "pq")]
-    let mode = OpModeR::Base;
-
-    #[cfg(not(feature = "pq"))]
     let mode = if envelope.crypto_type == CryptoType::HpkeEssr {
         OpModeR::Base
     } else {
-        let sender_encryption_key = Kem::PublicKey::from_bytes(sender.encryption_key().as_ref())?;
+        let sender_encryption_key =
+            <X25519Kem as hpke::Kem>::PublicKey::from_bytes(sender.encryption_key().as_ref())?;
         OpModeR::Auth(sender_encryption_key)
     };
 
-    // decrypt the ciphertext
-    single_shot_open_in_place_detached::<A, Kdf, Kem>(
+    single_shot_open_in_place_detached::<X25519Aead, X25519Kdf, X25519Kem>(
         &mode,
         &receiver_decryption_key,
         &encapped_key,
@@ -249,6 +280,47 @@ where
         &tag,
     )?;
 
+    open_payload(sender, envelope, ciphertext)
+}
+
+pub(crate) fn open_pq<'a>(
+    receiver: &dyn PrivateVid,
+    sender: &dyn VerifiedVid,
+    raw_header: &'a [u8],
+    envelope: Envelope<'a, &[u8]>,
+    ciphertext: &'a mut [u8],
+) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
+    let (ciphertext, footer) = ciphertext.split_at_mut(
+        ciphertext.len()
+            - hpke_pq::aead::AeadTag::<PqAead>::size()
+            - <PqKem as hpke_pq::Kem>::EncappedKey::size(),
+    );
+    let (tag, encapped_key) =
+        footer.split_at(footer.len() - <PqKem as hpke_pq::Kem>::EncappedKey::size());
+
+    let receiver_decryption_key =
+        <PqKem as hpke_pq::Kem>::PrivateKey::from_bytes(receiver.decryption_key().as_ref())?;
+    let encapped_key = <PqKem as hpke_pq::Kem>::EncappedKey::from_bytes(encapped_key)?;
+    let tag = hpke_pq::aead::AeadTag::<PqAead>::from_bytes(tag)?;
+
+    pq_single_shot_open_in_place_detached::<PqAead, PqKdf, PqKem>(
+        &PqOpModeR::Base,
+        &receiver_decryption_key,
+        &encapped_key,
+        raw_header,
+        ciphertext,
+        &[],
+        &tag,
+    )?;
+
+    open_payload(sender, envelope, ciphertext)
+}
+
+fn open_payload<'a>(
+    sender: &dyn VerifiedVid,
+    envelope: Envelope<'a, &[u8]>,
+    ciphertext: &'a mut [u8],
+) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     #[allow(unused_variables)]
     let DecodedPayload {
         payload,
@@ -286,16 +358,6 @@ where
             ),
             None,
         ),
-        crate::cesr::Payload::RelationshipCancel { reply, .. } => (
-            Payload::CancelRelationship {
-                thread_id: *reply.as_bytes(),
-            },
-            None,
-        ),
-        crate::cesr::Payload::NestedMessage(data) => (Payload::NestedMessage(data), None),
-        crate::cesr::Payload::RoutedMessage(hops, data) => {
-            (Payload::RoutedMessage(hops, data as _), None)
-        }
         crate::cesr::Payload::ParallelRelationProposal {
             nonce,
             request_digest,
@@ -346,6 +408,16 @@ where
                 )?,
             }),
         ),
+        crate::cesr::Payload::RelationshipCancel { reply, .. } => (
+            Payload::CancelRelationship {
+                thread_id: *reply.as_bytes(),
+            },
+            None,
+        ),
+        crate::cesr::Payload::NestedMessage(data) => (Payload::NestedMessage(data), None),
+        crate::cesr::Payload::RoutedMessage(hops, data) => {
+            (Payload::RoutedMessage(hops, data as _), None)
+        }
     };
 
     Ok((

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -8,26 +8,14 @@ use super::{
     CryptoError, MessageContents, ParallelSignatureInfo, open_relationship_accept,
     open_relationship_request,
 };
-#[cfg(feature = "nacl")]
 use super::{
-    RelationshipDigestAlgorithm, build_relationship_accept_payload,
-    build_relationship_request_payload,
+    RelationshipDigestAlgorithm, append_signature, build_relationship_accept_payload,
+    build_relationship_request_payload, signature_type,
 };
-#[cfg(feature = "nacl")]
-use crate::{
-    cesr::SignatureType,
-    definitions::{NonConfidentialData, TSPMessage, VidSignatureKeyType},
-};
-#[cfg(feature = "nacl")]
+use crate::definitions::{NonConfidentialData, TSPMessage};
 use crypto_box::aead::{AeadCore, OsRng};
-#[cfg(feature = "nacl")]
-use ed25519_dalek::Signer;
-#[cfg(all(feature = "pq", feature = "nacl"))]
-use ml_dsa::{EncodedSigningKey, MlDsa65};
-#[cfg(feature = "nacl")]
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 
-#[cfg(feature = "nacl")]
 pub(crate) fn seal(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
@@ -35,17 +23,19 @@ pub(crate) fn seal(
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
     request_nonce_override: Option<[u8; 32]>,
+    crypto_type: CryptoType,
 ) -> Result<TSPMessage, CryptoError> {
+    if !matches!(crypto_type, CryptoType::NaclAuth | CryptoType::NaclEssr) {
+        return Err(CryptoError::InvalidCryptoSelection(crypto_type));
+    }
+
     let mut csprng = StdRng::from_entropy();
 
     let mut data = Vec::with_capacity(64);
     crate::cesr::encode_ets_envelope(
         crate::cesr::Envelope {
-            #[cfg(feature = "essr")]
-            crypto_type: CryptoType::NaclEssr,
-            #[cfg(not(feature = "essr"))]
-            crypto_type: CryptoType::NaclAuth,
-            signature_type: SignatureType::Ed25519,
+            crypto_type,
+            signature_type: signature_type(sender),
             sender: sender.identifier(),
             receiver: Some(receiver.identifier()),
             nonconfidential_data,
@@ -58,6 +48,7 @@ pub(crate) fn seal(
     let mut request_digest_storage = [0_u8; 32];
     let mut reply_digest_storage = [0_u8; 32];
     let mut payload_digest_override = None;
+    let digest_algorithm = RelationshipDigestAlgorithm::for_crypto_type(crypto_type)?;
 
     let secret_payload = match secret_payload {
         Payload::Content(data) => crate::cesr::Payload::GenericMessage(data),
@@ -74,7 +65,7 @@ pub(crate) fn seal(
             let (payload, payload_digest) = build_relationship_request_payload(
                 &form,
                 sender_in_payload,
-                RelationshipDigestAlgorithm::Blake2b256,
+                digest_algorithm,
                 nonce_bytes,
                 &mut request_digest_storage,
             )?;
@@ -90,14 +81,14 @@ pub(crate) fn seal(
                 thread_id,
                 &form,
                 sender_in_payload,
-                RelationshipDigestAlgorithm::Blake2b256,
+                digest_algorithm,
                 &mut reply_digest_storage,
             )?;
             payload_digest_override = Some(payload_digest);
             payload
         }
         Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
-            reply: crate::cesr::Digest::Blake2b256(thread_id),
+            reply: digest_algorithm.field(thread_id),
         },
         Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(data),
         Payload::RoutedMessage(hops, data) => crate::cesr::Payload::RoutedMessage(hops, data),
@@ -110,8 +101,7 @@ pub(crate) fn seal(
 
     // hash the raw bytes of the plaintext before encryption
     if let Some(digest) = digest {
-        *digest =
-            payload_digest_override.unwrap_or_else(|| crate::crypto::blake2b256(&cesr_message));
+        *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
     }
 
     let sender_secret_key = SecretKey::from_slice(sender.decryption_key())?;
@@ -129,42 +119,9 @@ pub(crate) fn seal(
     cesr_message.extend(nonce);
 
     // encode and append the ciphertext to the envelope data
-    crate::cesr::encode_ciphertext(
-        &cesr_message,
-        if cfg!(feature = "essr") {
-            CryptoType::NaclEssr
-        } else {
-            CryptoType::NaclAuth
-        },
-        &mut data,
-    )?;
+    crate::cesr::encode_ciphertext(&cesr_message, crypto_type, &mut data)?;
 
-    // create and append signature
-    match sender.signature_key_type() {
-        VidSignatureKeyType::Ed25519 => {
-            #[cfg(feature = "bench-network-timings")]
-            let signature_started = std::time::Instant::now();
-            let sign_key = ed25519_dalek::SigningKey::from_bytes(&TryInto::<[u8; 32]>::try_into(
-                sender.signing_key().as_slice(),
-            )?);
-            let signature = sign_key.sign(&data).to_bytes();
-            crate::cesr::encode_signature(&signature, &mut data, SignatureType::Ed25519);
-            #[cfg(feature = "bench-network-timings")]
-            crate::bench::record_signature(signature_started);
-        }
-        #[cfg(feature = "pq")]
-        VidSignatureKeyType::MlDsa65 => {
-            #[cfg(feature = "bench-network-timings")]
-            let signature_started = std::time::Instant::now();
-            let sign_key = ml_dsa::SigningKey::<MlDsa65>::decode(
-                &EncodedSigningKey::<MlDsa65>::try_from(sender.signing_key().as_slice())?,
-            );
-            let signature = sign_key.sign(&data).encode();
-            crate::cesr::encode_signature(signature.as_slice(), &mut data, SignatureType::MlDsa65);
-            #[cfg(feature = "bench-network-timings")]
-            crate::bench::record_signature(signature_started);
-        }
-    }
+    append_signature(sender, &mut data)?;
 
     Ok(data)
 }

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -10,9 +10,6 @@ use zeroize::Zeroize;
 #[cfg(feature = "async")]
 use futures::Stream;
 
-#[cfg(feature = "pq")]
-use crate::vid::did::web::Algorithm;
-use crate::vid::did::web::{Curve, KeyType};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
@@ -252,20 +249,58 @@ impl<Bytes: AsRef<[u8]>> fmt::Display for Payload<'_, Bytes> {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub enum VidEncryptionKeyType {
     #[default]
     X25519,
-    #[cfg(feature = "pq")]
     X25519Kyber768Draft00,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
 pub enum VidSignatureKeyType {
     #[default]
     Ed25519,
-    #[cfg(feature = "pq")]
     MlDsa65,
+}
+
+impl VidEncryptionKeyType {
+    fn jwk_key_type(self) -> &'static str {
+        match self {
+            VidEncryptionKeyType::X25519 => "OKP",
+            VidEncryptionKeyType::X25519Kyber768Draft00 => "X25519Kyber768Draft00",
+        }
+    }
+
+    fn jwk_curve(self) -> &'static str {
+        match self {
+            VidEncryptionKeyType::X25519 | VidEncryptionKeyType::X25519Kyber768Draft00 => "X25519",
+        }
+    }
+}
+
+impl VidSignatureKeyType {
+    fn jwk_key_type(self) -> &'static str {
+        match self {
+            VidSignatureKeyType::Ed25519 => "OKP",
+            VidSignatureKeyType::MlDsa65 => "APK",
+        }
+    }
+
+    fn jwk_curve(self) -> Option<&'static str> {
+        match self {
+            VidSignatureKeyType::Ed25519 => Some("Ed25519"),
+            VidSignatureKeyType::MlDsa65 => None,
+        }
+    }
+
+    fn jwk_algorithm(self) -> Option<&'static str> {
+        match self {
+            VidSignatureKeyType::Ed25519 => None,
+            VidSignatureKeyType::MlDsa65 => Some("ML-DSA-65"),
+        }
+    }
 }
 
 // ANCHOR: custom-vid-mbBook
@@ -290,8 +325,8 @@ pub trait VerifiedVid: Send + Sync {
 
     fn encryption_key_jwk(&self) -> serde_json::Value {
         serde_json::json!({
-            "kty": Into::<KeyType>::into(self.encryption_key_type()),
-            "crv": Into::<Curve>::into(self.encryption_key_type()),
+            "kty": self.encryption_key_type().jwk_key_type(),
+            "crv": self.encryption_key_type().jwk_curve(),
             "use": "enc",
             "x": Base64UrlUnpadded::encode_string(self.encryption_key().as_ref()),
         })
@@ -301,17 +336,16 @@ pub trait VerifiedVid: Send + Sync {
         match self.signature_key_type() {
             VidSignatureKeyType::Ed25519 => {
                 serde_json::json!({
-                    "kty": Into::<KeyType>::into(self.signature_key_type()),
-                    "crv": Into::<Option<Curve>>::into(self.signature_key_type()),
+                    "kty": self.signature_key_type().jwk_key_type(),
+                    "crv": self.signature_key_type().jwk_curve(),
                     "use": "sig",
                     "x": Base64UrlUnpadded::encode_string(self.verifying_key().as_ref()),
                 })
             }
-            #[cfg(feature = "pq")]
             VidSignatureKeyType::MlDsa65 => {
                 serde_json::json!({
-                    "kty": Into::<KeyType>::into(self.signature_key_type()),
-                    "alg": Into::<Option<Algorithm>>::into(self.signature_key_type()),
+                    "kty": self.signature_key_type().jwk_key_type(),
+                    "alg": self.signature_key_type().jwk_algorithm(),
                     "use": "sig",
                     "pub": Base64UrlUnpadded::encode_string(self.verifying_key().as_ref()),
                 })
@@ -329,8 +363,8 @@ pub trait PrivateVid: VerifiedVid + Send + Sync {
 
     fn private_encryption_key_jwk(&self) -> serde_json::Value {
         serde_json::json!({
-            "kty": Into::<KeyType>::into(self.encryption_key_type()),
-            "crv": Into::<Curve>::into(self.encryption_key_type()),
+            "kty": self.encryption_key_type().jwk_key_type(),
+            "crv": self.encryption_key_type().jwk_curve(),
             "use": "enc",
             "x": Base64UrlUnpadded::encode_string(self.encryption_key().as_ref()),
             "d": Base64UrlUnpadded::encode_string(self.decryption_key().as_ref()),

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -1,7 +1,7 @@
 use crate::{
     ExportVid, OwnedVid,
     cesr::EnvelopeType,
-    crypto::CryptoError,
+    crypto::{CryptoError, OutboundCryptoSelection, RelationshipDigestAlgorithm},
     definitions::{
         Digest, MessageType, Payload, PendingIncomingParallelRelationship,
         PendingNestedRelationship, PendingParallelRelationship, PrivateVid,
@@ -84,40 +84,50 @@ impl VidContext {
     }
 }
 
-fn nested_digest(bytes: &[u8]) -> Digest {
-    #[cfg(feature = "nacl")]
-    {
-        crate::crypto::blake2b256(bytes)
-    }
-
-    #[cfg(not(feature = "nacl"))]
-    {
-        crate::crypto::sha256(bytes)
-    }
+fn nested_digest(bytes: &[u8], algorithm: RelationshipDigestAlgorithm) -> Digest {
+    algorithm.hash(bytes)
 }
 
-fn relationship_digest_algorithm() -> crate::crypto::RelationshipDigestAlgorithm {
-    #[cfg(feature = "nacl")]
-    {
-        crate::crypto::RelationshipDigestAlgorithm::Blake2b256
-    }
-
-    #[cfg(not(feature = "nacl"))]
-    {
-        crate::crypto::RelationshipDigestAlgorithm::Sha2_256
-    }
+fn nested_digest_field<'a>(
+    digest: &'a Digest,
+    algorithm: RelationshipDigestAlgorithm,
+) -> crate::cesr::Digest<'a> {
+    algorithm.field(digest)
 }
 
-fn nested_digest_field<'a>(digest: &'a Digest) -> crate::cesr::Digest<'a> {
-    #[cfg(feature = "nacl")]
-    {
-        crate::cesr::Digest::Blake2b256(digest)
-    }
+fn selected_outbound_crypto(
+    receiver: &dyn VerifiedVid,
+    selection: Option<OutboundCryptoSelection>,
+) -> OutboundCryptoSelection {
+    selection.unwrap_or_else(|| crate::crypto::default_outbound_crypto_selection(receiver))
+}
 
-    #[cfg(not(feature = "nacl"))]
-    {
-        crate::cesr::Digest::Sha2_256(digest)
-    }
+fn digest_algorithm_for_selection(
+    selection: OutboundCryptoSelection,
+) -> Result<RelationshipDigestAlgorithm, Error> {
+    Ok(RelationshipDigestAlgorithm::for_crypto_type(
+        selection.crypto_type,
+    )?)
+}
+
+fn seal_envelope(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    nonconfidential_data: Option<&[u8]>,
+    payload: Payload<&[u8]>,
+    digest: Option<&mut Digest>,
+    request_nonce_override: Option<[u8; 32]>,
+    selection: Option<OutboundCryptoSelection>,
+) -> Result<Vec<u8>, Error> {
+    Ok(crate::crypto::seal_with_selection(
+        sender,
+        receiver,
+        nonconfidential_data,
+        payload,
+        digest,
+        request_nonce_override,
+        selected_outbound_crypto(receiver, selection),
+    )?)
 }
 
 enum NestedRelationshipEvent {
@@ -660,6 +670,24 @@ impl SecureStore {
         result
     }
 
+    pub fn seal_message_with_crypto_type(
+        &self,
+        sender: &str,
+        receiver: &str,
+        nonconfidential_data: Option<&[u8]>,
+        message: &[u8],
+        crypto_type: crate::cesr::CryptoType,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.seal_message_payload_and_hash_with_selection(
+            sender,
+            receiver,
+            nonconfidential_data,
+            Payload::Content(message),
+            None,
+            Some(OutboundCryptoSelection { crypto_type }),
+        )
+    }
+
     // ANCHOR_END: seal_message-mbBook
 
     /// Seal a TSP message.
@@ -682,6 +710,25 @@ impl SecureStore {
         payload: Payload<&[u8]>,
         digest: Option<&mut Digest>,
     ) -> Result<(url::Url, Vec<u8>), Error> {
+        self.seal_message_payload_and_hash_with_selection(
+            sender,
+            receiver,
+            nonconfidential_data,
+            payload,
+            digest,
+            None,
+        )
+    }
+
+    pub(crate) fn seal_message_payload_and_hash_with_selection(
+        &self,
+        sender: &str,
+        receiver: &str,
+        nonconfidential_data: Option<&[u8]>,
+        payload: Payload<&[u8]>,
+        digest: Option<&mut Digest>,
+        selection: Option<OutboundCryptoSelection>,
+    ) -> Result<(url::Url, Vec<u8>), Error> {
         let sender = self.get_private_vid(sender)?;
         let receiver_context = self.get_vid(receiver)?;
 
@@ -696,12 +743,14 @@ impl SecureStore {
                         .unwrap_or(sender.identifier());
                     let inner_sender = self.get_private_vid(inner_sender)?;
 
-                    let tsp_message: Vec<u8> = crate::crypto::seal_and_hash(
+                    let tsp_message = seal_envelope(
                         &*inner_sender,
                         &*receiver_context.vid,
                         nonconfidential_data,
                         payload,
                         digest,
+                        None,
+                        selection,
                     )?;
 
                     let first_sender = self.get_private_vid(first_sender)?;
@@ -716,11 +765,13 @@ impl SecureStore {
                 .map(|x| x.as_ref())
                 .collect::<Vec<_>>();
 
-            return self.seal_message_payload(
+            return self.seal_message_payload_and_hash_with_selection(
                 sender.identifier(),
                 first_hop.vid.identifier(),
                 None,
                 Payload::RoutedMessage(hops, &inner_message),
+                None,
+                None,
             );
         }
 
@@ -742,40 +793,47 @@ impl SecureStore {
 
             let inner_sender = self.get_private_vid(inner_sender)?;
 
-            let inner_message = if let Payload::Content(_) = payload {
+            let content_payload = matches!(&payload, Payload::Content(_));
+            let inner_message = if content_payload {
                 crate::crypto::sign(
                     &*inner_sender,
                     Some(&*receiver_context.vid),
                     payload.as_bytes(),
                 )?
             } else {
-                crate::crypto::seal_and_hash(
+                seal_envelope(
                     &*inner_sender,
                     &*receiver_context.vid,
                     None,
                     payload,
                     digest,
+                    None,
+                    selection,
                 )?
             };
 
             let parent_sender = self.get_private_vid(parent_sender)?;
             let parent_receiver = self.get_verified_vid(parent_receiver)?;
 
-            return self.seal_message_payload(
+            return self.seal_message_payload_and_hash_with_selection(
                 parent_sender.identifier(),
                 parent_receiver.identifier(),
                 nonconfidential_data,
                 Payload::NestedMessage(&inner_message),
+                None,
+                if content_payload { selection } else { None },
             );
         }
 
         // send direct mode
-        let tsp_message = crate::crypto::seal_and_hash(
+        let tsp_message = seal_envelope(
             &*sender,
             &*receiver_context.vid,
             nonconfidential_data,
             payload,
             digest,
+            None,
+            selection,
         )?;
 
         Ok((receiver_context.vid.endpoint().clone(), tsp_message))
@@ -801,6 +859,7 @@ impl SecureStore {
     fn make_signed_nested_request_message(
         &self,
         sender: &dyn PrivateVid,
+        digest_algorithm: RelationshipDigestAlgorithm,
     ) -> Result<(Vec<u8>, Digest), Error> {
         let mut csprng = StdRng::from_entropy();
         let mut nonce_bytes = [0_u8; 32];
@@ -812,20 +871,20 @@ impl SecureStore {
         let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
             crate::cesr::Payload::DirectRelationProposal {
                 nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
-                request_digest: nested_digest_field(&request_digest),
+                request_digest: nested_digest_field(&request_digest, digest_algorithm),
             };
 
         let mut encoded_payload =
             Vec::with_capacity(placeholder_payload.calculate_size(sender_identity));
         crate::cesr::encode_payload(&placeholder_payload, sender_identity, &mut encoded_payload)?;
 
-        request_digest = nested_digest(&encoded_payload);
+        request_digest = nested_digest(&encoded_payload, digest_algorithm);
 
         encoded_payload.clear();
         let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
             crate::cesr::Payload::DirectRelationProposal {
                 nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
-                request_digest: nested_digest_field(&request_digest),
+                request_digest: nested_digest_field(&request_digest, digest_algorithm),
             };
         crate::cesr::encode_payload(&payload, sender_identity, &mut encoded_payload)?;
 
@@ -839,27 +898,28 @@ impl SecureStore {
         sender: &dyn PrivateVid,
         receiver: &dyn VerifiedVid,
         thread_id: Digest,
+        digest_algorithm: RelationshipDigestAlgorithm,
     ) -> Result<(Vec<u8>, Digest), Error> {
         let sender_identity = Some(sender.identifier().as_bytes());
         let mut reply_thread_id = [0_u8; 32];
 
         let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
             crate::cesr::Payload::DirectRelationAffirm {
-                request_digest: nested_digest_field(&thread_id),
-                reply_digest: nested_digest_field(&reply_thread_id),
+                request_digest: nested_digest_field(&thread_id, digest_algorithm),
+                reply_digest: nested_digest_field(&reply_thread_id, digest_algorithm),
             };
 
         let mut encoded_payload =
             Vec::with_capacity(placeholder_payload.calculate_size(sender_identity));
         crate::cesr::encode_payload(&placeholder_payload, sender_identity, &mut encoded_payload)?;
 
-        reply_thread_id = nested_digest(&encoded_payload);
+        reply_thread_id = nested_digest(&encoded_payload, digest_algorithm);
 
         encoded_payload.clear();
         let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
             crate::cesr::Payload::DirectRelationAffirm {
-                request_digest: nested_digest_field(&thread_id),
-                reply_digest: nested_digest_field(&reply_thread_id),
+                request_digest: nested_digest_field(&thread_id, digest_algorithm),
+                reply_digest: nested_digest_field(&reply_thread_id, digest_algorithm),
             };
         crate::cesr::encode_payload(&payload, sender_identity, &mut encoded_payload)?;
 
@@ -1320,6 +1380,31 @@ impl SecureStore {
         receiver: &str,
         route: Option<&[&str]>,
     ) -> Result<(Url, Vec<u8>), Error> {
+        self.make_relationship_request_with_selection(sender, receiver, route, None)
+    }
+
+    pub fn make_relationship_request_with_crypto_type(
+        &self,
+        sender: &str,
+        receiver: &str,
+        route: Option<&[&str]>,
+        crypto_type: crate::cesr::CryptoType,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.make_relationship_request_with_selection(
+            sender,
+            receiver,
+            route,
+            Some(OutboundCryptoSelection { crypto_type }),
+        )
+    }
+
+    fn make_relationship_request_with_selection(
+        &self,
+        sender: &str,
+        receiver: &str,
+        route: Option<&[&str]>,
+        selection: Option<OutboundCryptoSelection>,
+    ) -> Result<(Url, Vec<u8>), Error> {
         if route.is_some() {
             return Err(Error::Relationship(
                 "routed relationship-forming requires Reply_Path; not implemented".into(),
@@ -1329,7 +1414,7 @@ impl SecureStore {
         let sender = self.get_private_vid(sender)?;
         let receiver = self.get_verified_vid(receiver)?;
         let mut thread_id = Default::default();
-        let tsp_message = crate::crypto::seal_and_hash(
+        let tsp_message = seal_envelope(
             &*sender,
             &*receiver,
             None,
@@ -1338,6 +1423,8 @@ impl SecureStore {
                 form: RelationshipForm::Direct,
             },
             Some(&mut thread_id),
+            None,
+            selection,
         )?;
 
         self.set_relation_and_status_for_vid(
@@ -1353,8 +1440,8 @@ impl SecureStore {
         &self,
         sender_new_vid: &dyn PrivateVid,
         context: ParallelSignatureContext<'_>,
+        digest_algorithm: RelationshipDigestAlgorithm,
     ) -> Result<ParallelSignatureMaterial, Error> {
-        let digest_algorithm = relationship_digest_algorithm();
         let mut digest = [0_u8; 32];
 
         let (signed_data, request_nonce) = match context {
@@ -1416,16 +1503,19 @@ impl SecureStore {
             }
         }
 
+        let selection = selected_outbound_crypto(&*receiver, None);
+        let digest_algorithm = digest_algorithm_for_selection(selection)?;
         let signature_material = self.build_parallel_signature_material(
             &*sender_new_vid,
             ParallelSignatureContext::Request {
                 sender_identity: sender.identifier(),
                 nonce: random_nonce_bytes(),
             },
+            digest_algorithm,
         )?;
         let mut thread_id = signature_material.digest;
 
-        let tsp_message = crate::crypto::seal_and_hash_with_relationship_nonce(
+        let tsp_message = seal_envelope(
             &*sender,
             &*receiver,
             None,
@@ -1438,6 +1528,7 @@ impl SecureStore {
             },
             Some(&mut thread_id),
             signature_material.request_nonce,
+            Some(selection),
         )?;
 
         self.add_pending_parallel_request(
@@ -1495,16 +1586,19 @@ impl SecureStore {
         let pending_incoming_request =
             self.find_pending_incoming_parallel_request(receiver_new_vid.identifier(), thread_id)?;
         let outer_sender = self.get_private_vid(&pending_incoming_request.local_outer_vid)?;
+        let selection = selected_outbound_crypto(&*receiver_new_vid, None);
+        let digest_algorithm = digest_algorithm_for_selection(selection)?;
         let signature_material = self.build_parallel_signature_material(
             &*sender_new_vid,
             ParallelSignatureContext::Accept {
                 sender_identity: outer_sender.identifier(),
                 thread_id,
             },
+            digest_algorithm,
         )?;
         let mut reply_thread_id = signature_material.digest;
 
-        let tsp_message = crate::crypto::seal_and_hash(
+        let tsp_message = seal_envelope(
             &*outer_sender,
             &*receiver_new_vid,
             None,
@@ -1517,6 +1611,8 @@ impl SecureStore {
                 },
             },
             Some(&mut reply_thread_id),
+            None,
+            Some(selection),
         )?;
 
         self.establish_bidirectional_relation(
@@ -1569,13 +1665,18 @@ impl SecureStore {
         let receiver = self.get_verified_vid(receiver)?;
 
         let nested_vid = self.make_propositioning_vid(sender.identifier())?;
-        let (inner_message, thread_id) = self.make_signed_nested_request_message(&nested_vid)?;
+        let selection = selected_outbound_crypto(&*receiver, None);
+        let digest_algorithm = digest_algorithm_for_selection(selection)?;
+        let (inner_message, thread_id) =
+            self.make_signed_nested_request_message(&nested_vid, digest_algorithm)?;
 
-        let (endpoint, tsp_message) = self.seal_message_payload(
+        let (endpoint, tsp_message) = self.seal_message_payload_and_hash_with_selection(
             sender.identifier(),
             receiver.identifier(),
             None,
             Payload::NestedMessage(&inner_message),
+            None,
+            Some(selection),
         )?;
 
         self.add_pending_nested_request(receiver.identifier(), thread_id, nested_vid.identifier())?;
@@ -1601,14 +1702,23 @@ impl SecureStore {
                 "missing parent for {nested_receiver}"
             )))?;
 
-        let (inner_message, reply_thread_id) =
-            self.make_signed_nested_accept_message(&nested_vid, &*receiver_vid.vid, thread_id)?;
+        let parent_receiver_vid = self.get_verified_vid(parent_receiver)?;
+        let selection = selected_outbound_crypto(&*parent_receiver_vid, None);
+        let digest_algorithm = digest_algorithm_for_selection(selection)?;
+        let (inner_message, reply_thread_id) = self.make_signed_nested_accept_message(
+            &nested_vid,
+            &*receiver_vid.vid,
+            thread_id,
+            digest_algorithm,
+        )?;
 
-        let (transport, tsp_message) = self.seal_message_payload(
+        let (transport, tsp_message) = self.seal_message_payload_and_hash_with_selection(
             parent_sender,
             parent_receiver,
             None,
             Payload::NestedMessage(&inner_message),
+            None,
+            Some(selection),
         )?;
 
         let relation_status = RelationshipStatus::bi(reply_thread_id, thread_id);
@@ -1967,7 +2077,6 @@ mod test {
     use rand::{RngCore, SeedableRng, rngs::StdRng};
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    use crate::store::relationship_digest_algorithm;
     use crate::test_utils::*;
     use crate::{
         Error, Payload, PendingParallelRelationship, ReceivedRelationshipDelivery,
@@ -1977,6 +2086,13 @@ mod test {
 
     fn assert_url_matches(url: &url::Url, expected_receiver: &dyn VerifiedVid) {
         assert_eq!(url.as_str(), expected_receiver.endpoint().as_str());
+    }
+
+    fn relationship_digest_algorithm(
+        receiver: &dyn VerifiedVid,
+    ) -> crate::crypto::RelationshipDigestAlgorithm {
+        super::digest_algorithm_for_selection(super::selected_outbound_crypto(receiver, None))
+            .unwrap()
     }
 
     fn establish_existing_relationship(
@@ -2590,20 +2706,20 @@ mod test {
             .add_verified_vid(alice_parallel.clone(), None)
             .unwrap();
 
+        let forged_receiver = c_store
+            .get_verified_vid(alice_parallel.identifier())
+            .unwrap();
         let mut reply_thread_id = [0_u8; 32];
         let signed_data = crate::crypto::build_parallel_accept_signed_data(
             &thread_id,
             Some(charlie.identifier().as_bytes()),
-            relationship_digest_algorithm(),
+            relationship_digest_algorithm(&*forged_receiver),
             &mut reply_thread_id,
             charlie_parallel.identifier().as_bytes(),
         )
         .unwrap();
         let sig_new_vid = crate::crypto::sign_detached(&charlie_parallel, &signed_data).unwrap();
         let forged_sender = c_store.get_private_vid(charlie.identifier()).unwrap();
-        let forged_receiver = c_store
-            .get_verified_vid(alice_parallel.identifier())
-            .unwrap();
         let mut forged_accept = crate::crypto::seal_and_hash(
             &*forged_sender,
             &*forged_receiver,
@@ -2722,7 +2838,7 @@ mod test {
         let mut thread_id = [0_u8; 32];
         let signed_data = crate::crypto::build_parallel_request_signed_data(
             Some(alice.identifier().as_bytes()),
-            relationship_digest_algorithm(),
+            relationship_digest_algorithm(&bob),
             nonce_bytes,
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),
@@ -2783,7 +2899,7 @@ mod test {
         let mut thread_id = [0_u8; 32];
         let signed_data = crate::crypto::build_parallel_request_signed_data(
             Some(alice.identifier().as_bytes()),
-            relationship_digest_algorithm(),
+            relationship_digest_algorithm(&bob),
             nonce_bytes,
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -96,10 +96,11 @@ fn nested_digest_field<'a>(
 }
 
 fn selected_outbound_crypto(
+    sender: &dyn VerifiedVid,
     receiver: &dyn VerifiedVid,
     selection: Option<OutboundCryptoSelection>,
 ) -> OutboundCryptoSelection {
-    selection.unwrap_or_else(|| crate::crypto::default_outbound_crypto_selection(receiver))
+    selection.unwrap_or_else(|| crate::crypto::default_outbound_crypto_selection(sender, receiver))
 }
 
 fn digest_algorithm_for_selection(
@@ -126,7 +127,7 @@ fn seal_envelope(
         payload,
         digest,
         request_nonce_override,
-        selected_outbound_crypto(receiver, selection),
+        selected_outbound_crypto(sender, receiver, selection),
     )?)
 }
 
@@ -1503,7 +1504,7 @@ impl SecureStore {
             }
         }
 
-        let selection = selected_outbound_crypto(&*receiver, None);
+        let selection = selected_outbound_crypto(&*sender, &*receiver, None);
         let digest_algorithm = digest_algorithm_for_selection(selection)?;
         let signature_material = self.build_parallel_signature_material(
             &*sender_new_vid,
@@ -1586,7 +1587,7 @@ impl SecureStore {
         let pending_incoming_request =
             self.find_pending_incoming_parallel_request(receiver_new_vid.identifier(), thread_id)?;
         let outer_sender = self.get_private_vid(&pending_incoming_request.local_outer_vid)?;
-        let selection = selected_outbound_crypto(&*receiver_new_vid, None);
+        let selection = selected_outbound_crypto(&*outer_sender, &*receiver_new_vid, None);
         let digest_algorithm = digest_algorithm_for_selection(selection)?;
         let signature_material = self.build_parallel_signature_material(
             &*sender_new_vid,
@@ -1665,7 +1666,7 @@ impl SecureStore {
         let receiver = self.get_verified_vid(receiver)?;
 
         let nested_vid = self.make_propositioning_vid(sender.identifier())?;
-        let selection = selected_outbound_crypto(&*receiver, None);
+        let selection = selected_outbound_crypto(&*sender, &*receiver, None);
         let digest_algorithm = digest_algorithm_for_selection(selection)?;
         let (inner_message, thread_id) =
             self.make_signed_nested_request_message(&nested_vid, digest_algorithm)?;
@@ -1702,8 +1703,9 @@ impl SecureStore {
                 "missing parent for {nested_receiver}"
             )))?;
 
+        let parent_sender_vid = self.get_private_vid(parent_sender)?;
         let parent_receiver_vid = self.get_verified_vid(parent_receiver)?;
-        let selection = selected_outbound_crypto(&*parent_receiver_vid, None);
+        let selection = selected_outbound_crypto(&*parent_sender_vid, &*parent_receiver_vid, None);
         let digest_algorithm = digest_algorithm_for_selection(selection)?;
         let (inner_message, reply_thread_id) = self.make_signed_nested_accept_message(
             &nested_vid,
@@ -2089,10 +2091,13 @@ mod test {
     }
 
     fn relationship_digest_algorithm(
+        sender: &dyn VerifiedVid,
         receiver: &dyn VerifiedVid,
     ) -> crate::crypto::RelationshipDigestAlgorithm {
-        super::digest_algorithm_for_selection(super::selected_outbound_crypto(receiver, None))
-            .unwrap()
+        super::digest_algorithm_for_selection(super::selected_outbound_crypto(
+            sender, receiver, None,
+        ))
+        .unwrap()
     }
 
     fn establish_existing_relationship(
@@ -2713,7 +2718,7 @@ mod test {
         let signed_data = crate::crypto::build_parallel_accept_signed_data(
             &thread_id,
             Some(charlie.identifier().as_bytes()),
-            relationship_digest_algorithm(&*forged_receiver),
+            relationship_digest_algorithm(&charlie, &*forged_receiver),
             &mut reply_thread_id,
             charlie_parallel.identifier().as_bytes(),
         )
@@ -2838,7 +2843,7 @@ mod test {
         let mut thread_id = [0_u8; 32];
         let signed_data = crate::crypto::build_parallel_request_signed_data(
             Some(alice.identifier().as_bytes()),
-            relationship_digest_algorithm(&bob),
+            relationship_digest_algorithm(&alice, &bob),
             nonce_bytes,
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),
@@ -2899,7 +2904,7 @@ mod test {
         let mut thread_id = [0_u8; 32];
         let signed_data = crate::crypto::build_parallel_request_signed_data(
             Some(alice.identifier().as_bytes()),
-            relationship_digest_algorithm(&bob),
+            relationship_digest_algorithm(&alice, &bob),
             nonce_bytes,
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),

--- a/tsp_sdk/src/transport/http.rs
+++ b/tsp_sdk/src/transport/http.rs
@@ -15,7 +15,6 @@ use super::TransportError;
 #[cfg(feature = "use_local_certificate")]
 use {
     rustls_pki_types::{CertificateDer, pem::PemObject},
-    std::sync::Arc,
     tokio_tungstenite::Connector,
     tracing::warn,
 };

--- a/tsp_sdk/src/vid/did/peer.rs
+++ b/tsp_sdk/src/vid/did/peer.rs
@@ -21,7 +21,6 @@ pub fn encode_did_peer(vid: &Vid) -> String {
             // key bytes length
             v.push(0x20);
         }
-        #[cfg(feature = "pq")]
         VidSignatureKeyType::MlDsa65 => {
             // private use area (0x300001) => encoded as unsigned varint, see: https://github.com/multiformats/unsigned-varint
             v.extend_from_slice(&0x8180c001u32.to_be_bytes());
@@ -46,7 +45,6 @@ pub fn encode_did_peer(vid: &Vid) -> String {
             // key bytes length
             v.push(0x20);
         }
-        #[cfg(feature = "pq")]
         VidEncryptionKeyType::X25519Kyber768Draft00 => {
             #[cfg(feature = "async")]
             trace!("serializing X25519Kyber768Draft00 encryption key");
@@ -114,7 +112,6 @@ pub fn verify_did_peer(parts: &[&str]) -> Result<Vid, VidError> {
                         public_enckey = Some(rest[..0x20].to_vec());
                         enc_key_type = Some(VidEncryptionKeyType::X25519)
                     }
-                    #[cfg(feature = "pq")]
                     // multicodec reserved range (0x300000), followed by length (1216)
                     [
                         0b10000000,
@@ -154,7 +151,6 @@ pub fn verify_did_peer(parts: &[&str]) -> Result<Vid, VidError> {
                         public_sigkey = Some(rest[..0x20].to_vec());
                         sig_key_type = Some(VidSignatureKeyType::Ed25519)
                     }
-                    #[cfg(feature = "pq")]
                     // multicodec reserved range (0x300001), followed by length (1952) (https://go.dev/play/p/KskwkAiBV7D)
                     [
                         0b10000001,

--- a/tsp_sdk/src/vid/did/web.rs
+++ b/tsp_sdk/src/vid/did/web.rs
@@ -81,7 +81,6 @@ impl From<VidEncryptionKeyType> for KeyType {
     fn from(value: VidEncryptionKeyType) -> Self {
         match value {
             VidEncryptionKeyType::X25519 => KeyType::OKP,
-            #[cfg(feature = "pq")]
             VidEncryptionKeyType::X25519Kyber768Draft00 => KeyType::X25519Kyber768Draft00,
         }
     }
@@ -91,7 +90,6 @@ impl From<VidSignatureKeyType> for KeyType {
     fn from(value: VidSignatureKeyType) -> Self {
         match value {
             VidSignatureKeyType::Ed25519 => KeyType::OKP,
-            #[cfg(feature = "pq")]
             VidSignatureKeyType::MlDsa65 => KeyType::APK,
         }
     }
@@ -110,7 +108,6 @@ impl From<VidEncryptionKeyType> for Curve {
     fn from(value: VidEncryptionKeyType) -> Self {
         match value {
             VidEncryptionKeyType::X25519 => Curve::X25519,
-            #[cfg(feature = "pq")]
             VidEncryptionKeyType::X25519Kyber768Draft00 => Curve::X25519,
         }
     }
@@ -120,7 +117,6 @@ impl From<VidSignatureKeyType> for Option<Curve> {
     fn from(value: VidSignatureKeyType) -> Self {
         match value {
             VidSignatureKeyType::Ed25519 => Some(Curve::Ed25519),
-            #[cfg(feature = "pq")]
             VidSignatureKeyType::MlDsa65 => None,
         }
     }
@@ -130,7 +126,6 @@ impl From<VidSignatureKeyType> for Option<Algorithm> {
     fn from(value: VidSignatureKeyType) -> Self {
         match value {
             VidSignatureKeyType::Ed25519 => None,
-            #[cfg(feature = "pq")]
             VidSignatureKeyType::MlDsa65 => Some(Algorithm::MlDsa65),
         }
     }
@@ -324,7 +319,6 @@ pub fn resolve_document(did_document: DidDocument, target_id: &str) -> Result<Vi
 
     let enc_key_type = match (enc_key_type, enc_curve, enc_alg) {
         (KeyType::OKP, Some(Curve::X25519), None) => VidEncryptionKeyType::X25519,
-        #[cfg(feature = "pq")]
         (KeyType::X25519Kyber768Draft00, Some(Curve::X25519), None) => {
             VidEncryptionKeyType::X25519Kyber768Draft00
         }
@@ -333,7 +327,6 @@ pub fn resolve_document(did_document: DidDocument, target_id: &str) -> Result<Vi
 
     let sig_key_type = match (sig_key_type, sig_curve, sig_alg) {
         (KeyType::OKP, Some(Curve::Ed25519), None) => VidSignatureKeyType::Ed25519,
-        #[cfg(feature = "pq")]
         (KeyType::APK, None, Some(Algorithm::MlDsa65)) => VidSignatureKeyType::MlDsa65,
         _ => return Err(VidError::ResolveVid("Unsupported key type or curve")),
     };

--- a/tsp_sdk/src/vid/mod.rs
+++ b/tsp_sdk/src/vid/mod.rs
@@ -16,7 +16,6 @@ pub mod did;
 
 pub mod error;
 
-#[cfg(feature = "resolve")]
 pub mod resolve;
 
 #[cfg(feature = "resolve")]
@@ -66,10 +65,10 @@ pub enum ResolutionContext {
 pub struct Vid {
     id: String,
     transport: Url,
-    #[serde(default)]
+    #[cfg_attr(feature = "serialize", serde(default))]
     sig_key_type: VidSignatureKeyType,
     public_sigkey: PublicVerificationKeyData,
-    #[serde(default)]
+    #[cfg_attr(feature = "serialize", serde(default))]
     enc_key_type: VidEncryptionKeyType,
     public_enckey: PublicKeyData,
 }
@@ -169,22 +168,28 @@ impl AsRef<[u8]> for Vid {
 
 impl OwnedVid {
     pub fn bind(id: impl Into<String>, transport: url::Url) -> Self {
-        let (sigkey, public_sigkey) = crate::crypto::gen_sign_keypair();
-        let (enckey, public_enckey) = crate::crypto::gen_encrypt_keypair();
+        let sig_key_type = crate::crypto::default_signature_key_type();
+        let enc_key_type = crate::crypto::default_encryption_key_type();
+
+        Self::bind_with_key_types(id, transport, sig_key_type, enc_key_type)
+    }
+
+    pub fn bind_with_key_types(
+        id: impl Into<String>,
+        transport: url::Url,
+        sig_key_type: VidSignatureKeyType,
+        enc_key_type: VidEncryptionKeyType,
+    ) -> Self {
+        let (sigkey, public_sigkey) = crate::crypto::gen_sign_keypair_for(sig_key_type);
+        let (enckey, public_enckey) = crate::crypto::gen_encrypt_keypair_for(enc_key_type);
 
         Self {
             vid: Vid {
                 id: id.into(),
                 transport,
-                #[cfg(not(feature = "pq"))]
-                sig_key_type: VidSignatureKeyType::Ed25519,
-                #[cfg(feature = "pq")]
-                sig_key_type: VidSignatureKeyType::MlDsa65,
+                sig_key_type,
                 public_sigkey,
-                #[cfg(not(feature = "pq"))]
-                enc_key_type: VidEncryptionKeyType::X25519,
-                #[cfg(feature = "pq")]
-                enc_key_type: VidEncryptionKeyType::X25519Kyber768Draft00,
+                enc_key_type,
                 public_enckey,
             },
             sigkey,
@@ -193,20 +198,25 @@ impl OwnedVid {
     }
 
     pub fn new_did_peer(transport: Url) -> OwnedVid {
-        let (sigkey, public_sigkey) = crate::crypto::gen_sign_keypair();
-        let (enckey, public_enckey) = crate::crypto::gen_encrypt_keypair();
+        let sig_key_type = crate::crypto::default_signature_key_type();
+        let enc_key_type = crate::crypto::default_encryption_key_type();
+
+        Self::new_did_peer_with_key_types(transport, sig_key_type, enc_key_type)
+    }
+
+    pub fn new_did_peer_with_key_types(
+        transport: Url,
+        sig_key_type: VidSignatureKeyType,
+        enc_key_type: VidEncryptionKeyType,
+    ) -> OwnedVid {
+        let (sigkey, public_sigkey) = crate::crypto::gen_sign_keypair_for(sig_key_type);
+        let (enckey, public_enckey) = crate::crypto::gen_encrypt_keypair_for(enc_key_type);
 
         let mut vid = Vid {
             id: Default::default(),
             transport,
-            #[cfg(not(feature = "pq"))]
-            sig_key_type: VidSignatureKeyType::Ed25519,
-            #[cfg(feature = "pq")]
-            sig_key_type: VidSignatureKeyType::MlDsa65,
-            #[cfg(not(feature = "pq"))]
-            enc_key_type: VidEncryptionKeyType::X25519,
-            #[cfg(feature = "pq")]
-            enc_key_type: VidEncryptionKeyType::X25519Kyber768Draft00,
+            sig_key_type,
+            enc_key_type,
             public_sigkey,
             public_enckey,
         };

--- a/tsp_sdk/src/vid/resolve.rs
+++ b/tsp_sdk/src/vid/resolve.rs
@@ -1,7 +1,8 @@
-use super::did::{scid, webvh};
+#[cfg(feature = "resolve")]
+use super::did::{scid, web, webvh};
 use super::{
     VerifyVidOptions,
-    did::{self, peer, web},
+    did::{self, peer},
     error::VidError,
 };
 use crate::Vid;
@@ -47,6 +48,7 @@ pub fn verify_vid_offline_with_options(
 
     match parts.get(0..2) {
         Some([did::SCHEME, peer::SCHEME]) => peer::verify_did_peer(&parts),
+        #[cfg(feature = "resolve")]
         Some([did::SCHEME, scid::SCHEME]) => scid::resolve_offline(id, options),
         _ => Err(VidError::InvalidVid(id.to_string())),
     }


### PR DESCRIPTION
## Summary

Enable runtime selection of outbound confidential crypto while keeping existing default send APIs compatible.

This keeps feature flags as default-selection inputs only. The SDK now compiles the first-class outbound backends together, and confidential send dispatch is driven by the selected `CryptoType`.

## Changes

- Compile NACL, X25519 HPKE, and PQ HPKE send/open paths together.
- Make PQ crypto/key/signature variants visible without `pq` feature gating.
- Add runtime outbound crypto selection through `CryptoType`.
- Keep existing `seal()` / store send APIs on feature-preserving defaults.
- Add explicit override APIs for SDK/store/async store and CLI `send --crypto`.
- Make relationship digest selection follow the selected outbound crypto.
- Use PQ by default when the receiver has a PQ key, even without the `pq` feature.
- Keep signing based on the sender VID’s current signature key.
- Expose PQ message type variants unconditionally in Python/JS bindings.

## Review Notes

The commits are organized for review:

1. `feat(crypto): select outbound crypto at runtime`
   Core SDK behavior: backend normalization, selection dispatch, relationship digest, store/async store paths, and tests.

2. `feat(cli): add outbound crypto override`
   CLI-facing explicit selection.

3. `fix(bindings): expose PQ crypto variants unconditionally`
   Python/JS/demo type visibility after backend normalization.

4. `fix(clippy): clean all-target lint warnings`
   Mechanical lint cleanup only.

## Non-Goals

- No DID capability negotiation.
- No public `VerifiedVid` trait redesign.
- No persistence schema changes.
- No authentication selection.
- No plugin registry or backend trait abstraction.