### PR TITLE
test(crypto): add error path tests for MissingCiphertext and Verify

### DIFF
--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -757,7 +757,7 @@ mod tests {
     };
     use url::Url;
 
-    use super::{CryptoError, open, seal, seal_with_crypto_type};
+    use super::{CryptoError, open, seal, seal_with_crypto_type, sign};
 
     #[test]
     fn seal_open_message() {
@@ -991,5 +991,38 @@ mod tests {
         let result = open(&wrong_alice, &bob, &mut message);
 
         assert!(matches!(result, Err(CryptoError::CryptographicNacl(_))))
+    }
+
+    #[test]
+    fn open_missing_ciphertext() {
+        let alice = OwnedVid::bind(
+            "did:test:alice",
+            Url::parse("tcp://127.0.0.1:13371").unwrap(),
+        );
+        let bob = OwnedVid::bind("did:test:bob", Url::parse("tcp://127.0.0.1:13372").unwrap());
+
+        let mut message = sign(&alice, None, b"hello").unwrap();
+
+        let result = open(&bob, &alice, &mut message);
+
+        assert!(matches!(result, Err(CryptoError::MissingCiphertext)))
+    }
+
+    #[test]
+    fn open_tampered_signature() {
+        let alice = OwnedVid::bind(
+            "did:test:alice",
+            Url::parse("tcp://127.0.0.1:13371").unwrap(),
+        );
+        let bob = OwnedVid::bind("did:test:bob", Url::parse("tcp://127.0.0.1:13372").unwrap());
+
+        let mut message = seal(&bob, &alice, None, Payload::Content(b"secret")).unwrap();
+
+        let last = message.len() - 1;
+        message[last] ^= 0xFF;
+
+        let result = open(&alice, &bob, &mut message);
+
+        assert!(matches!(result, Err(CryptoError::Verify(_, _))))
     }
 }


### PR DESCRIPTION
## Summary
- Adds open_missing_ciphertext: calls crypto::sign to produce a non-confidential (signed-only) message, then open`s it, expecting CryptoError::MissingCiphertext.
- Adds open_tampered_signature: seals a message, flips the last byte (part of the signature), then open`s it, expecting CryptoError::Verify.

Closes #254 .

## Test plan
- [x] cargo test -p tsp_sdk -- open_missing_ciphertext open_tampered_signature
- [x] cargo test -p tsp_sdk --features fuzzing -- crypto:: (all 10 crypto tests pass)