### PR TITLE
rev3: bump hpke to 0.14 and RustCrypto digests to 0.11 final

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ ed25519-dalek = { version = "2.2", default-features = false, features = [
   "zeroize",
   "rand_core",
 ] }
-hpke = { version = "0.12.0", features = ["std"] }
+hpke = { version = "0.14.0" }
 hpke_pq = { version = "0.11.1", features = ["alloc", "std", "xyber768d00"] }
 ml-dsa = { version = "0.1.0-rc.3", features = ["rand_core"] }
 rand = { version = "0.8" }
 rand_core = "0.6.4"
-sha2 = "0.11.0-pre.5"
-blake2 = "0.11.0-pre.5"
+sha2 = "0.11.0"
+blake2 = "0.11.0"
 typenum = "1.18.0"
 crypto_box = { version = "0.9.1", features = ["std", "chacha20"] }
 # async

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -3,8 +3,8 @@ use crate::{
     definitions::{NonConfidentialData, Payload, PrivateVid, TSPMessage, VerifiedVid},
 };
 use hpke::{
-    Deserializable, OpModeR, OpModeS, Serializable, single_shot_open_in_place_detached,
-    single_shot_seal_in_place_detached,
+    Deserializable, OpModeR, OpModeS, Serializable, inout::InOutBuf,
+    single_shot_open_inout_detached, single_shot_seal_inout_detached,
 };
 use hpke_pq::{
     Deserializable as PqDeserializable, OpModeR as PqOpModeR, OpModeS as PqOpModeS,
@@ -156,15 +156,13 @@ pub(crate) fn seal_x25519(
         *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
     }
 
-    let (encapped_key, tag) =
-        single_shot_seal_in_place_detached::<X25519Aead, X25519Kdf, X25519Kem, StdRng>(
-            &mode,
-            &message_receiver,
-            &data,
-            &mut cesr_message,
-            &[],
-            &mut csprng,
-        )?;
+    let (encapped_key, tag) = single_shot_seal_inout_detached::<X25519Aead, X25519Kdf, X25519Kem>(
+        &mode,
+        &message_receiver,
+        &data,
+        InOutBuf::from(cesr_message.as_mut_slice()),
+        &[],
+    )?;
 
     cesr_message.extend(tag.to_bytes());
     cesr_message.extend(encapped_key.to_bytes());
@@ -270,12 +268,12 @@ pub(crate) fn open_x25519<'a>(
         OpModeR::Auth(sender_encryption_key)
     };
 
-    single_shot_open_in_place_detached::<X25519Aead, X25519Kdf, X25519Kem>(
+    single_shot_open_inout_detached::<X25519Aead, X25519Kdf, X25519Kem>(
         &mode,
         &receiver_decryption_key,
         &encapped_key,
         raw_header,
-        ciphertext,
+        InOutBuf::from(&mut *ciphertext),
         &[],
         &tag,
     )?;


### PR DESCRIPTION
First PR of the Rev 3 conformance series, targeting the `rev3` integration branch (created at today's `main`).

## What

- `hpke` 0.12 → **0.14**: the `single_shot_*_in_place_detached` functions became `single_shot_*_inout_detached` taking an `InOutBuf`; the seal call now draws randomness from `getrandom` internally. Only the two X25519 seal/open call sites in `tsp_sdk/src/crypto/tsp_hpke.rs` are touched.
- `sha2`/`blake2` `0.11.0-pre.5` → **0.11.0** (hpke 0.14 pulls the final RustCrypto 0.11 digest stack; the pre-releases fail to build next to it).

No wire-format or behavior change.

## Why

hpke 0.14 ships the draft-ietf-hpke-pq KEMs — in particular `kem::XWing` with KEM id **0x647a**, the PQ/T hybrid the Rev 3 spec mandates (spec name X25519MLKEM768; draft -05 name MLKEM768-X25519). A later PR in this series will switch the PQ path to it and drop the `hpke_pq`/`safe_pqc_kyber` fork, so the whole series builds on the final dependency set from the start.

## Verification

- `cargo fmt --all --check` clean
- `cargo test --workspace --exclude tsp_python --features ""` and `--features "nacl"`: all green (122 sdk tests + examples)
- `cargo check -p tsp_sdk --no-default-features --features resolve --target wasm32-unknown-unknown` with the wasm_js getrandom backend: clean
- `cargo clippy --workspace --tests`: two pre-existing `collapsible_else_if` warnings in `cesr/packet.rs` (present on `main`, newer local clippy); untouched here
- `cargo deny check`: advisory failures are pre-existing on `main` (aws-lc-rs, bytes, h2, core2 — none appear in this change's dependency delta)