### PR TITLE
Fix broken CI: bench-track workflow YAML, mdBook config, rev3 triggers

### DIFF
--- a/.github/workflows/bench-guardrail-pr-track.yml
+++ b/.github/workflows/bench-guardrail-pr-track.yml
@@ -49,10 +49,10 @@ jobs:
             echo "## Bencher"
             echo
             echo "- Perf URL: ${BENCHER_PERF_URL}"
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Download benchmark artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: guardrail-pr-benchmarks

--- a/.github/workflows/bench-guardrail-pr.yml
+++ b/.github/workflows/bench-guardrail-pr.yml
@@ -2,7 +2,7 @@ name: Guardrail Bench (PR Run)
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "rev3"]
     types: [opened, reopened, synchronize]
 
 permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@ name: Check
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "rev3"]
 
 jobs:
   clippy:

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Marlon Baeten"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Rust TSP Guides"
 


### PR DESCRIPTION
Three CI repairs, no code changes:

- **bench-guardrail-pr-track.yml has been invalid YAML** since the SHA-pinning commit (15e5ced): the pin line was pasted into the middle of the 'Publish Bencher URL' `run` block, truncating it. Every run since has failed in 0s with 'workflow file issue'. This restores the block's closing lines and applies the intended SHA pin to the download step's `uses:` line.
- **docs/book.toml**: drop `multilingual = false` — the field was removed in current mdBook and aborts the Pages deploy (failing since May). Verified locally with `mdbook-mermaid install && mdbook build` on mdBook 0.5.4.
- **check.yml / bench-guardrail-pr.yml**: also trigger on PRs targeting the `rev3` integration branch, so the Rev 3 PR series (starting with #325) gets the same checks as PRs to main. Currently such PRs get no CI beyond DCO.