### PR TITLE
Bump pyo3 to 0.29 to clear RUSTSEC-2026-0176/-0177

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ reqwest = { version = "0.12.12", default-features = false, features = [
 didwebvh-rs = "=0.1.10"
 
 # Python bindings
-pyo3 = { version = "0.26", features = ["serde"] }
-pythonize = "0.26"
+pyo3 = { version = "0.29", features = ["serde"] }
+pythonize = "0.29"
 
 # serialize
 serde = { version = "1.0.220", features = ["derive"] }

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -382,7 +382,7 @@ impl Store {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ReceivedTspMessageVariant {
     GenericMessage,
@@ -406,14 +406,14 @@ impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RelationshipForm {
     Direct = 0,
     Parallel = 1,
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RelationshipDelivery {
     Direct = 0,
@@ -421,7 +421,7 @@ pub enum RelationshipDelivery {
     Routed = 2,
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CryptoType {
     Plaintext = 0,
@@ -432,7 +432,7 @@ pub enum CryptoType {
     X25519Kyber768Draft00 = 5,
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SignatureType {
     NoSignature = 0,
@@ -630,7 +630,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 struct OwnedVid(tsp_sdk::OwnedVid);
 


### PR DESCRIPTION
pyo3 0.26 is flagged by cargo-deny with two advisories, which fails the CI cargo-deny job on any fresh dependency resolution:

- RUSTSEC-2026-0176: out-of-bounds read in `PyList`/`PyTuple` iterators' `nth`/`nth_back`
- RUSTSEC-2026-0177: missing `Sync` bound on `PyCFunction::new_closure` closures

Both are fixed in pyo3 ≥ 0.29; pythonize moves in lockstep. The only code change is opting the Clone-implementing pyclass types into `from_py_object` explicitly, preserving the extraction behavior pyo3 0.29 deprecates as an automatic default (those deprecation warnings would otherwise fail the clippy job).

Verified: `cargo check`/`clippy -p tsp_python` clean; `cargo deny check` reports **advisories ok, bans ok, licenses ok, sources ok** on a fresh resolution.