### PR TITLE
Fix clippy lints flagged by current stable (1.98)

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -1573,7 +1573,7 @@ fn show_local(vids: &[ExportVid], aliases: &Aliases) -> Result<(), Error> {
             .find_map(|(a, id)| if id == &vid.id { Some(a.clone()) } else { None })
             .unwrap_or("None".to_string());
 
-        println!("{}", &vid.id);
+        println!("{}", vid.id);
         println!("\t Alias: {alias}");
         println!("\t Transport: {transport}");
         if vid.id.starts_with("did:web") {
@@ -1699,7 +1699,7 @@ fn show_relations(vids: &[ExportVid], vid: Option<String>, aliases: &Aliases) ->
             .find_map(|(a, id)| if id == &vid.id { Some(a.clone()) } else { None })
             .unwrap_or("None".to_string());
 
-        println!("{}", &vid.id);
+        println!("{}", vid.id);
         println!("\t Relation Status: {}", vid.relation_status);
         println!("\t Alias: {alias}");
         if vid.id.starts_with("did:web") {

--- a/examples/src/did-server.rs
+++ b/examples/src/did-server.rs
@@ -186,7 +186,7 @@ async fn create_identity(
     let (did_doc, _, private_vid) = tsp_sdk::vid::create_did_web(
         &form.name,
         &state.domain,
-        &format!("{}/{}", &state.transport, form.name),
+        &format!("{}/{}", state.transport, form.name),
     );
 
     let key = private_vid.identifier();

--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -319,7 +319,7 @@ async fn main() {
                 tokio::time::sleep(Duration::from_secs(60)).await;
                 let mut buffers = state.buffers.write().await;
                 let mut expired_count = 0;
-                for (_, buf) in buffers.iter_mut() {
+                for buf in buffers.values_mut() {
                     let before = buf.messages.len();
                     buf.expire(state.buffer_ttl);
                     expired_count += before - buf.messages.len();

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -662,7 +662,7 @@ fn render_vid_error_page(did: &str, error: &str) -> String {
 
 /// Create a new identity (private VID)
 async fn create_identity(State(state): State<Arc<AppState>>) -> Response {
-    Redirect::temporary(format!("{}/create-identity", &state.did_server).as_str()).into_response()
+    Redirect::temporary(format!("{}/create-identity", state.did_server).as_str()).into_response()
 }
 
 #[derive(Deserialize, Debug)]
@@ -743,6 +743,9 @@ struct Metadata {
     timestamp: u64,
 }
 
+// axum handlers conventionally use Result<_, Response>; the Response error type is
+// larger than clippy's result_large_err threshold but is what axum expects here
+#[allow(clippy::result_large_err)]
 async fn sign_timestamp(
     State(state): State<Arc<AppState>>,
     body: Bytes,

--- a/tsp_sdk/src/cesr/decode.rs
+++ b/tsp_sdk/src/cesr/decode.rs
@@ -62,18 +62,12 @@ pub fn decode_variable_data_index(
     let input = extract_triplet(stream.get(0..=2)?.try_into().unwrap());
     let selector = input >> 18;
 
-    let size;
-    let found_id;
-
-    match selector {
-        D4 | D5 | D6 => {
-            found_id = (input >> 12) & mask(6);
-            size = input & mask(12);
-        }
-        D7 | D8 | D9 => {
-            found_id = input & mask(18);
-            size = extract_triplet(stream.get(3..6)?.try_into().unwrap());
-        }
+    let (found_id, size) = match selector {
+        D4 | D5 | D6 => ((input >> 12) & mask(6), input & mask(12)),
+        D7 | D8 | D9 => (
+            input & mask(18),
+            extract_triplet(stream.get(3..6)?.try_into().unwrap()),
+        ),
         _ => return None,
     };
 
@@ -138,18 +132,18 @@ pub fn decode_indexed_data<'a, const N: usize>(
     let hdr_bytes = total_size - N;
 
     let input = extract_triplet(stream.get(0..=2)?.try_into().unwrap());
-    let word;
+
     let index;
 
-    match hdr_bytes {
+    let word = match hdr_bytes {
         1 => panic!("an indexed type can only have 0 or 2 lead bytes"),
         2 => {
             index = (input >> 12) & mask(6);
-            word = (bits(identifier, 6) << 18) | (bits(index, 6) << 12);
+            (bits(identifier, 6) << 18) | (bits(index, 6) << 12)
         }
         3 => {
             index = input & mask(12);
-            word = (D0 << 18) | (bits(identifier, 6) << 12) | bits(index, 12);
+            (D0 << 18) | (bits(identifier, 6) << 12) | bits(index, 12)
         }
         _ => unreachable!("unsigned integer arithmetic is broken"),
     };

--- a/tsp_sdk/src/vid/did/web.rs
+++ b/tsp_sdk/src/vid/did/web.rs
@@ -302,13 +302,12 @@ pub fn resolve_document(did_document: DidDocument, target_id: &str) -> Result<Vi
         ));
     };
 
-    let transport = match did_document.service.into_iter().next().and_then(|service| {
-        if service.service_type == "TSPTransport" {
-            Some(service)
-        } else {
-            None
-        }
-    }) {
+    let transport = match did_document
+        .service
+        .into_iter()
+        .next()
+        .filter(|service| service.service_type == "TSPTransport")
+    {
         Some(service) => service.service_endpoint,
         None => {
             return Err(VidError::ResolveVid(
@@ -354,13 +353,13 @@ pub fn vid_to_did_document(vid: &impl VerifiedVid) -> serde_json::Value {
             {
                 "id": format!("{id}#verification-key"),
                 "type": "JsonWebKey2020",
-                "controller":  format!("{id}"),
+                "controller":  id.to_string(),
                 "publicKeyJwk": vid.signature_key_jwk()
             },
             {
                 "id": format!("{id}#encryption-key"),
                 "type": "JsonWebKey2020",
-                "controller": format!("{id}"),
+                "controller": id.to_string(),
                 "publicKeyJwk": vid.encryption_key_jwk()
             },
         ],


### PR DESCRIPTION
CI installs the latest stable toolchain; clippy 1.98 flags code that June's stable accepted, and with `--deny warnings` this fails the clippy job on **every** PR regardless of content (first seen on #326, which touches only workflow files).

Mechanical fixes (`cargo clippy --fix` + `cargo fmt`): unneeded late initialization in `cesr/decode.rs`, manual `Option::filter` and useless `format!` in `vid/did/web.rs`, redundant references and map-values iteration in the examples. One explicit `#[allow(clippy::result_large_err)]` on the axum `sign_timestamp` handler, whose `Result<_, Response>` shape is axum convention.

Verified: `cargo clippy --workspace --tests -- --deny warnings` clean on rustc 1.98, `cargo fmt --check` clean, tsp_sdk tests all pass.

Not addressed here (its own issue): `test_send_command_unverified_receiver_default` in `examples/tests/cli_tests.rs` talks to the public teaspoon.world testbed from the CI runner and fails intermittently — the cargo-test job needs a re-run or that test made hermetic.