### PR TITLE
Restore green CI: workflow repairs, pyo3 advisories, clippy 1.98

### DIFF
--- a/.github/workflows/bench-guardrail-pr-track.yml
+++ b/.github/workflows/bench-guardrail-pr-track.yml
@@ -49,10 +49,10 @@ jobs:
             echo "## Bencher"
             echo
             echo "- Perf URL: ${BENCHER_PERF_URL}"
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Download benchmark artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: guardrail-pr-benchmarks

--- a/.github/workflows/bench-guardrail-pr.yml
+++ b/.github/workflows/bench-guardrail-pr.yml
@@ -2,7 +2,7 @@ name: Guardrail Bench (PR Run)
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "rev3"]
     types: [opened, reopened, synchronize]
 
 permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@ name: Check
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "rev3"]
 
 jobs:
   clippy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ reqwest = { version = "0.12.12", default-features = false, features = [
 didwebvh-rs = "=0.1.10"
 
 # Python bindings
-pyo3 = { version = "0.26", features = ["serde"] }
-pythonize = "0.26"
+pyo3 = { version = "0.29", features = ["serde"] }
+pythonize = "0.29"
 
 # serialize
 serde = { version = "1.0.220", features = ["derive"] }

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Marlon Baeten"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Rust TSP Guides"
 

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -1573,7 +1573,7 @@ fn show_local(vids: &[ExportVid], aliases: &Aliases) -> Result<(), Error> {
             .find_map(|(a, id)| if id == &vid.id { Some(a.clone()) } else { None })
             .unwrap_or("None".to_string());
 
-        println!("{}", &vid.id);
+        println!("{}", vid.id);
         println!("\t Alias: {alias}");
         println!("\t Transport: {transport}");
         if vid.id.starts_with("did:web") {
@@ -1699,7 +1699,7 @@ fn show_relations(vids: &[ExportVid], vid: Option<String>, aliases: &Aliases) ->
             .find_map(|(a, id)| if id == &vid.id { Some(a.clone()) } else { None })
             .unwrap_or("None".to_string());
 
-        println!("{}", &vid.id);
+        println!("{}", vid.id);
         println!("\t Relation Status: {}", vid.relation_status);
         println!("\t Alias: {alias}");
         if vid.id.starts_with("did:web") {

--- a/examples/src/did-server.rs
+++ b/examples/src/did-server.rs
@@ -186,7 +186,7 @@ async fn create_identity(
     let (did_doc, _, private_vid) = tsp_sdk::vid::create_did_web(
         &form.name,
         &state.domain,
-        &format!("{}/{}", &state.transport, form.name),
+        &format!("{}/{}", state.transport, form.name),
     );
 
     let key = private_vid.identifier();

--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -319,7 +319,7 @@ async fn main() {
                 tokio::time::sleep(Duration::from_secs(60)).await;
                 let mut buffers = state.buffers.write().await;
                 let mut expired_count = 0;
-                for (_, buf) in buffers.iter_mut() {
+                for buf in buffers.values_mut() {
                     let before = buf.messages.len();
                     buf.expire(state.buffer_ttl);
                     expired_count += before - buf.messages.len();

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -662,7 +662,7 @@ fn render_vid_error_page(did: &str, error: &str) -> String {
 
 /// Create a new identity (private VID)
 async fn create_identity(State(state): State<Arc<AppState>>) -> Response {
-    Redirect::temporary(format!("{}/create-identity", &state.did_server).as_str()).into_response()
+    Redirect::temporary(format!("{}/create-identity", state.did_server).as_str()).into_response()
 }
 
 #[derive(Deserialize, Debug)]
@@ -743,6 +743,9 @@ struct Metadata {
     timestamp: u64,
 }
 
+// axum handlers conventionally use Result<_, Response>; the Response error type is
+// larger than clippy's result_large_err threshold but is what axum expects here
+#[allow(clippy::result_large_err)]
 async fn sign_timestamp(
     State(state): State<Arc<AppState>>,
     body: Bytes,

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -382,7 +382,7 @@ impl Store {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ReceivedTspMessageVariant {
     GenericMessage,
@@ -406,14 +406,14 @@ impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RelationshipForm {
     Direct = 0,
     Parallel = 1,
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RelationshipDelivery {
     Direct = 0,
@@ -421,7 +421,7 @@ pub enum RelationshipDelivery {
     Routed = 2,
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CryptoType {
     Plaintext = 0,
@@ -432,7 +432,7 @@ pub enum CryptoType {
     X25519Kyber768Draft00 = 5,
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SignatureType {
     NoSignature = 0,
@@ -630,7 +630,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 struct OwnedVid(tsp_sdk::OwnedVid);
 

--- a/tsp_sdk/src/cesr/decode.rs
+++ b/tsp_sdk/src/cesr/decode.rs
@@ -62,18 +62,12 @@ pub fn decode_variable_data_index(
     let input = extract_triplet(stream.get(0..=2)?.try_into().unwrap());
     let selector = input >> 18;
 
-    let size;
-    let found_id;
-
-    match selector {
-        D4 | D5 | D6 => {
-            found_id = (input >> 12) & mask(6);
-            size = input & mask(12);
-        }
-        D7 | D8 | D9 => {
-            found_id = input & mask(18);
-            size = extract_triplet(stream.get(3..6)?.try_into().unwrap());
-        }
+    let (found_id, size) = match selector {
+        D4 | D5 | D6 => ((input >> 12) & mask(6), input & mask(12)),
+        D7 | D8 | D9 => (
+            input & mask(18),
+            extract_triplet(stream.get(3..6)?.try_into().unwrap()),
+        ),
         _ => return None,
     };
 
@@ -138,18 +132,18 @@ pub fn decode_indexed_data<'a, const N: usize>(
     let hdr_bytes = total_size - N;
 
     let input = extract_triplet(stream.get(0..=2)?.try_into().unwrap());
-    let word;
+
     let index;
 
-    match hdr_bytes {
+    let word = match hdr_bytes {
         1 => panic!("an indexed type can only have 0 or 2 lead bytes"),
         2 => {
             index = (input >> 12) & mask(6);
-            word = (bits(identifier, 6) << 18) | (bits(index, 6) << 12);
+            (bits(identifier, 6) << 18) | (bits(index, 6) << 12)
         }
         3 => {
             index = input & mask(12);
-            word = (D0 << 18) | (bits(identifier, 6) << 12) | bits(index, 12);
+            (D0 << 18) | (bits(identifier, 6) << 12) | bits(index, 12)
         }
         _ => unreachable!("unsigned integer arithmetic is broken"),
     };

--- a/tsp_sdk/src/vid/did/web.rs
+++ b/tsp_sdk/src/vid/did/web.rs
@@ -302,13 +302,12 @@ pub fn resolve_document(did_document: DidDocument, target_id: &str) -> Result<Vi
         ));
     };
 
-    let transport = match did_document.service.into_iter().next().and_then(|service| {
-        if service.service_type == "TSPTransport" {
-            Some(service)
-        } else {
-            None
-        }
-    }) {
+    let transport = match did_document
+        .service
+        .into_iter()
+        .next()
+        .filter(|service| service.service_type == "TSPTransport")
+    {
         Some(service) => service.service_endpoint,
         None => {
             return Err(VidError::ResolveVid(
@@ -354,13 +353,13 @@ pub fn vid_to_did_document(vid: &impl VerifiedVid) -> serde_json::Value {
             {
                 "id": format!("{id}#verification-key"),
                 "type": "JsonWebKey2020",
-                "controller":  format!("{id}"),
+                "controller":  id.to_string(),
                 "publicKeyJwk": vid.signature_key_jwk()
             },
             {
                 "id": format!("{id}#encryption-key"),
                 "type": "JsonWebKey2020",
-                "controller": format!("{id}"),
+                "controller": id.to_string(),
                 "publicKeyJwk": vid.encryption_key_jwk()
             },
         ],


### PR DESCRIPTION
Main currently fails CI in three independent ways, so no single-topic PR can show green checks — each inherits the other two failures. This PR combines the three fixes (supersedes #326, #327, #330; same three commits, cherry-picked) so its own checks demonstrate the result:

**Commit 1 — CI workflow repairs**
- `bench-guardrail-pr-track.yml` has been invalid YAML since the SHA-pinning commit (15e5ced) — the pin line was pasted mid-`run`-block. Every run since has failed in 0s. Restores the block and applies the pin where intended.
- `docs/book.toml`: drop `multilingual = false`, removed in current mdBook; the Pages deploy has failed since May. Verified with a local `mdbook build`.
- `check.yml`/`bench-guardrail-pr.yml`: also trigger on PRs targeting `rev3`, so the Rev 3 series (#325) gets CI.

**Commit 2 — pyo3 0.26 → 0.29** (+pythonize): clears RUSTSEC-2026-0176 (OOB read in PyList/PyTuple iterators) and RUSTSEC-2026-0177 (missing Sync bound on `new_closure`), which fail the cargo-deny job. Only code change: explicit `from_py_object` opt-in on Clone pyclasses.

**Commit 3 — clippy 1.98**: CI floats the stable toolchain; current clippy flags code June's stable accepted, and `--deny warnings` makes that fatal on every PR. Mechanical `clippy --fix` + fmt, plus one `#[allow(clippy::result_large_err)]` on the axum `sign_timestamp` handler.

**Local verification of the combined branch:** `cargo fmt --check` clean; `cargo clippy --workspace --tests -- --deny warnings` clean on rustc 1.98; `cargo deny check` advisories ok; workspace tests (excl. tsp_python, which doesn't link on this machine) all pass.

Known residual flake, not addressed here: `test_send_command_unverified_receiver_default` (examples/tests/cli_tests.rs) talks to the public teaspoon.world testbed from the runner and fails intermittently; re-run if it trips.