### PR TITLE
Rev 3 crypto: cipher suites, self-referencing digests, KATs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
 dependencies = [
  "aead 0.5.2",
- "chacha20 0.9.1",
+ "blake2 0.10.6",
  "crypto_secretbox",
  "curve25519-dalek 4.1.3",
  "salsa20",
@@ -1152,7 +1152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
  "aead 0.5.2",
- "chacha20 0.9.1",
  "cipher 0.4.4",
  "generic-array",
  "poly1305 0.8.0",
@@ -2103,29 +2102,6 @@ dependencies = [
  "turboshake",
  "x-wing",
  "x25519-dalek 3.0.0",
- "zeroize",
-]
-
-[[package]]
-name = "hpke_pq"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b405447b60d50d27aaaba4fb6d7888d63868dcc4f3409bf6c4250360de07ba"
-dependencies = [
- "aead 0.5.2",
- "aes-gcm",
- "byteorder",
- "chacha20poly1305 0.10.1",
- "digest 0.10.7",
- "generic-array",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "p256",
- "rand_core 0.6.4",
- "safe_pqc_kyber",
- "sha2 0.10.9",
- "subtle",
- "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -3897,15 +3873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
-name = "safe_pqc_kyber"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "108c4ad7fe882cbb078ff40de415658e9d827f636e4fb17e7d5a97503a9aceaf"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5090,7 +5057,6 @@ dependencies = [
  "getrandom 0.4.3",
  "gungraun",
  "hpke",
- "hpke_pq",
  "ml-dsa",
  "once_cell",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,13 @@ ed25519-dalek = { version = "2.2", default-features = false, features = [
   "rand_core",
 ] }
 hpke = { version = "0.14.0" }
-hpke_pq = { version = "0.11.1", features = ["alloc", "std", "xyber768d00"] }
 ml-dsa = { version = "0.1.0-rc.3", features = ["rand_core"] }
 rand = { version = "0.8" }
 rand_core = "0.6.4"
 sha2 = "0.11.0"
 blake2 = "0.11.0"
 typenum = "1.18.0"
-crypto_box = { version = "0.9.1", features = ["std", "chacha20"] }
+crypto_box = { version = "0.9.1", features = ["std", "seal"] }
 # async
 async-stream = { version = "0.3" }
 futures = { version = "0.3" }

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -54,11 +54,8 @@ impl FromStr for DidType {
 fn parse_crypto_type(value: &str) -> Result<cesr::CryptoType, String> {
     let normalized = value.to_ascii_lowercase().replace('_', "-");
     match normalized.as_str() {
-        "hpke-auth" => Ok(cesr::CryptoType::HpkeAuth),
-        "hpke-essr" => Ok(cesr::CryptoType::HpkeEssr),
-        "nacl-auth" => Ok(cesr::CryptoType::NaclAuth),
-        "nacl-essr" => Ok(cesr::CryptoType::NaclEssr),
-        "pq" | "x25519-kyber768-draft00" => Ok(cesr::CryptoType::X25519Kyber768Draft00),
+        "hpke" | "hpke-base" => Ok(cesr::CryptoType::HpkeBase),
+        "sealed-box" | "nacl" => Ok(cesr::CryptoType::SealedBox),
         "plaintext" => Err("plaintext is not valid for confidential send".to_string()),
         _ => Err(format!("invalid crypto type: {value}")),
     }
@@ -1117,11 +1114,8 @@ async fn run() -> Result<(), Error> {
                             };
                             let crypto_type = match message_type.crypto_type {
                                 cesr::CryptoType::Plaintext => "Plain text",
-                                cesr::CryptoType::HpkeAuth => "HPKE Auth",
-                                cesr::CryptoType::HpkeEssr => "HPKE ESSR",
-                                cesr::CryptoType::NaclAuth => "NaCl Auth",
-                                cesr::CryptoType::NaclEssr => "NaCl ESSR",
-                                cesr::CryptoType::X25519Kyber768Draft00 => "X25519Kyber768Draft00",
+                                cesr::CryptoType::HpkeBase => "HPKE-Base",
+                                cesr::CryptoType::SealedBox => "Sealed Box",
                             };
                             let signature_type = match message_type.signature_type {
                                 cesr::SignatureType::NoSignature => "no signature",

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -167,8 +167,6 @@ enum Commands {
         sender_vid: String,
         #[arg(short, long, required = true)]
         receiver_vid: String,
-        #[arg(short, long)]
-        non_confidential_data: Option<String>,
         #[arg(
             long,
             help = "Ask for confirmation before interacting with unknown end-points"
@@ -1047,11 +1045,9 @@ async fn run() -> Result<(), Error> {
         Commands::Send {
             sender_vid,
             receiver_vid,
-            non_confidential_data,
             ask,
             crypto,
         } => {
-            let non_confidential_data = non_confidential_data.as_deref().map(|s| s.as_bytes());
             let receiver_vid = vid_wallet.try_resolve_alias(&receiver_vid)?;
 
             ensure_vid_verified(&vid_wallet, &receiver_vid, &args.wallet, ask).await?;
@@ -1064,18 +1060,10 @@ async fn run() -> Result<(), Error> {
 
             let send_result = if let Some(crypto_type) = crypto {
                 vid_wallet
-                    .send_with_crypto_type(
-                        &sender_vid,
-                        &receiver_vid,
-                        non_confidential_data,
-                        &message,
-                        crypto_type,
-                    )
+                    .send_with_crypto_type(&sender_vid, &receiver_vid, &message, crypto_type)
                     .await
             } else {
-                vid_wallet
-                    .send(&sender_vid, &receiver_vid, non_confidential_data, &message)
-                    .await
+                vid_wallet.send(&sender_vid, &receiver_vid, &message).await
             };
 
             match send_result {
@@ -1120,7 +1108,6 @@ async fn run() -> Result<(), Error> {
                         ReceivedTspMessage::GenericMessage {
                             sender,
                             receiver: _,
-                            nonconfidential_data: _,
                             message,
                             message_type,
                         } => {

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -12,7 +12,6 @@ use axum::{
 };
 use base64ct::{Base64UrlUnpadded, Encoding};
 use clap::Parser;
-use core::time;
 use futures::{sink::SinkExt, stream::StreamExt};
 use serde::Deserialize;
 use serde_json::json;
@@ -709,7 +708,7 @@ fn open_message(message: &[u8], payload: Option<&[u8]>) -> Option<serde_json::Va
         "prefix": format_part("Prefix", &parts.prefix, None),
         "sender": format_part("Sender", &parts.sender, None),
         "receiver": parts.receiver.map(|v| format_part("Receiver", &v, None)),
-        "nonconfidentialData": parts.nonconfidential_data.map(|v| format_part("Non-confidential data", &v, None)),
+        "nonconfidentialData": Option::<serde_json::Value>::None,
         "ciphertext": parts.ciphertext.map(|v| format_part("Ciphertext", &v, payload)),
         "signature": format_part("Signature", &parts.signature, None),
         "cryptoType": match parts.crypto_type {
@@ -732,15 +731,8 @@ fn open_message(message: &[u8], payload: Option<&[u8]>) -> Option<serde_json::Va
 #[derive(Deserialize, Debug)]
 struct SendMessageForm {
     message: String,
-    nonconfidential_data: Option<String>,
     sender: OwnedVid,
     receiver: Vid,
-}
-
-#[derive(Deserialize, Debug)]
-struct Metadata {
-    name: String,
-    timestamp: u64,
 }
 
 // axum handlers conventionally use Result<_, Response>; the Response error type is
@@ -755,10 +747,6 @@ async fn sign_timestamp(
     let header = cesr::probe(&mut header_bytes)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Error probing message").into_response())?;
 
-    let metadata = header
-        .get_nonconfidential_data()
-        .ok_or((StatusCode::BAD_REQUEST, "No nonconfidential data").into_response())?;
-
     let receiver = header
         .get_receiver()
         .ok_or((StatusCode::BAD_REQUEST, "No receiver set").into_response())?;
@@ -766,29 +754,13 @@ async fn sign_timestamp(
     let receiver = from_utf8(receiver)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Receiver vid is not valid utf8").into_response())?;
 
-    let metadata: Metadata = serde_json::from_slice(metadata)
-        .map_err(|_| (StatusCode::BAD_REQUEST, "Error parsing json").into_response())?;
-
-    tracing::info!(
-        "received timestamp sign request from {}: {}",
-        metadata.name,
-        metadata.timestamp
-    );
-
     let start = SystemTime::now();
     let since_the_epoch = start
         .duration_since(UNIX_EPOCH)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid timestamp").into_response())?
         .as_secs();
-    let delta = metadata.timestamp.max(since_the_epoch) - metadata.timestamp.min(since_the_epoch);
 
-    if delta > time::Duration::from_secs(60).as_secs() {
-        tracing::error!("timestamp delta to large: {delta} seconds");
-
-        return Err((StatusCode::BAD_REQUEST, "Invalid timestamp").into_response());
-    }
-
-    tracing::info!("timestamp delta ok: {delta} seconds");
+    tracing::info!("received timestamp sign request at {since_the_epoch}");
 
     let (verified_vid, metadata) = tsp_sdk::vid::verify_vid(receiver)
         .await
@@ -798,6 +770,14 @@ async fn sign_timestamp(
         .add_verified_vid(verified_vid, metadata)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Error adding verified vid").into_response())?;
 
+    // the attestation binds the received message to the time of signing;
+    // it is sealed to the message's receiver by the timestamp server
+    let attestation = serde_json::to_vec(&json!({
+        "timestamp": since_the_epoch,
+        "message": Base64UrlUnpadded::encode_string(&bytes),
+    }))
+    .expect("serializing attestation cannot fail");
+
     let (_url, response_bytes) = state
         .timestamp_server
         .seal_message(
@@ -806,8 +786,7 @@ async fn sign_timestamp(
                 state.domain.replace(":", "%3A")
             ),
             receiver,
-            Some(&bytes),
-            &[],
+            &attestation,
         )
         .map_err(|_| {
             (StatusCode::INTERNAL_SERVER_ERROR, "Error signing message").into_response()
@@ -862,13 +841,6 @@ async fn send_message(
     let result = tsp_sdk::crypto::seal(
         &form.sender,
         &form.receiver,
-        form.nonconfidential_data.as_deref().and_then(|d| {
-            if d.is_empty() {
-                None
-            } else {
-                Some(d.as_bytes())
-            }
-        }),
         Payload::Content(form.message.as_bytes()),
     );
 
@@ -951,7 +923,7 @@ async fn websocket(stream: WebSocket, state: Arc<AppState>) {
 
             // if the sender is verified, decrypt the message
             let result = if let Some(sender_vid) = incoming_senders_read.get(&sender_id) {
-                let Ok((_, payload, _, _)) =
+                let Ok((payload, _, _)) =
                     tsp_sdk::crypto::open(receiver_vid, sender_vid, &mut encrypted_message)
                 else {
                     continue;

--- a/examples/src/server.rs
+++ b/examples/src/server.rs
@@ -713,11 +713,8 @@ fn open_message(message: &[u8], payload: Option<&[u8]>) -> Option<serde_json::Va
         "signature": format_part("Signature", &parts.signature, None),
         "cryptoType": match parts.crypto_type {
             cesr::CryptoType::Plaintext => "Plain text",
-            cesr::CryptoType::HpkeAuth => "HPKE Auth",
-            cesr::CryptoType::HpkeEssr => "HPKE ESSR",
-            cesr::CryptoType::NaclAuth => "NaCl Auth",
-            cesr::CryptoType::NaclEssr => "NaCl ESSR",
-            cesr::CryptoType::X25519Kyber768Draft00 => "X25519 Kyber768 Draft 00",
+            cesr::CryptoType::HpkeBase => "HPKE-Base",
+            cesr::CryptoType::SealedBox => "Sealed Box",
         },
         "signatureType": match parts.signature_type {
             cesr::SignatureType::NoSignature => "No Signature",

--- a/fuzz/fuzz_targets/crypto_seal_open.rs
+++ b/fuzz/fuzz_targets/crypto_seal_open.rs
@@ -18,15 +18,10 @@ fuzz_target!(|data: cesr::fuzzing::FuzzInput| {
         data.receiver_sign_key,
         data.receiver_enc_key,
     );
-    let result = crypto::seal(
-        &sender,
-        &receiver,
-        data.nonconfidential_data.as_deref(),
-        Payload::Content(&data.payload),
-    );
+    let result = crypto::seal(&sender, &receiver, Payload::Content(&data.payload));
 
     if let Ok(mut message) = result {
-        let (_, opened_payload, _, _) = crypto::open(&receiver, &sender, &mut message)
+        let (opened_payload, _, _) = crypto::open(&receiver, &sender, &mut message)
             .expect("open failed after seal succeeded");
 
         assert_eq!(opened_payload, Payload::Content(data.payload.as_slice()));

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -448,11 +448,8 @@ pub enum RelationshipDelivery {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum CryptoType {
     Plaintext = 0,
-    HpkeAuth = 1,
-    HpkeEssr = 2,
-    NaclAuth = 3,
-    NaclEssr = 4,
-    X25519Kyber768Draft00 = 5,
+    HpkeBase = 1,
+    SealedBox = 2,
 }
 
 #[wasm_bindgen]
@@ -470,7 +467,6 @@ pub struct FlatReceivedTspMessage {
     pub variant: ReceivedTspMessageVariant,
     sender: Option<String>,
     receiver: Option<String>,
-    nonconfidential_data: Option<Option<Vec<u8>>>,
     message: Option<Vec<u8>>,
     pub crypto_type: Option<CryptoType>,
     pub signature_type: Option<SignatureType>,
@@ -497,14 +493,6 @@ impl FlatReceivedTspMessage {
     #[wasm_bindgen(getter)]
     pub fn receiver(&self) -> Option<String> {
         self.receiver.clone()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn nonconfidential_data(&self) -> JsValue {
-        match &self.nonconfidential_data {
-            Some(Some(data)) => serde_wasm_bindgen::to_value(data).unwrap(),
-            _ => JsValue::NULL,
-        }
     }
 
     #[wasm_bindgen(getter)]
@@ -619,7 +607,6 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             variant,
             sender: None,
             receiver: None,
-            nonconfidential_data: None,
             message: None,
             crypto_type: None,
             signature_type: None,
@@ -655,13 +642,8 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.message = Some(message.into());
                 this.crypto_type = match message_type.crypto_type {
                     tsp_sdk::cesr::CryptoType::Plaintext => Some(CryptoType::Plaintext),
-                    tsp_sdk::cesr::CryptoType::HpkeAuth => Some(CryptoType::HpkeAuth),
-                    tsp_sdk::cesr::CryptoType::HpkeEssr => Some(CryptoType::HpkeEssr),
-                    tsp_sdk::cesr::CryptoType::NaclAuth => Some(CryptoType::NaclAuth),
-                    tsp_sdk::cesr::CryptoType::NaclEssr => Some(CryptoType::NaclEssr),
-                    tsp_sdk::cesr::CryptoType::X25519Kyber768Draft00 => {
-                        Some(CryptoType::X25519Kyber768Draft00)
-                    }
+                    tsp_sdk::cesr::CryptoType::HpkeBase => Some(CryptoType::HpkeBase),
+                    tsp_sdk::cesr::CryptoType::SealedBox => Some(CryptoType::SealedBox),
                 };
                 this.signature_type = match message_type.signature_type {
                     tsp_sdk::cesr::SignatureType::NoSignature => Some(SignatureType::NoSignature),

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -82,17 +82,11 @@ impl Store {
         &self,
         sender: String,
         receiver: String,
-        nonconfidential_data: Option<Vec<u8>>,
         message: Vec<u8>,
     ) -> Result<SealedMessage, Error> {
         let (url, sealed) = self
             .0
-            .seal_message(
-                &sender,
-                &receiver,
-                nonconfidential_data.as_deref(),
-                &message,
-            )
+            .seal_message(&sender, &receiver, &message)
             .map_err(Error)?;
 
         Ok(SealedMessage {
@@ -382,40 +376,24 @@ pub fn message_parts(message: &[u8]) -> Result<String, Error> {
         "prefix": format_part("Prefix", &parts.prefix, None),
         "sender": format_part("Sender", &parts.sender, None),
         "receiver": parts.receiver.map(|v| format_part("Receiver", &v, None)),
-        "nonconfidentialData": parts.nonconfidential_data.map(|v| format_part("Non-confidential data", &v, None)),
         "ciphertext": parts.ciphertext.map(|v| format_part("Ciphertext", &v, None)),
         "signature": format_part("Signature", &parts.signature, None),
-    })).unwrap())
+    }))
+    .unwrap())
 }
 
 #[wasm_bindgen]
 pub fn probe_message(mut message: Vec<u8>) -> Result<String, Error> {
     tsp_sdk::cesr::probe(&mut message)
         .map(|e: EnvelopeType| match e {
-            EnvelopeType::EncryptedMessage {
-                sender,
-                receiver,
-                nonconfidential_data,
-            } => serde_json::to_string(&json!({
+            EnvelopeType::EncryptedMessage { sender, receiver } => serde_json::to_string(&json!({
                 "sender": String::from_utf8_lossy(sender).to_string(),
                 "receiver": String::from_utf8_lossy(receiver).to_string(),
-                "nonconfidential_data": String::from_utf8_lossy(
-                    nonconfidential_data.unwrap_or_default(),
-                )
-                .to_string(),
             }))
             .unwrap(),
-            EnvelopeType::SignedMessage {
-                sender,
-                receiver,
-                nonconfidential_data,
-            } => serde_json::to_string(&json!({
+            EnvelopeType::SignedMessage { sender, receiver } => serde_json::to_string(&json!({
                 "sender": String::from_utf8_lossy(sender).to_string(),
                 "receiver": String::from_utf8_lossy(receiver.unwrap_or_default()).to_string(),
-                "nonconfidential_data": String::from_utf8_lossy(
-                    nonconfidential_data.unwrap_or_default(),
-                )
-                .to_string(),
             }))
             .unwrap(),
         })
@@ -669,13 +647,11 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             tsp_sdk::ReceivedTspMessage::GenericMessage {
                 sender,
                 receiver,
-                nonconfidential_data,
                 message,
                 message_type,
             } => {
                 this.sender = Some(sender);
                 this.receiver = receiver;
-                this.nonconfidential_data = Some(nonconfidential_data.map(Into::into));
                 this.message = Some(message.into());
                 this.crypto_type = match message_type.crypto_type {
                     tsp_sdk::cesr::CryptoType::Plaintext => Some(CryptoType::Plaintext),

--- a/tsp_node/test.js
+++ b/tsp_node/test.js
@@ -300,7 +300,7 @@ describe('tsp node tests', function() {
 
                 // Check the final received message in d_store
                 if (received instanceof GenericMessage) {
-                    const { sender, nonconfidential_data: _, message: messageBytes, crypto_type, signature_type } = received;
+                    const { sender, message: messageBytes, crypto_type, signature_type } = received;
                     assert.strictEqual(sender, sneaky_a.identifier());
                     message = String.fromCharCode.apply(null, messageBytes);
                     assert.strictEqual(message, hello_world, "Received message does not match");
@@ -375,11 +375,10 @@ describe('tsp node tests', function() {
 
                         // Pattern match for GenericMessage in received message
                         if (received_3 instanceof GenericMessage) {
-                            let { sender, nonconfidential_data, message: messageBytes, crypto_type, signature_type } = received_3;
+                            let { sender, message: messageBytes, crypto_type, signature_type } = received_3;
 
                             // Assertions for GenericMessage
                             assert.strictEqual(sender, nested_vid_1);
-                            assert.strictEqual(nonconfidential_data, null);
                             message = String.fromCharCode.apply(null, messageBytes);
                             assert.strictEqual(message, hello_world, "Received message does not match");
                             assert.notStrictEqual(crypto_type, CryptoType.Plaintext, "Crypto type should not be Plaintext");

--- a/tsp_node/test.js
+++ b/tsp_node/test.js
@@ -56,7 +56,7 @@ describe('tsp node tests', function() {
 
         let message = "hello world";
 
-        let { url, sealed } = store.seal_message(alice_identifier, bob_identifier, null, message);
+        let { url, sealed } = store.seal_message(alice_identifier, bob_identifier, message);
 
         assert.strictEqual(url, "tcp://127.0.0.1:1337");
 
@@ -271,7 +271,7 @@ describe('tsp node tests', function() {
         let hello_world = "hello world";
 
         // Seal the message from a_store
-        let { url, sealed } = a_store.seal_message(sneaky_a.identifier(), sneaky_d.identifier(), null, Buffer.from(hello_world));
+        let { url, sealed } = a_store.seal_message(sneaky_a.identifier(), sneaky_d.identifier(), Buffer.from(hello_world));
 
         // Open the sealed message in b_store
         let received = b_store.open_message(sealed);
@@ -367,7 +367,6 @@ describe('tsp node tests', function() {
                         ({ url: _, sealed: sealed_hello_world } = a_store.seal_message(
                             nested_vid_1,
                             nested_vid_2,
-                            null,
                             hello_world,
                         ));
 

--- a/tsp_node/tsp.js
+++ b/tsp_node/tsp.js
@@ -40,7 +40,7 @@ class Store {
         return this.inner.set_route_for_vid(...args);
     }
 
-    seal_message(sender, receiver, nonconfidential_data, message) {
+    seal_message(sender, receiver, message) {
         let byteArray;
         
         if (typeof message === 'string') {
@@ -52,7 +52,7 @@ class Store {
             throw new TypeError("Message must be a string or a Uint8Array");
         }
 
-        return this.inner.seal_message(sender, receiver, nonconfidential_data, byteArray);
+        return this.inner.seal_message(sender, receiver, byteArray);
     }
 
     make_relationship_request(...args) {
@@ -100,7 +100,6 @@ class ReceivedTspMessage {
                 return new GenericMessage(
                     msg.sender,
                     msg.receiver,
-                    msg.nonconfidential_data,
                     new Uint8Array(msg.message),
                     msg.crypto_type,
                     msg.signature_type
@@ -154,11 +153,10 @@ class ReceivedTspMessage {
 }
 
 class GenericMessage extends ReceivedTspMessage {
-    constructor(sender, receiver, nonconfidential_data, message, crypto_type, signature_type) {
+    constructor(sender, receiver, message, crypto_type, signature_type) {
         super();
         this.sender = sender;
         this.receiver = receiver;
-        this.nonconfidential_data = nonconfidential_data;
         this.message = message;
         this.crypto_type = crypto_type;
         this.signature_type = signature_type;

--- a/tsp_node/tsp.js
+++ b/tsp_node/tsp.js
@@ -8,10 +8,8 @@ const {
 
 const CryptoType = {
     Plaintext: 0,
-    HpkeAuth: 1,
-    HpkeEssr: 2,
-    NaclAuth: 3,
-    NaclEssr: 4,
+    HpkeBase: 1,
+    SealedBox: 2,
 };
 
 const SignatureType = {

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -405,11 +405,8 @@ pub enum RelationshipDelivery {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CryptoType {
     Plaintext = 0,
-    HpkeAuth = 1,
-    HpkeEssr = 2,
-    NaclAuth = 3,
-    NaclEssr = 4,
-    X25519Kyber768Draft00 = 5,
+    HpkeBase = 1,
+    SealedBox = 2,
 }
 
 #[pyclass(eq, eq_int, from_py_object)]
@@ -429,7 +426,6 @@ struct FlatReceivedTspMessage {
     sender: Option<String>,
     #[pyo3(get, set)]
     receiver: Option<String>,
-    #[pyo3(get, set)]
     #[pyo3(get, set)]
     message: Option<Vec<u8>>,
     #[pyo3(get, set)]
@@ -526,13 +522,8 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.message = Some(message.into());
                 this.crypto_type = match message_type.crypto_type {
                     tsp_sdk::cesr::CryptoType::Plaintext => Some(CryptoType::Plaintext),
-                    tsp_sdk::cesr::CryptoType::HpkeAuth => Some(CryptoType::HpkeAuth),
-                    tsp_sdk::cesr::CryptoType::HpkeEssr => Some(CryptoType::HpkeEssr),
-                    tsp_sdk::cesr::CryptoType::NaclAuth => Some(CryptoType::NaclAuth),
-                    tsp_sdk::cesr::CryptoType::NaclEssr => Some(CryptoType::NaclEssr),
-                    tsp_sdk::cesr::CryptoType::X25519Kyber768Draft00 => {
-                        Some(CryptoType::X25519Kyber768Draft00)
-                    }
+                    tsp_sdk::cesr::CryptoType::HpkeBase => Some(CryptoType::HpkeBase),
+                    tsp_sdk::cesr::CryptoType::SealedBox => Some(CryptoType::SealedBox),
                 };
                 this.signature_type = match message_type.signature_type {
                     tsp_sdk::cesr::SignatureType::NoSignature => Some(SignatureType::NoSignature),

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -180,42 +180,22 @@ impl Store {
             .map_err(py_exception)
     }
 
-    #[pyo3(signature = (sender, receiver, message, nonconfidential_data = None))]
     fn seal_message(
         &self,
         sender: String,
         receiver: String,
         message: Vec<u8>,
-        nonconfidential_data: Option<Vec<u8>>,
     ) -> PyResult<(String, Vec<u8>)> {
         let (url, bytes) = self
             .inner
-            .seal_message(
-                &sender,
-                &receiver,
-                nonconfidential_data.as_deref(),
-                &message,
-            )
+            .seal_message(&sender, &receiver, &message)
             .map_err(py_exception)?;
 
         Ok((url.to_string(), bytes))
     }
 
-    #[pyo3(signature = (sender, receiver, message, nonconfidential_data = None))]
-    fn send(
-        &self,
-        sender: String,
-        receiver: String,
-        message: Vec<u8>,
-        nonconfidential_data: Option<Vec<u8>>,
-    ) -> PyResult<()> {
-        wait_for(self.inner.send(
-            &sender,
-            &receiver,
-            nonconfidential_data.as_deref(),
-            &message,
-        ))?
-        .map_err(py_exception)
+    fn send(&self, sender: String, receiver: String, message: Vec<u8>) -> PyResult<()> {
+        wait_for(self.inner.send(&sender, &receiver, &message))?.map_err(py_exception)
     }
 
     fn receive(&mut self, vid: String) -> PyResult<Option<FlatReceivedTspMessage>> {
@@ -450,7 +430,6 @@ struct FlatReceivedTspMessage {
     #[pyo3(get, set)]
     receiver: Option<String>,
     #[pyo3(get, set)]
-    nonconfidential_data: Option<Option<Vec<u8>>>,
     #[pyo3(get, set)]
     message: Option<Vec<u8>>,
     #[pyo3(get, set)]
@@ -519,7 +498,6 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             variant,
             sender: None,
             receiver: None,
-            nonconfidential_data: None,
             message: None,
             crypto_type: None,
             signature_type: None,
@@ -540,13 +518,11 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             tsp_sdk::ReceivedTspMessage::GenericMessage {
                 sender,
                 receiver,
-                nonconfidential_data,
                 message,
                 message_type,
             } => {
                 this.sender = Some(sender);
                 this.receiver = receiver;
-                this.nonconfidential_data = Some(nonconfidential_data.map(Into::into));
                 this.message = Some(message.into());
                 this.crypto_type = match message_type.crypto_type {
                     tsp_sdk::cesr::CryptoType::Plaintext => Some(CryptoType::Plaintext),

--- a/tsp_python/test.py
+++ b/tsp_python/test.py
@@ -326,14 +326,12 @@ class AliceBob(unittest.TestCase):
             case tsp.GenericMessage(
                 sender,
                 receiver,
-                nonconfidential_data,
                 message,
                 crypto_type,
                 signature_type,
             ):
                 self.assertEqual(sender, sneaky_a.identifier())
                 self.assertEqual(receiver, sneaky_d.identifier())
-                self.assertEqual(nonconfidential_data, None)
                 self.assertEqual(message, hello_world)
                 self.assertNotEqual(crypto_type, tsp.CryptoType.Plaintext)
                 self.assertNotEqual(signature_type, tsp.SignatureType.NoSignature)

--- a/tsp_python/test.py
+++ b/tsp_python/test.py
@@ -58,7 +58,7 @@ class AliceBob(unittest.TestCase):
 
         match received:
             case tsp.GenericMessage(
-                sender, receiver, _, received_message, crypto_type, signature_type
+                sender, receiver, received_message, crypto_type, signature_type
             ):
                 self.assertEqual(sender, self.alice.identifier())
                 self.assertEqual(receiver, self.bob.identifier())
@@ -417,7 +417,7 @@ class AliceBob(unittest.TestCase):
 
         match received:
             case tsp.GenericMessage(
-                sender, receiver, _, received_message, crypto_type, signature_type
+                sender, receiver, received_message, crypto_type, signature_type
             ):
                 self.assertEqual(sender, nested_a.identifier())
                 self.assertEqual(receiver, nested_b.identifier())

--- a/tsp_python/tsp_python/tsp.py
+++ b/tsp_python/tsp_python/tsp.py
@@ -95,7 +95,6 @@ class SecureStore:
             sender: str,
             receiver: str,
             message: bytes,
-            nonconfidential_data: bytes | None = None,
     ) -> tuple[str, bytes]:
         """
         Seal a TSP message.
@@ -104,9 +103,7 @@ class SecureStore:
         of the sender and receiver, specified by their VIDs.
         """
         with Wallet(self):
-            return self.inner.seal_message(
-                sender, receiver, message, nonconfidential_data
-            )
+            return self.inner.seal_message(sender, receiver, message)
 
     def open_message(self, message: bytes):
         """Decode an encrypted `message`"""
@@ -121,7 +118,6 @@ class SecureStore:
             sender: str,
             receiver: str,
             message: bytes,
-            nonconfidential_data: bytes | None = None,
     ):
         """
         Send a TSP message given earlier resolved VIDs
@@ -129,7 +125,7 @@ class SecureStore:
         Encodes, encrypts, signs, and sends a TSP message
         """
         with Wallet(self):
-            self.inner.send(sender, receiver, message, nonconfidential_data)
+            self.inner.send(sender, receiver, message)
 
     def receive(self, vid: str):
         """Receive a single TSP messages for the private VID identified by `vid`, using the appropriate transport mechanism for it."""
@@ -210,7 +206,6 @@ class ReceivedTspMessage:
                 return GenericMessage(
                     msg.sender,
                     msg.receiver,
-                    msg.nonconfidential_data,
                     bytes(msg.message),
                     msg.crypto_type,
                     msg.signature_type,
@@ -262,7 +257,6 @@ class ReceivedTspMessage:
 class GenericMessage(ReceivedTspMessage):
     sender: str
     receiver: str | None
-    nonconfidential_data: bytes | None
     message: bytes
     crypto_type: str
     signature_type: str

--- a/tsp_sdk/Cargo.toml
+++ b/tsp_sdk/Cargo.toml
@@ -55,7 +55,6 @@ once_cell = { workspace = true }
 # crypto
 ed25519-dalek = { workspace = true }
 hpke = { workspace = true }
-hpke_pq = { workspace = true }
 ml-dsa = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }

--- a/tsp_sdk/benches/bench_utils.rs
+++ b/tsp_sdk/benches/bench_utils.rs
@@ -50,8 +50,8 @@ pub fn deterministic_owned_vid_mldsa65_x25519kyber768(
     seed: u64,
 ) -> tsp_sdk::OwnedVid {
     use base64ct::{Base64UrlUnpadded, Encoding as _};
-    use hpke_pq::Kem as _;
-    use hpke_pq::Serializable as _;
+    use hpke::Kem as _;
+    use hpke::Serializable as _;
     use ml_dsa::MlDsa65;
 
     use rand::{RngCore as _, SeedableRng as _};
@@ -65,7 +65,7 @@ pub fn deterministic_owned_vid_mldsa65_x25519kyber768(
         <ml_dsa::SigningKey<MlDsa65> as ml_dsa::Keypair>::verifying_key(&sig).encode();
 
     let ikm = seeded_bytes(seed ^ 0x454E435F4B594245u64, 32);
-    let (enckey, public_enckey) = hpke_pq::kem::X25519MlKem768::derive_keypair(ikm.as_slice());
+    let (enckey, public_enckey) = hpke::kem::XWing::derive_keypair(ikm.as_slice());
     let enckey = enckey.to_bytes();
     let public_enckey = public_enckey.to_bytes();
 

--- a/tsp_sdk/benches/bench_utils.rs
+++ b/tsp_sdk/benches/bench_utils.rs
@@ -65,8 +65,7 @@ pub fn deterministic_owned_vid_mldsa65_x25519kyber768(
         <ml_dsa::SigningKey<MlDsa65> as ml_dsa::Keypair>::verifying_key(&sig).encode();
 
     let ikm = seeded_bytes(seed ^ 0x454E435F4B594245u64, 32);
-    let (enckey, public_enckey) =
-        hpke_pq::kem::X25519Kyber768Draft00::derive_keypair(ikm.as_slice());
+    let (enckey, public_enckey) = hpke_pq::kem::X25519MlKem768::derive_keypair(ikm.as_slice());
     let enckey = enckey.to_bytes();
     let public_enckey = public_enckey.to_bytes();
 
@@ -76,7 +75,7 @@ pub fn deterministic_owned_vid_mldsa65_x25519kyber768(
         "sigKeyType": "MlDsa65",
         "publicSigkey": Base64UrlUnpadded::encode_string(public_sigkey.as_slice()),
         "sigkey": Base64UrlUnpadded::encode_string(sigkey.as_slice()),
-        "encKeyType": "X25519Kyber768Draft00",
+        "encKeyType": "X25519MlKem768",
         "publicEnckey": Base64UrlUnpadded::encode_string(public_enckey.as_slice()),
         "enckey": Base64UrlUnpadded::encode_string(enckey.as_slice()),
     })

--- a/tsp_sdk/benches/common/bench.rs
+++ b/tsp_sdk/benches/common/bench.rs
@@ -51,7 +51,7 @@ pub fn setup_store(_benchmark_id: &'static str, payload_len: usize) -> StoreCase
 pub fn store_seal_open(case: &StoreCase) -> usize {
     let (_endpoint, mut sealed) = case
         .store
-        .seal_message(&case.sender, &case.receiver, None, case.payload.as_slice())
+        .seal_message(&case.sender, &case.receiver, case.payload.as_slice())
         .unwrap();
 
     let opened = case.store.open_message(sealed.as_mut_slice()).unwrap();
@@ -79,12 +79,11 @@ pub fn crypto_seal_open(case: &CryptoCase) -> usize {
     let mut sealed = tsp_sdk::crypto::seal(
         black_box(&case.alice),
         black_box(&case.bob),
-        None,
         Payload::Content(case.payload.as_slice()),
     )
     .unwrap();
 
-    let (_ncd, opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
+    let (opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
         black_box(&case.bob),
         black_box(&case.alice),
         sealed.as_mut_slice(),
@@ -113,7 +112,7 @@ pub fn setup_cesr_fixture(_benchmark_id: &'static str, payload_len: usize) -> Ve
     let bob = fixture_owned_vid("bob");
     let payload = seeded_bytes(0x434553525F504C44u64 ^ payload_len as u64, payload_len);
 
-    tsp_sdk::crypto::seal(&alice, &bob, None, Payload::Content(payload.as_slice())).unwrap()
+    tsp_sdk::crypto::seal(&alice, &bob, Payload::Content(payload.as_slice())).unwrap()
 }
 
 pub fn cesr_decode_envelope(message: &mut [u8]) -> usize {

--- a/tsp_sdk/benches/guardrail_hpke.rs
+++ b/tsp_sdk/benches/guardrail_hpke.rs
@@ -65,12 +65,11 @@ fn guardrail_crypto_seal_open_hpke(case: SealOpenCase) -> usize {
     let mut sealed = tsp_sdk::crypto::seal(
         black_box(&case.alice),
         black_box(&case.bob),
-        None,
         Payload::Content(case.payload.as_slice()),
     )
     .unwrap();
 
-    let (_ncd, opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
+    let (opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
         black_box(&case.bob),
         black_box(&case.alice),
         sealed.as_mut_slice(),

--- a/tsp_sdk/benches/guardrail_pq.rs
+++ b/tsp_sdk/benches/guardrail_pq.rs
@@ -65,12 +65,11 @@ fn guardrail_crypto_seal_open_hpke_pq(case: SealOpenCase) -> usize {
     let mut sealed = tsp_sdk::crypto::seal(
         black_box(&case.alice),
         black_box(&case.bob),
-        None,
         Payload::Content(case.payload.as_slice()),
     )
     .unwrap();
 
-    let (_ncd, opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
+    let (opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
         black_box(&case.bob),
         black_box(&case.alice),
         sealed.as_mut_slice(),

--- a/tsp_sdk/benches/throughput_cli.rs
+++ b/tsp_sdk/benches/throughput_cli.rs
@@ -147,7 +147,7 @@ fn bench_send_receive_direct(c: &mut Criterion, backend: &'static str, payload_l
                 for _ in 0..iters {
                     sample_attempts += 1;
                     let (_endpoint, message) = alice
-                        .seal_message(&alice_id, &bob_id, None, payload.as_slice())
+                        .seal_message(&alice_id, &bob_id, payload.as_slice())
                         .unwrap();
 
                     if let Err(error) =

--- a/tsp_sdk/benches/throughput_hpke.rs
+++ b/tsp_sdk/benches/throughput_hpke.rs
@@ -56,12 +56,11 @@ fn seal_open_hpke(case: &SealOpenCase) -> usize {
     let mut sealed = tsp_sdk::crypto::seal(
         black_box(&case.alice),
         black_box(&case.bob),
-        None,
         Payload::Content(case.payload.as_slice()),
     )
     .unwrap();
 
-    let (_ncd, opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
+    let (opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
         black_box(&case.bob),
         black_box(&case.alice),
         sealed.as_mut_slice(),

--- a/tsp_sdk/benches/throughput_pq.rs
+++ b/tsp_sdk/benches/throughput_pq.rs
@@ -55,12 +55,11 @@ fn seal_open_hpke_pq(case: &SealOpenCase) -> usize {
     let mut sealed = tsp_sdk::crypto::seal(
         black_box(&case.alice),
         black_box(&case.bob),
-        None,
         Payload::Content(case.payload.as_slice()),
     )
     .unwrap();
 
-    let (_ncd, opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
+    let (opened, _crypto_type, _sig_type) = tsp_sdk::crypto::open(
         black_box(&case.bob),
         black_box(&case.alice),
         sealed.as_mut_slice(),

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -37,7 +37,6 @@ use url::Url;
 ///     let result = db.send(
 ///         "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
 ///         "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
-///         Some(b"extra non-confidential data"),
 ///         b"hello world",
 ///     ).await;
 /// }
@@ -234,11 +233,9 @@ impl AsyncSecureStore {
         &self,
         sender: &str,
         receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
         message: &[u8],
     ) -> Result<(Url, Vec<u8>), Error> {
-        self.inner
-            .seal_message(sender, receiver, nonconfidential_data, message)
+        self.inner.seal_message(sender, receiver, message)
     }
 
     /// Send a TSP message given earlier resolved VIDs
@@ -248,7 +245,6 @@ impl AsyncSecureStore {
     ///
     /// * `sender`               - A sender VID
     /// * `receiver`             - A receiver VID
-    /// * `nonconfidential_data` - Optional extra non-confidential data
     /// * `payload`              - The raw message payload as byte slice
     ///
     /// # Example
@@ -267,16 +263,10 @@ impl AsyncSecureStore {
     ///     let sender = "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob";
     ///     let receiver = "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice";
     ///
-    ///     let result = db.send(sender, receiver, None, b"hello world").await;
+    ///     let result = db.send(sender, receiver, b"hello world").await;
     /// }
     /// ```
-    pub async fn send(
-        &self,
-        sender: &str,
-        receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
-        message: &[u8],
-    ) -> Result<(), Error> {
+    pub async fn send(&self, sender: &str, receiver: &str, message: &[u8]) -> Result<(), Error> {
         match self.inner.relation_status_for_vid_pair(sender, receiver) {
             Ok(relation) => {
                 if matches!(relation, RelationshipStatus::Unrelated) {
@@ -291,9 +281,7 @@ impl AsyncSecureStore {
             Err(e) => return Err(e),
         };
 
-        let (endpoint, message) =
-            self.inner
-                .seal_message(sender, receiver, nonconfidential_data, message)?;
+        let (endpoint, message) = self.inner.seal_message(sender, receiver, message)?;
 
         tracing::info!("sending message to {endpoint}");
 
@@ -306,7 +294,6 @@ impl AsyncSecureStore {
         &self,
         sender: &str,
         receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
         message: &[u8],
         crypto_type: CryptoType,
     ) -> Result<(), Error> {
@@ -329,13 +316,9 @@ impl AsyncSecureStore {
             Err(e) => return Err(e),
         };
 
-        let (endpoint, message) = self.inner.seal_message_with_crypto_type(
-            sender,
-            receiver,
-            nonconfidential_data,
-            message,
-            crypto_type,
-        )?;
+        let (endpoint, message) =
+            self.inner
+                .seal_message_with_crypto_type(sender, receiver, message, crypto_type)?;
 
         tracing::info!("sending message to {endpoint}");
 

--- a/tsp_sdk/src/cesr/error.rs
+++ b/tsp_sdk/src/cesr/error.rs
@@ -11,6 +11,8 @@ pub enum EncodeError {
     InvalidSignatureType,
     #[error("a nested message must be CESR data (a multiple of 3 bytes long)")]
     MisalignedNestedMessage,
+    #[error("this payload type does not carry a self-referencing digest")]
+    NoDigestSlot,
 }
 
 /// An error type to indicate something went wrong with decoding

--- a/tsp_sdk/src/cesr/mod.rs
+++ b/tsp_sdk/src/cesr/mod.rs
@@ -64,12 +64,10 @@ pub enum EnvelopeType<'a> {
     EncryptedMessage {
         sender: &'a [u8],
         receiver: &'a [u8],
-        nonconfidential_data: Option<&'a [u8]>,
     },
     SignedMessage {
         sender: &'a [u8],
         receiver: Option<&'a [u8]>,
-        nonconfidential_data: Option<&'a [u8]>,
     },
 }
 
@@ -78,19 +76,6 @@ impl EnvelopeType<'_> {
         match self {
             EnvelopeType::EncryptedMessage { receiver, .. } => Some(*receiver),
             EnvelopeType::SignedMessage { receiver, .. } => *receiver,
-        }
-    }
-
-    pub fn get_nonconfidential_data(&self) -> Option<&[u8]> {
-        match self {
-            EnvelopeType::EncryptedMessage {
-                nonconfidential_data,
-                ..
-            } => *nonconfidential_data,
-            EnvelopeType::SignedMessage {
-                nonconfidential_data,
-                ..
-            } => *nonconfidential_data,
         }
     }
 }
@@ -109,13 +94,11 @@ pub fn probe(stream: &mut [u8]) -> Result<EnvelopeType<'_>, error::DecodeError> 
         EnvelopeType::EncryptedMessage {
             sender: envelope.sender,
             receiver: envelope.receiver.expect("Infallible"),
-            nonconfidential_data: envelope.nonconfidential_data,
         }
     } else {
         EnvelopeType::SignedMessage {
             sender: envelope.sender,
             receiver: envelope.receiver,
-            nonconfidential_data: envelope.nonconfidential_data,
         }
     })
 }
@@ -127,7 +110,6 @@ pub fn color_format(message: &[u8]) -> Result<String, DecodeError> {
         (Some(parts.prefix), 31),
         (Some(parts.sender), 35),
         (parts.receiver, 34),
-        (parts.nonconfidential_data, 32),
         (parts.ciphertext, 33),
         (Some(parts.signature), 36),
     ];

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -10,11 +10,8 @@ pub const TSP_CESR_GENUS: ([u8; 3], (u8, u8, u8)) = (cesr_data("AAA"), (2, 0, 0)
 
 /// Constants that determine the specific CESR types for "variable length data"
 const TSP_PLAINTEXT: u32 = cesr!("B");
-const TSP_NACL_CIPHERTEXT: u32 = cesr!("C");
-const TSP_NACLAUTH_CIPHERTEXT: u32 = cesr!("NCL");
+const TSP_SEALEDBOX_CIPHERTEXT: u32 = cesr!("C");
 const TSP_HPKEBASE_CIPHERTEXT: u32 = cesr!("F");
-const TSP_HPKEAUTH_CIPHERTEXT: u32 = cesr!("G");
-const TSP_HPKEPQ_CIPHERTEXT: u32 = cesr!("PQC");
 const TSP_VID: u32 = cesr!("B");
 
 /// Constants that determine the specific CESR types for "fixed length data"
@@ -153,31 +150,11 @@ pub mod fuzzing;
 #[repr(u8)]
 pub enum CryptoType {
     Plaintext = 0,
-    HpkeAuth = 1,
-    HpkeEssr = 2,
-    NaclAuth = 3,
-    NaclEssr = 4,
-    X25519Kyber768Draft00 = 5,
-}
-
-pub trait AsCryptoType {
-    fn crypto_type() -> CryptoType;
-}
-
-impl AsCryptoType for hpke_pq::kem::X25519Kyber768Draft00 {
-    fn crypto_type() -> CryptoType {
-        CryptoType::X25519Kyber768Draft00
-    }
-}
-
-impl AsCryptoType for hpke::kem::X25519HkdfSha256 {
-    fn crypto_type() -> CryptoType {
-        if cfg!(feature = "essr") {
-            CryptoType::HpkeEssr
-        } else {
-            CryptoType::HpkeAuth
-        }
-    }
+    /// HPKE-Base; the KEM (X25519 or X25519MLKEM768) is selected by the
+    /// recipient VID's encryption key type, with no separate code point
+    HpkeBase = 1,
+    /// The libsodium anonymous sealed box
+    SealedBox = 2,
 }
 
 impl CryptoType {
@@ -916,12 +893,9 @@ pub fn encode_signature(
 impl CryptoType {
     fn cesr_code(&self) -> Result<u32, DecodeError> {
         Ok(match self {
-            CryptoType::NaclEssr => TSP_NACL_CIPHERTEXT,
-            CryptoType::HpkeEssr => TSP_HPKEBASE_CIPHERTEXT,
-            CryptoType::HpkeAuth => TSP_HPKEAUTH_CIPHERTEXT,
-            CryptoType::NaclAuth => TSP_NACLAUTH_CIPHERTEXT,
-            CryptoType::X25519Kyber768Draft00 => TSP_HPKEPQ_CIPHERTEXT,
-            _ => return Err(DecodeError::InvalidCrypto),
+            CryptoType::SealedBox => TSP_SEALEDBOX_CIPHERTEXT,
+            CryptoType::HpkeBase => TSP_HPKEBASE_CIPHERTEXT,
+            CryptoType::Plaintext => return Err(DecodeError::InvalidCrypto),
         })
     }
 }
@@ -988,16 +962,10 @@ pub(super) fn detected_tsp_header_size_and_confidentiality(
     /* look ahead to determine the crypto and signature types; the payload
     position holds either a ciphertext primitive (confidential message) or a
     cleartext -Z## payload (non-confidential, signed-only message) */
-    let crypto_type = if decode_variable_data(TSP_HPKEAUTH_CIPHERTEXT, &mut stream).is_some() {
-        CryptoType::HpkeAuth
-    } else if decode_variable_data(TSP_HPKEBASE_CIPHERTEXT, &mut stream).is_some() {
-        CryptoType::HpkeEssr
-    } else if decode_variable_data(TSP_NACL_CIPHERTEXT, &mut stream).is_some() {
-        CryptoType::NaclEssr
-    } else if decode_variable_data(TSP_NACLAUTH_CIPHERTEXT, &mut stream).is_some() {
-        CryptoType::NaclAuth
-    } else if decode_variable_data(TSP_HPKEPQ_CIPHERTEXT, &mut stream).is_some() {
-        CryptoType::X25519Kyber768Draft00
+    let crypto_type = if decode_variable_data(TSP_HPKEBASE_CIPHERTEXT, &mut stream).is_some() {
+        CryptoType::HpkeBase
+    } else if decode_variable_data(TSP_SEALEDBOX_CIPHERTEXT, &mut stream).is_some() {
+        CryptoType::SealedBox
     } else if let Some(quadlets) = decode_count(TSP_PAYLOAD, &mut stream) {
         let payload_bytes = (quadlets as usize)
             .checked_mul(3)
@@ -1363,7 +1331,7 @@ pub fn encode_tsp_message<Vid: AsRef<[u8]>, Sig: AsRef<[u8]>>(
     sign: impl FnOnce(&Vid, &[u8]) -> Sig,
 ) -> Result<Vec<u8>, EncodeError> {
     let mut cesr = encode_envelope_vec(Envelope {
-        crypto_type: CryptoType::HpkeAuth,
+        crypto_type: CryptoType::HpkeBase,
         signature_type: SignatureType::Ed25519,
         sender,
         receiver: Some(receiver),
@@ -1371,7 +1339,7 @@ pub fn encode_tsp_message<Vid: AsRef<[u8]>, Sig: AsRef<[u8]>>(
 
     let ciphertext = &encrypt(receiver, encode_payload_vec(&message)?);
 
-    encode_ciphertext(ciphertext, CryptoType::HpkeAuth, &mut cesr)?;
+    encode_ciphertext(ciphertext, CryptoType::HpkeBase, &mut cesr)?;
     finalize_envelope_frame(&mut cesr);
     let signature = sign(sender, &cesr);
     encode_signature(signature.as_ref(), &mut cesr, SignatureType::Ed25519);
@@ -1448,14 +1416,14 @@ mod test {
             { encode_payload_vec(&Payload::<_, &[u8]>::GenericMessage(b"Hello TSP!")).unwrap() };
 
         let mut outer = encode_envelope_vec(Envelope {
-            crypto_type: CryptoType::HpkeAuth,
+            crypto_type: CryptoType::HpkeBase,
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
-        encode_ciphertext(ciphertext, CryptoType::HpkeAuth, &mut outer).unwrap();
+        encode_ciphertext(ciphertext, CryptoType::HpkeBase, &mut outer).unwrap();
         finalize_envelope_frame(&mut outer);
 
         let signed_data = outer.clone();
@@ -1495,14 +1463,14 @@ mod test {
             { encode_payload_vec(&Payload::<_, &[u8]>::GenericMessage(b"Hello TSP!")).unwrap() };
 
         let mut outer = encode_envelope_vec(Envelope {
-            crypto_type: CryptoType::HpkeAuth,
+            crypto_type: CryptoType::HpkeBase,
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
-        encode_ciphertext(ciphertext, CryptoType::HpkeAuth, &mut outer).unwrap();
+        encode_ciphertext(ciphertext, CryptoType::HpkeBase, &mut outer).unwrap();
         finalize_envelope_frame(&mut outer);
 
         let signed_data = outer.clone();
@@ -1601,7 +1569,7 @@ mod test {
         // that does not cover the ciphertext, which the receiver must reject
         finalize_envelope_frame(&mut outer);
         let ciphertext = dummy_crypt(&cesr_payload);
-        encode_ciphertext(ciphertext, CryptoType::HpkeAuth, &mut outer).unwrap();
+        encode_ciphertext(ciphertext, CryptoType::HpkeBase, &mut outer).unwrap();
         encode_signature(&fixed_sig, &mut outer, SignatureType::Ed25519);
 
         assert!(matches!(
@@ -1618,7 +1586,7 @@ mod test {
         let mut outer = vec![];
         encode_envelope(
             Envelope {
-                crypto_type: CryptoType::HpkeAuth,
+                crypto_type: CryptoType::HpkeBase,
                 signature_type: SignatureType::Ed25519,
                 sender: &b"Alister"[..],
                 receiver: Some(&b"Bobbi"[..]),
@@ -1628,7 +1596,7 @@ mod test {
         .unwrap();
         // no envelope frame, and signature and ciphertext in the wrong order
         encode_signature(&fixed_sig, &mut outer, SignatureType::Ed25519);
-        encode_ciphertext(&[], CryptoType::HpkeAuth, &mut outer).unwrap();
+        encode_ciphertext(&[], CryptoType::HpkeBase, &mut outer).unwrap();
 
         assert!(decode_envelope(&mut outer).is_err());
     }
@@ -1639,13 +1607,13 @@ mod test {
         let fixed_sig = [1; 64];
 
         let mut outer = encode_envelope_vec(Envelope {
-            crypto_type: CryptoType::HpkeAuth,
+            crypto_type: CryptoType::HpkeBase,
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
         })
         .unwrap();
-        encode_ciphertext(&[], CryptoType::HpkeAuth, &mut outer).unwrap();
+        encode_ciphertext(&[], CryptoType::HpkeBase, &mut outer).unwrap();
         finalize_envelope_frame(&mut outer);
         encode_signature(&fixed_sig, &mut outer, SignatureType::Ed25519);
 
@@ -1801,14 +1769,14 @@ mod test {
         let mut cesr_payload = encode_payload_vec(&payload).unwrap();
 
         let mut outer = encode_envelope_vec(Envelope {
-            crypto_type: CryptoType::HpkeAuth,
+            crypto_type: CryptoType::HpkeBase,
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
-        encode_ciphertext(ciphertext, CryptoType::HpkeAuth, &mut outer).unwrap();
+        encode_ciphertext(ciphertext, CryptoType::HpkeBase, &mut outer).unwrap();
         finalize_envelope_frame(&mut outer);
 
         let signed_data = outer.clone();
@@ -1870,13 +1838,13 @@ mod test {
         // 3-byte-aligned field contents, so the part lengths are exact
         // (unaligned contents include their lead bytes in the reported parts)
         let mut message = encode_envelope_vec(Envelope {
-            crypto_type: CryptoType::HpkeEssr,
+            crypto_type: CryptoType::HpkeBase,
             signature_type: SignatureType::Ed25519,
             sender: &b"did:test:bob"[..],
             receiver: Some(&b"did:test:alice3"[..]),
         })
         .unwrap();
-        encode_ciphertext(&[0xAA; 69], CryptoType::HpkeEssr, &mut message).unwrap();
+        encode_ciphertext(&[0xAA; 69], CryptoType::HpkeBase, &mut message).unwrap();
         finalize_envelope_frame(&mut message);
         encode_signature(&fixed_sig, &mut message, SignatureType::Ed25519);
 
@@ -1997,14 +1965,14 @@ mod test {
             { encode_payload_vec(&Payload::<_, &[u8]>::GenericMessage(b"Hello TSP!")).unwrap() };
 
         let mut outer = encode_envelope_vec(Envelope {
-            crypto_type: CryptoType::HpkeAuth,
+            crypto_type: CryptoType::HpkeBase,
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
-        encode_ciphertext(ciphertext, CryptoType::HpkeAuth, &mut outer).unwrap();
+        encode_ciphertext(ciphertext, CryptoType::HpkeBase, &mut outer).unwrap();
         finalize_envelope_frame(&mut outer);
 
         let signed_data = outer.clone();

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -769,18 +769,85 @@ pub fn encode_envelope<Vid: AsRef<[u8]>>(
     envelope: Envelope<Vid>,
     output: &mut Vec<u8>,
 ) -> Result<(), EncodeError> {
+    encode_envelope_prefix(
+        envelope.sender.as_ref(),
+        envelope.receiver.as_ref().map(AsRef::as_ref),
+        output,
+    )
+}
+
+/// Encode the envelope prefix: the version, sender VID and receiver VID
+/// (the NULL VID `4BAA` when absent). These bytes are the HPKE associated
+/// data and the leading input of the TSP digest (spec 7.2.1, 8.2.2).
+pub fn encode_envelope_prefix(
+    sender: &[u8],
+    receiver: Option<&[u8]>,
+    output: &mut impl for<'a> Extend<&'a u8>,
+) -> Result<(), EncodeError> {
     encode_version(output);
 
-    if envelope.sender.as_ref().is_empty() {
+    if sender.is_empty() {
         return Err(EncodeError::InvalidVid);
     }
-    checked_encode_variable_data(TSP_VID, envelope.sender.as_ref(), output)?;
+    checked_encode_variable_data(TSP_VID, sender, output)?;
 
-    checked_encode_variable_data(
-        TSP_VID,
-        envelope.receiver.as_ref().map(AsRef::as_ref).unwrap_or(&[]),
-        output,
-    )?;
+    checked_encode_variable_data(TSP_VID, receiver.unwrap_or(&[]), output)?;
+
+    Ok(())
+}
+
+/// The dummy filling the digest's own slot during SAID derivation (spec 7.2.1):
+/// 0x23 over the full encoded length of the digest primitive (code + 32 bytes)
+const DIGEST_DUMMY: [u8; 33] = [0x23; 33];
+
+/// Encode the input of the self-referencing TSP digest (spec 7.2.1) for a
+/// relationship-forming payload: the envelope prefix (version and VIDs)
+/// followed by the payload fields, with the digest's own slot (the Digest of
+/// an invite, the Reply_Digest of an accept) filled with the 0x23 dummy.
+/// The -E## and -Z## framing tags, the padding field, and the new-VID
+/// signature field (which is produced after the digest) are excluded.
+pub fn encode_digest_input(
+    payload: &Payload<impl AsRef<[u8]>, impl AsRef<[u8]>>,
+    sender_identity: Option<&[u8]>,
+    envelope_prefix: &[u8],
+    output: &mut Vec<u8>,
+) -> Result<(), EncodeError> {
+    output.extend(envelope_prefix);
+
+    match payload {
+        Payload::DirectRelationProposal { nonce, .. } => {
+            output.extend(&XRFI);
+            encode_sender_identity(sender_identity, output)?;
+            output.extend(&DIGEST_DUMMY);
+            encode_fixed_data(TSP_NONCE, &nonce.0, output);
+            checked_encode_variable_data(TSP_VID, &[], output)?;
+        }
+        Payload::ParallelRelationProposal { nonce, new_vid, .. } => {
+            output.extend(&XRFI);
+            encode_sender_identity(sender_identity, output)?;
+            output.extend(&DIGEST_DUMMY);
+            encode_fixed_data(TSP_NONCE, &nonce.0, output);
+            checked_encode_variable_data(TSP_VID, new_vid.as_ref(), output)?;
+        }
+        Payload::DirectRelationAffirm { request_digest, .. } => {
+            output.extend(&XRFA);
+            encode_sender_identity(sender_identity, output)?;
+            encode_digest(request_digest, output);
+            output.extend(&DIGEST_DUMMY);
+        }
+        Payload::ParallelRelationAffirm {
+            request_digest,
+            new_vid,
+            ..
+        } => {
+            output.extend(&XRFA);
+            encode_sender_identity(sender_identity, output)?;
+            encode_digest(request_digest, output);
+            output.extend(&DIGEST_DUMMY);
+            checked_encode_variable_data(TSP_VID, new_vid.as_ref(), output)?;
+        }
+        _ => return Err(EncodeError::NoDigestSlot),
+    }
 
     Ok(())
 }

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -203,18 +203,19 @@ impl SignatureType {
 
 /// Type representing a TSP Envelope
 #[derive(Debug, Clone)]
-pub struct Envelope<'a, Vid> {
+pub struct Envelope<Vid> {
     pub crypto_type: CryptoType,
     pub signature_type: SignatureType,
     pub sender: Vid,
     pub receiver: Option<Vid>,
-    pub nonconfidential_data: Option<&'a [u8]>,
 }
 
 pub struct DecodedEnvelope<'a, Vid, Bytes> {
-    pub envelope: Envelope<'a, Vid>,
+    pub envelope: Envelope<Vid>,
     pub raw_header: &'a [u8], // for associated data purposes
-    pub ciphertext: Option<Bytes>,
+    /// The payload position: the ciphertext of a confidential message, or the
+    /// cleartext `-Z##` payload of a non-confidential (signed-only) message
+    pub payload_position: Option<Bytes>,
 }
 
 type Signature = [u8];
@@ -787,8 +788,8 @@ fn decode_version(stream: &mut &[u8]) -> Result<(), DecodeError> {
 ///
 /// The `-E##` frame is prepended later by [finalize_envelope_frame], after the
 /// ciphertext (if any) has been appended, since its count covers both.
-pub fn encode_envelope<'a, Vid: AsRef<[u8]>>(
-    envelope: Envelope<'a, Vid>,
+pub fn encode_envelope<Vid: AsRef<[u8]>>(
+    envelope: Envelope<Vid>,
     output: &mut Vec<u8>,
 ) -> Result<(), EncodeError> {
     encode_version(output);
@@ -803,10 +804,6 @@ pub fn encode_envelope<'a, Vid: AsRef<[u8]>>(
         envelope.receiver.as_ref().map(AsRef::as_ref).unwrap_or(&[]),
         output,
     )?;
-
-    if let Some(data) = envelope.nonconfidential_data {
-        checked_encode_variable_data(TSP_PLAINTEXT, data, output)?;
-    }
 
     Ok(())
 }
@@ -988,9 +985,9 @@ pub(super) fn detected_tsp_header_size_and_confidentiality(
     *pos = mid_pos;
     let mut stream = &origin[mid_pos..];
 
-    /* look ahead to determine the crypto and signature types */
-    let _nonconf_data = decode_variable_data(TSP_PLAINTEXT, &mut stream);
-
+    /* look ahead to determine the crypto and signature types; the payload
+    position holds either a ciphertext primitive (confidential message) or a
+    cleartext -Z## payload (non-confidential, signed-only message) */
     let crypto_type = if decode_variable_data(TSP_HPKEAUTH_CIPHERTEXT, &mut stream).is_some() {
         CryptoType::HpkeAuth
     } else if decode_variable_data(TSP_HPKEBASE_CIPHERTEXT, &mut stream).is_some() {
@@ -1001,8 +998,16 @@ pub(super) fn detected_tsp_header_size_and_confidentiality(
         CryptoType::NaclAuth
     } else if decode_variable_data(TSP_HPKEPQ_CIPHERTEXT, &mut stream).is_some() {
         CryptoType::X25519Kyber768Draft00
-    } else {
+    } else if let Some(quadlets) = decode_count(TSP_PAYLOAD, &mut stream) {
+        let payload_bytes = (quadlets as usize)
+            .checked_mul(3)
+            .ok_or(DecodeError::InvalidFrameCount)?;
+        stream = stream
+            .get(payload_bytes..)
+            .ok_or(DecodeError::InvalidFrameCount)?;
         CryptoType::Plaintext
+    } else {
+        return Err(DecodeError::UnexpectedData);
     };
 
     // validate the frame count: the envelope fields and ciphertext must end
@@ -1071,7 +1076,6 @@ pub struct CipherView<'a> {
 
     sender: Range<usize>,
     receiver: Option<Range<usize>>,
-    nonconfidential_data: Option<Range<usize>>,
 
     associated_data: Range<usize>,
     signature: &'a Signature,
@@ -1104,16 +1108,12 @@ impl<'a> CipherView<'a> {
                 .receiver
                 .map(|r| header[r.clone()].try_into())
                 .transpose()?,
-            nonconfidential_data: self
-                .nonconfidential_data
-                .as_ref()
-                .map(|range| &header[range.clone()]),
         };
 
         Ok(DecodedEnvelope {
             envelope,
             raw_header,
-            ciphertext,
+            payload_position: ciphertext,
         })
     }
 
@@ -1137,11 +1137,9 @@ pub fn decode_envelope<'a>(stream: &'a mut [u8]) -> Result<CipherView<'a>, Decod
     let (sender, receiver, crypto_type, signature_type) =
         detected_tsp_header_size_and_confidentiality(stream, &mut pos)?;
 
-    let nonconfidential_data = decode_variable_data_index(TSP_PLAINTEXT, stream, &mut pos);
-
     // the associated data binds the envelope fields: everything after the `-E##`
     // frame code (which is excluded, matching the seal side where the frame is
-    // prepended only after encryption) up to the ciphertext
+    // prepended only after encryption) up to the payload position
     let frame_len = {
         let mut s = &stream[..];
         decode_count(TSP_WRAPPER, &mut s).ok_or(DecodeError::NotTsp)?;
@@ -1149,13 +1147,25 @@ pub fn decode_envelope<'a>(stream: &'a mut [u8]) -> Result<CipherView<'a>, Decod
     };
     let associated_data = frame_len..pos;
 
+    // the payload position: a ciphertext primitive, or the cleartext -Z## payload
     let ciphertext = if crypto_type.is_encrypted() {
         Some(
             checked_decode_variable_data_index(crypto_type.cesr_code()?, stream, &mut pos)
                 .ok_or(DecodeError::UnexpectedData)?,
         )
     } else {
-        None
+        let start = pos;
+        let mut s = &stream[pos..];
+        let quadlets = decode_count(TSP_PAYLOAD, &mut s).ok_or(DecodeError::UnexpectedData)?;
+        let code_len = stream.len() - pos - s.len();
+        let payload_bytes = (quadlets as usize)
+            .checked_mul(3)
+            .ok_or(DecodeError::InvalidFrameCount)?;
+        pos = start
+            .checked_add(code_len + payload_bytes)
+            .filter(|&end| end <= stream.len())
+            .ok_or(DecodeError::InvalidFrameCount)?;
+        Some(start..pos)
     };
 
     let signed_data = 0..pos;
@@ -1184,7 +1194,6 @@ pub fn decode_envelope<'a>(stream: &'a mut [u8]) -> Result<CipherView<'a>, Decod
 
         sender,
         receiver,
-        nonconfidential_data,
 
         associated_data,
         signature,
@@ -1241,7 +1250,7 @@ pub struct MessageParts<'a> {
     pub prefix: Part<'a>,
     pub sender: Part<'a>,
     pub receiver: Option<Part<'a>>,
-    pub nonconfidential_data: Option<Part<'a>>,
+
     pub ciphertext: Option<Part<'a>>,
     pub signature: Part<'a>,
     pub crypto_type: CryptoType,
@@ -1290,10 +1299,25 @@ pub fn open_message_into_parts(data: &[u8]) -> Result<MessageParts<'_>, DecodeEr
         }
     });
 
-    let nonconfidential_data = Part::decode(TSP_PLAINTEXT, data, &mut pos);
-
-    let cipher_code = crypto_type.cesr_code()?;
-    let ciphertext = Part::decode(cipher_code, data, &mut pos);
+    let ciphertext = if crypto_type.is_encrypted() {
+        let cipher_code = crypto_type.cesr_code()?;
+        Part::decode(cipher_code, data, &mut pos)
+    } else {
+        // the payload position holds the cleartext -Z## payload
+        let start = pos;
+        let mut s = &data[pos..];
+        let quadlets = decode_count(TSP_PAYLOAD, &mut s).ok_or(DecodeError::UnexpectedData)?;
+        let code_len = data.len() - pos - s.len();
+        let end = start
+            .checked_add(code_len + (quadlets as usize) * 3)
+            .filter(|&end| end <= data.len())
+            .ok_or(DecodeError::InvalidFrameCount)?;
+        pos = end;
+        Some(Part {
+            prefix: &data[start..start + code_len],
+            data: &data[start + code_len..end],
+        })
+    };
 
     let signature = match EncodedSignature::decode(&mut &data[pos..])? {
         EncodedSignature::NoSignature => &[],
@@ -1310,7 +1334,6 @@ pub fn open_message_into_parts(data: &[u8]) -> Result<MessageParts<'_>, DecodeEr
         prefix,
         sender,
         receiver,
-        nonconfidential_data,
         ciphertext,
         signature,
         crypto_type,
@@ -1325,7 +1348,6 @@ pub fn open_message_into_parts(data: &[u8]) -> Result<MessageParts<'_>, DecodeEr
 pub struct Message<'a, Vid, Bytes: AsRef<[u8]>> {
     pub sender: Vid,
     pub receiver: Vid,
-    pub nonconfidential_data: Option<&'a [u8]>,
     pub message: Payload<'a, Bytes, Vid>,
 }
 
@@ -1335,7 +1357,6 @@ pub fn encode_tsp_message<Vid: AsRef<[u8]>, Sig: AsRef<[u8]>>(
     Message {
         ref sender,
         ref receiver,
-        nonconfidential_data,
         message,
     }: Message<Vid, impl AsRef<[u8]>>,
     encrypt: impl FnOnce(&Vid, Vec<u8>) -> Vec<u8>,
@@ -1346,7 +1367,6 @@ pub fn encode_tsp_message<Vid: AsRef<[u8]>, Sig: AsRef<[u8]>>(
         signature_type: SignatureType::Ed25519,
         sender,
         receiver: Some(receiver),
-        nonconfidential_data,
     })?;
 
     let ciphertext = &encrypt(receiver, encode_payload_vec(&message)?);
@@ -1373,7 +1393,6 @@ where
         data,
         sender,
         receiver,
-        nonconfidential_data,
         signature,
         signed_data,
         ciphertext,
@@ -1407,7 +1426,6 @@ where
     Ok(Message {
         sender: data[sender].try_into().unwrap(),
         receiver: data[receiver.unwrap()].try_into().unwrap(),
-        nonconfidential_data: nonconfidential_data.map(|ncd| data[ncd].try_into().unwrap()),
         message,
     })
 }
@@ -1420,7 +1438,7 @@ mod test {
 
     #[test]
     #[wasm_bindgen_test]
-    fn envelope_without_nonconfidential_data() {
+    fn envelope_roundtrip() {
         fn dummy_crypt(data: &mut [u8]) -> &mut [u8] {
             data
         }
@@ -1434,7 +1452,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: None,
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
@@ -1450,12 +1467,11 @@ mod test {
         assert_eq!(ver.signature, &fixed_sig);
         let DecodedEnvelope {
             envelope: env,
-            ciphertext,
+            payload_position: ciphertext,
             ..
         } = view.into_opened().unwrap();
         assert_eq!(env.sender, &b"Alister"[..]);
         assert_eq!(env.receiver, Some(&b"Bobbi"[..]));
-        assert_eq!(env.nonconfidential_data, None);
 
         let DecodedPayload {
             payload: Payload::GenericMessage(data),
@@ -1469,7 +1485,7 @@ mod test {
 
     #[test]
     #[wasm_bindgen_test]
-    fn envelope_with_nonconfidential_data() {
+    fn envelope_roundtrip_second() {
         fn dummy_crypt(data: &mut [u8]) -> &mut [u8] {
             data
         }
@@ -1483,7 +1499,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: Some(b"treasure"),
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
@@ -1499,12 +1514,11 @@ mod test {
         assert_eq!(ver.signature, &fixed_sig);
         let DecodedEnvelope {
             envelope: env,
-            ciphertext,
+            payload_position: ciphertext,
             ..
         } = view.into_opened().unwrap();
         assert_eq!(env.sender, &b"Alister"[..]);
         assert_eq!(env.receiver, Some(&b"Bobbi"[..]));
-        assert_eq!(env.nonconfidential_data, Some(&b"treasure"[..]));
 
         let DecodedPayload {
             payload: Payload::GenericMessage(data),
@@ -1526,8 +1540,15 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: Some(b"treasure"),
         })
+        .unwrap();
+        // a non-confidential message carries its cleartext -Z## payload in the payload position
+        encode_payload(
+            &Payload::<_, &[u8]>::GenericMessage(b"treasure"),
+            None,
+            None,
+            &mut outer,
+        )
         .unwrap();
         finalize_envelope_frame(&mut outer);
 
@@ -1540,14 +1561,22 @@ mod test {
         assert_eq!(ver.signature, &fixed_sig);
         let DecodedEnvelope {
             envelope: env,
-            ciphertext,
+            payload_position,
             ..
-        } = view.into_opened().unwrap();
+        } = view.into_opened::<&[u8]>().unwrap();
         assert_eq!(env.sender, &b"Alister"[..]);
         assert_eq!(env.receiver, Some(&b"Bobbi"[..]));
-        assert_eq!(env.nonconfidential_data, Some(&b"treasure"[..]));
+        assert_eq!(env.crypto_type, CryptoType::Plaintext);
 
-        assert!(ciphertext.is_none());
+        // the payload position holds the cleartext payload
+        let DecodedPayload {
+            payload: Payload::GenericMessage(data),
+            ..
+        } = decode_payload(payload_position.unwrap()).unwrap()
+        else {
+            unreachable!();
+        };
+        assert_eq!(data, b"treasure");
     }
 
     #[test]
@@ -1566,7 +1595,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: Some(b"treasure"),
         })
         .unwrap();
         // finalizing before the ciphertext is appended produces a frame count
@@ -1594,7 +1622,6 @@ mod test {
                 signature_type: SignatureType::Ed25519,
                 sender: &b"Alister"[..],
                 receiver: Some(&b"Bobbi"[..]),
-                nonconfidential_data: Some(b"treasure"),
             },
             &mut outer,
         )
@@ -1616,7 +1643,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: Some(b"treasure"),
         })
         .unwrap();
         encode_ciphertext(&[], CryptoType::HpkeAuth, &mut outer).unwrap();
@@ -1640,7 +1666,6 @@ mod test {
             Message {
                 sender,
                 receiver,
-                nonconfidential_data: None,
                 message: Payload::GenericMessage(payload),
             },
             |_, vec| vec,
@@ -1666,7 +1691,7 @@ mod test {
 
     #[test]
     #[wasm_bindgen_test]
-    fn mut_envelope_with_nonconfidential_data() {
+    fn mut_envelope_roundtrip() {
         test_turn_around(Payload::GenericMessage(&mut b"Hello TSP!".to_owned()));
     }
 
@@ -1780,7 +1805,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: Some(b"treasure"),
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
@@ -1795,13 +1819,12 @@ mod test {
         assert_eq!(view.as_challenge().signature, &fixed_sig);
         let DecodedEnvelope {
             envelope: env,
-            ciphertext,
+            payload_position: ciphertext,
             ..
         } = view.into_opened::<&[u8]>().unwrap();
 
         assert_eq!(env.sender, &b"Alister"[..]);
         assert_eq!(env.receiver, Some(&b"Bobbi"[..]));
-        assert_eq!(env.nonconfidential_data, Some(&b"treasure"[..]));
 
         assert_eq!(
             decode_payload(dummy_crypt(ciphertext.unwrap()))
@@ -1851,7 +1874,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"did:test:bob"[..],
             receiver: Some(&b"did:test:alice3"[..]),
-            nonconfidential_data: Some(b"extradata"),
         })
         .unwrap();
         encode_ciphertext(&[0xAA; 69], CryptoType::HpkeEssr, &mut message).unwrap();
@@ -1864,7 +1886,6 @@ mod test {
         assert_eq!(parts.prefix.prefix.len(), 9);
         assert_eq!(parts.sender.data.len(), b"did:test:bob".len());
         assert_eq!(parts.receiver.unwrap().data.len(), b"did:test:alice3".len());
-        assert_eq!(parts.nonconfidential_data.unwrap().data.len(), 9);
         assert_eq!(parts.ciphertext.unwrap().data.len(), 69);
         assert_eq!(parts.signature.data.len(), 64);
     }
@@ -1879,8 +1900,14 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: None::<&[u8]>,
-            nonconfidential_data: Some(b"treasure"),
         })
+        .unwrap();
+        encode_payload(
+            &Payload::<_, &[u8]>::GenericMessage(b"treasure"),
+            None,
+            None,
+            &mut outer,
+        )
         .unwrap();
         finalize_envelope_frame(&mut outer);
         encode_signature(&fixed_sig, &mut outer, SignatureType::Ed25519);
@@ -1926,7 +1953,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: Some(b"treasure"),
         })
         .unwrap();
         finalize_envelope_frame(&mut outer);
@@ -1975,7 +2001,6 @@ mod test {
             signature_type: SignatureType::Ed25519,
             sender: &b"Alister"[..],
             receiver: Some(&b"Bobbi"[..]),
-            nonconfidential_data: None,
         })
         .unwrap();
         let ciphertext = dummy_crypt(&mut cesr_payload);
@@ -1993,7 +2018,6 @@ mod test {
         let DecodedEnvelope { envelope: env, .. } = view.into_opened().unwrap();
         assert_eq!(env.sender, &b"Alister"[..]);
         assert_eq!(env.receiver, Some(&b"Bobbi"[..]));
-        assert_eq!(env.nonconfidential_data, None);
 
         let (sender, receiver, _, _) = decode_sender_receiver(&outer2).unwrap();
         assert_eq!(env.sender, sender);

--- a/tsp_sdk/src/cesr/packet/fuzzing.rs
+++ b/tsp_sdk/src/cesr/packet/fuzzing.rs
@@ -177,6 +177,5 @@ pub struct FuzzInput {
     pub sender_enc_key: [u8; 32],
     pub receiver_sign_key: [u8; 32],
     pub receiver_enc_key: [u8; 32],
-    pub nonconfidential_data: Option<Vec<u8>>,
     pub payload: Vec<u8>,
 }

--- a/tsp_sdk/src/crypto/error.rs
+++ b/tsp_sdk/src/crypto/error.rs
@@ -26,6 +26,8 @@ pub enum CryptoError {
     UnexpectedSender,
     #[error("no sender identity found in encrypted message")]
     MissingSender,
+    #[error("embedded digest does not match the message contents")]
+    DigestMismatch,
     #[error("invalid outbound crypto selection {0:?}")]
     InvalidCryptoSelection(CryptoType),
     #[error(

--- a/tsp_sdk/src/crypto/error.rs
+++ b/tsp_sdk/src/crypto/error.rs
@@ -9,8 +9,6 @@ pub enum CryptoError {
     #[error("failed to decode message {0}")]
     Decode(#[from] crate::cesr::error::DecodeError),
     #[error("encryption or decryption failed: {0}")]
-    CryptographicHpkePq(#[from] hpke_pq::HpkeError),
-    #[error("encryption or decryption failed: {0}")]
     CryptographicHpke(#[from] hpke::HpkeError),
     #[error("encryption or decryption failed")]
     CryptographicNacl(#[from] crypto_box::aead::Error),

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -51,6 +51,13 @@ impl RelationshipDigestAlgorithm {
         })
     }
 
+    pub(crate) fn for_field(field: &crate::cesr::Digest) -> Self {
+        match field {
+            crate::cesr::Digest::Sha2_256(_) => RelationshipDigestAlgorithm::Sha2_256,
+            crate::cesr::Digest::Blake2b256(_) => RelationshipDigestAlgorithm::Blake2b256,
+        }
+    }
+
     pub(crate) fn field<'a>(self, digest: &'a Digest) -> crate::cesr::Digest<'a> {
         match self {
             RelationshipDigestAlgorithm::Sha2_256 => crate::cesr::Digest::Sha2_256(digest),
@@ -128,61 +135,79 @@ fn mldsa65_signing_key_from_bytes(
     Ok(ExpandedSigningKey::<MlDsa65>::from_expanded(&signing_key))
 }
 
-fn encode_hashed_payload(
+/// Compute the self-referencing TSP digest (spec 7.2.1) of a relationship
+/// payload: the hash over the envelope prefix and the payload fields, with the
+/// digest's own slot filled with the 0x23 dummy and the padding field excluded
+fn compute_relationship_digest(
     payload: &CesrRelationshipPayload<'_>,
     sender_in_payload: Option<&[u8]>,
+    envelope_prefix: &[u8],
     algorithm: RelationshipDigestAlgorithm,
 ) -> Result<Digest, CryptoError> {
-    let mut encoded = Vec::with_capacity(payload.calculate_size(sender_in_payload));
-    crate::cesr::encode_payload(payload, sender_in_payload, None, &mut encoded)?;
-    Ok(algorithm.hash(&encoded))
+    let mut input = Vec::with_capacity(envelope_prefix.len() + 256);
+    crate::cesr::encode_digest_input(payload, sender_in_payload, envelope_prefix, &mut input)?;
+    Ok(algorithm.hash(&input))
 }
 
 pub(crate) fn build_parallel_request_signed_data(
     sender_in_payload: Option<&[u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
     nonce_bytes: [u8; 16],
+    envelope_prefix: &[u8],
     request_digest: &mut Digest,
     new_vid: &[u8],
 ) -> Result<Vec<u8>, CryptoError> {
+    // the digest is derived first (its own slot dummied, the new-VID signature
+    // not yet present); the signature is then made over the final digest
+    let payload = crate::cesr::Payload::<&[u8], &[u8]>::ParallelRelationProposal {
+        nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+        request_digest: digest_algorithm.field(&*request_digest),
+        sig_new_vid: &[0; 64],
+        new_vid,
+    };
+    *request_digest = compute_relationship_digest(
+        &payload,
+        sender_in_payload,
+        envelope_prefix,
+        digest_algorithm,
+    )?;
+
     let nonce = crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes);
-    let mut signed_data = crate::cesr::encode_parallel_relation_proposal_challenge(
+    Ok(crate::cesr::encode_parallel_relation_proposal_challenge(
         sender_in_payload,
         &nonce,
         digest_algorithm.field(request_digest),
         new_vid,
-    )?;
-    *request_digest = digest_algorithm.hash(&signed_data);
-    signed_data = crate::cesr::encode_parallel_relation_proposal_challenge(
-        sender_in_payload,
-        &nonce,
-        digest_algorithm.field(request_digest),
-        new_vid,
-    )?;
-    Ok(signed_data)
+    )?)
 }
 
 pub(crate) fn build_parallel_accept_signed_data(
     thread_id: &Digest,
     sender_in_payload: Option<&[u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
+    envelope_prefix: &[u8],
     reply_digest: &mut Digest,
     new_vid: &[u8],
 ) -> Result<Vec<u8>, CryptoError> {
-    let mut signed_data = crate::cesr::encode_parallel_relation_affirm_challenge(
+    let payload = crate::cesr::Payload::<&[u8], &[u8]>::ParallelRelationAffirm {
+        request_digest: digest_algorithm.field(thread_id),
+        reply_digest: digest_algorithm.field(&*reply_digest),
+        sig_new_vid: &[0; 64],
+        new_vid,
+    };
+    *reply_digest = compute_relationship_digest(
+        &payload,
+        sender_in_payload,
+        envelope_prefix,
+        digest_algorithm,
+    )?;
+
+    Ok(crate::cesr::encode_parallel_relation_affirm_challenge(
         sender_in_payload,
         digest_algorithm.field(thread_id),
         digest_algorithm.field(reply_digest),
         new_vid,
-    )?;
-    *reply_digest = digest_algorithm.hash(&signed_data);
-    signed_data = crate::cesr::encode_parallel_relation_affirm_challenge(
-        sender_in_payload,
-        digest_algorithm.field(thread_id),
-        digest_algorithm.field(reply_digest),
-        new_vid,
-    )?;
-    Ok(signed_data)
+    )?)
 }
 
 fn relationship_request_payload<'a>(
@@ -236,42 +261,24 @@ pub(crate) fn build_relationship_request_payload<'a>(
     sender_in_payload: Option<&[u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
     nonce_bytes: [u8; 16],
+    envelope_prefix: &[u8],
     request_digest: &'a mut Digest,
 ) -> Result<(CesrRelationshipPayload<'a>, Digest), CryptoError> {
-    match form {
-        RelationshipForm::Direct => {
-            let placeholder_payload =
-                relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest);
-            *request_digest =
-                encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
+    let placeholder =
+        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest);
+    *request_digest = compute_relationship_digest(
+        &placeholder,
+        sender_in_payload,
+        envelope_prefix,
+        digest_algorithm,
+    )?;
 
-            let digest = *request_digest;
+    let digest = *request_digest;
 
-            Ok((
-                relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
-                digest,
-            ))
-        }
-        RelationshipForm::Parallel {
-            new_vid,
-            sig_new_vid: _,
-        } => {
-            build_parallel_request_signed_data(
-                sender_in_payload,
-                digest_algorithm,
-                nonce_bytes,
-                request_digest,
-                new_vid,
-            )?;
-
-            let digest = *request_digest;
-
-            Ok((
-                relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
-                digest,
-            ))
-        }
-    }
+    Ok((
+        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
+        digest,
+    ))
 }
 
 pub(crate) fn build_relationship_accept_payload<'a>(
@@ -279,42 +286,52 @@ pub(crate) fn build_relationship_accept_payload<'a>(
     form: &RelationshipForm<'a, &'a [u8]>,
     sender_in_payload: Option<&[u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
+    envelope_prefix: &[u8],
     reply_digest: &'a mut Digest,
 ) -> Result<(CesrRelationshipPayload<'a>, Digest), CryptoError> {
-    match form {
-        RelationshipForm::Direct => {
-            let placeholder_payload =
-                relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest);
-            *reply_digest =
-                encode_hashed_payload(&placeholder_payload, sender_in_payload, digest_algorithm)?;
+    let placeholder =
+        relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest);
+    *reply_digest = compute_relationship_digest(
+        &placeholder,
+        sender_in_payload,
+        envelope_prefix,
+        digest_algorithm,
+    )?;
 
-            let digest = *reply_digest;
+    let digest = *reply_digest;
 
-            Ok((
-                relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest),
-                digest,
-            ))
-        }
-        RelationshipForm::Parallel {
-            new_vid,
-            sig_new_vid: _,
-        } => {
-            build_parallel_accept_signed_data(
-                thread_id,
-                sender_in_payload,
-                digest_algorithm,
-                reply_digest,
-                new_vid,
-            )?;
+    Ok((
+        relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest),
+        digest,
+    ))
+}
 
-            let digest = *reply_digest;
+/// Verify the embedded self-referencing digest (spec 7.2.1) of a received
+/// relationship-forming payload: recompute it from the envelope prefix and the
+/// decoded payload fields (with the digest's own slot dummied) using the hash
+/// identified by the embedded digest's code, and compare
+pub(crate) fn verify_relationship_digest(
+    payload: &crate::cesr::Payload<'_, impl AsRef<[u8]>, impl AsRef<[u8]>>,
+    sender_identity: Option<&[u8]>,
+    envelope_prefix: &[u8],
+) -> Result<(), CryptoError> {
+    let embedded = match payload {
+        crate::cesr::Payload::DirectRelationProposal { request_digest, .. }
+        | crate::cesr::Payload::ParallelRelationProposal { request_digest, .. } => request_digest,
+        crate::cesr::Payload::DirectRelationAffirm { reply_digest, .. }
+        | crate::cesr::Payload::ParallelRelationAffirm { reply_digest, .. } => reply_digest,
+        _ => return Ok(()),
+    };
 
-            Ok((
-                relationship_accept_payload(thread_id, form, digest_algorithm, &*reply_digest),
-                digest,
-            ))
-        }
+    let algorithm = RelationshipDigestAlgorithm::for_field(embedded);
+    let mut input = Vec::with_capacity(envelope_prefix.len() + 256);
+    crate::cesr::encode_digest_input(payload, sender_identity, envelope_prefix, &mut input)?;
+
+    if algorithm.hash(&input) != *embedded.as_bytes() {
+        return Err(CryptoError::DigestMismatch);
     }
+
+    Ok(())
 }
 
 pub(crate) fn open_relationship_request<'a>(
@@ -682,6 +699,45 @@ mod tests {
     use url::Url;
 
     use super::{CryptoError, open, seal, seal_with_crypto_type, sign};
+
+    #[test]
+    fn relationship_digest_tampering_is_detected() {
+        // a request payload whose embedded digest is the correct SAID verifies;
+        // any other value in the digest slot is rejected
+        let sender = b"did:test:alice".as_slice();
+        let receiver = b"did:test:bob".as_slice();
+        let mut envelope_prefix = Vec::new();
+        crate::cesr::encode_envelope_prefix(sender, Some(receiver), &mut envelope_prefix).unwrap();
+
+        let algorithm = super::RelationshipDigestAlgorithm::Sha2_256;
+        let nonce_bytes = [7_u8; 16];
+        let mut digest = [0_u8; 32];
+        let payload = crate::cesr::Payload::<&[u8], &[u8]>::DirectRelationProposal {
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            request_digest: algorithm.field(&digest),
+        };
+        let mut input = Vec::new();
+        crate::cesr::encode_digest_input(&payload, Some(sender), &envelope_prefix, &mut input)
+            .unwrap();
+        digest = algorithm.hash(&input);
+
+        let good = crate::cesr::Payload::<&[u8], &[u8]>::DirectRelationProposal {
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            request_digest: algorithm.field(&digest),
+        };
+        super::verify_relationship_digest(&good, Some(sender), &envelope_prefix).unwrap();
+
+        let mut tampered_digest = digest;
+        tampered_digest[0] ^= 0x01;
+        let tampered = crate::cesr::Payload::<&[u8], &[u8]>::DirectRelationProposal {
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            request_digest: algorithm.field(&tampered_digest),
+        };
+        assert!(matches!(
+            super::verify_relationship_digest(&tampered, Some(sender), &envelope_prefix),
+            Err(CryptoError::DigestMismatch)
+        ));
+    }
 
     #[test]
     fn seal_open_message() {

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -1,7 +1,7 @@
 use crate::definitions::{
-    Digest, MessageType, NonConfidentialData, Payload, PrivateKeyData, PrivateSigningKeyData,
-    PrivateVid, PublicKeyData, PublicVerificationKeyData, RelationshipForm, TSPMessage,
-    VerifiedVid, VidEncryptionKeyType, VidSignatureKeyType,
+    Digest, MessageType, Payload, PrivateKeyData, PrivateSigningKeyData, PrivateVid, PublicKeyData,
+    PublicVerificationKeyData, RelationshipForm, TSPMessage, VerifiedVid, VidEncryptionKeyType,
+    VidSignatureKeyType,
 };
 use ed25519_dalek::Signer;
 use ml_dsa::{EncodedVerifyingKey, ExpandedSigningKey, ExpandedSigningKeyBytes, MlDsa65};
@@ -399,7 +399,6 @@ pub(crate) fn verify_detached(
 pub fn seal(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     payload: Payload<&[u8]>,
 ) -> Result<TSPMessage, CryptoError> {
     #[cfg(feature = "bench-network-timings")]
@@ -407,7 +406,7 @@ pub fn seal(
     #[cfg(feature = "bench-network-timings")]
     let started = Instant::now();
 
-    let result = seal_and_hash(sender, receiver, nonconfidential_data, payload, None);
+    let result = seal_and_hash(sender, receiver, payload, None);
 
     #[cfg(feature = "bench-network-timings")]
     crate::bench::record_seal_core(started, signature_before);
@@ -419,41 +418,24 @@ pub fn seal(
 pub fn seal_and_hash(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     payload: Payload<&[u8]>,
     digest: Option<&mut Digest>,
 ) -> Result<TSPMessage, CryptoError> {
-    seal_and_hash_with_relationship_nonce(
-        sender,
-        receiver,
-        nonconfidential_data,
-        payload,
-        digest,
-        None,
-    )
+    seal_and_hash_with_relationship_nonce(sender, receiver, payload, digest, None)
 }
 
 pub fn seal_with_crypto_type(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     payload: Payload<&[u8]>,
     crypto_type: CryptoType,
 ) -> Result<TSPMessage, CryptoError> {
-    seal_and_hash_with_crypto_type(
-        sender,
-        receiver,
-        nonconfidential_data,
-        payload,
-        None,
-        crypto_type,
-    )
+    seal_and_hash_with_crypto_type(sender, receiver, payload, None, crypto_type)
 }
 
 pub fn seal_and_hash_with_crypto_type(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     payload: Payload<&[u8]>,
     digest: Option<&mut Digest>,
     crypto_type: CryptoType,
@@ -461,7 +443,6 @@ pub fn seal_and_hash_with_crypto_type(
     seal_with_selection(
         sender,
         receiver,
-        nonconfidential_data,
         payload,
         digest,
         None,
@@ -472,7 +453,6 @@ pub fn seal_and_hash_with_crypto_type(
 pub(crate) fn seal_and_hash_with_relationship_nonce(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     payload: Payload<&[u8]>,
     digest: Option<&mut Digest>,
     request_nonce_override: Option<[u8; 16]>,
@@ -480,7 +460,6 @@ pub(crate) fn seal_and_hash_with_relationship_nonce(
     seal_with_selection(
         sender,
         receiver,
-        nonconfidential_data,
         payload,
         digest,
         request_nonce_override,
@@ -491,7 +470,6 @@ pub(crate) fn seal_and_hash_with_relationship_nonce(
 pub(crate) fn seal_with_selection(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     payload: Payload<&[u8]>,
     digest: Option<&mut Digest>,
     request_nonce_override: Option<[u8; 16]>,
@@ -503,7 +481,6 @@ pub(crate) fn seal_with_selection(
         CryptoType::NaclAuth | CryptoType::NaclEssr => tsp_nacl::seal(
             sender,
             receiver,
-            nonconfidential_data,
             payload,
             digest,
             request_nonce_override,
@@ -512,20 +489,14 @@ pub(crate) fn seal_with_selection(
         CryptoType::HpkeAuth | CryptoType::HpkeEssr => tsp_hpke::seal_x25519(
             sender,
             receiver,
-            nonconfidential_data,
             payload,
             digest,
             request_nonce_override,
             selection.crypto_type,
         ),
-        CryptoType::X25519Kyber768Draft00 => tsp_hpke::seal_pq(
-            sender,
-            receiver,
-            nonconfidential_data,
-            payload,
-            digest,
-            request_nonce_override,
-        ),
+        CryptoType::X25519Kyber768Draft00 => {
+            tsp_hpke::seal_pq(sender, receiver, payload, digest, request_nonce_override)
+        }
         CryptoType::Plaintext => Err(CryptoError::InvalidCryptoSelection(selection.crypto_type)),
     }
 }
@@ -568,7 +539,6 @@ fn ensure_selection_matches_key_types(
 }
 
 pub type MessageContents<'a> = (
-    Option<NonConfidentialData<'a>>,
     Payload<'a, &'a [u8], &'a mut [u8]>,
     crate::cesr::CryptoType,
     crate::cesr::SignatureType,
@@ -615,7 +585,7 @@ pub(crate) fn open_with_signature_info<'a>(
     let crate::cesr::DecodedEnvelope {
         raw_header,
         envelope,
-        ciphertext: Some(ciphertext),
+        payload_position: Some(ciphertext),
     } = view
         .into_opened::<&[u8]>()
         .map_err(|_| crate::cesr::error::DecodeError::VidError)?
@@ -768,20 +738,11 @@ mod tests {
         let bob = OwnedVid::bind("did:test:bob", Url::parse("tcp://127.0.0.1:13372").unwrap());
 
         let secret_message: &[u8] = b"hello world";
-        let nonconfidential_data = b"extra header data";
 
-        let mut message = seal(
-            &bob,
-            &alice,
-            Some(nonconfidential_data),
-            Payload::Content(secret_message),
-        )
-        .unwrap();
+        let mut message = seal(&bob, &alice, Payload::Content(secret_message)).unwrap();
 
-        let (received_nonconfidential_data, received_secret_message, _, _) =
-            open(&alice, &bob, &mut message).unwrap();
+        let (received_secret_message, _, _) = open(&alice, &bob, &mut message).unwrap();
 
-        assert_eq!(received_nonconfidential_data.unwrap(), nonconfidential_data);
         assert_eq!(received_secret_message, Payload::Content(secret_message));
     }
 
@@ -814,13 +775,12 @@ mod tests {
             let mut message = seal_with_crypto_type(
                 &alice,
                 receiver,
-                None,
                 Payload::Content(b"selected backend"),
                 crypto_type,
             )
             .unwrap();
 
-            let (_, payload, opened_crypto_type, _) = open(receiver, &alice, &mut message).unwrap();
+            let (payload, opened_crypto_type, _) = open(receiver, &alice, &mut message).unwrap();
 
             assert_eq!(payload, Payload::Content(b"selected backend" as &[u8]));
             assert_eq!(opened_crypto_type, crypto_type);
@@ -842,8 +802,8 @@ mod tests {
             VidEncryptionKeyType::X25519Kyber768Draft00,
         );
 
-        let mut message = seal(&alice, &bob, None, Payload::Content(b"default pq")).unwrap();
-        let (_, payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
+        let mut message = seal(&alice, &bob, Payload::Content(b"default pq")).unwrap();
+        let (payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
 
         assert_eq!(payload, Payload::Content(b"default pq" as &[u8]));
         assert_eq!(opened_crypto_type, CryptoType::X25519Kyber768Draft00);
@@ -864,8 +824,8 @@ mod tests {
             VidEncryptionKeyType::X25519,
         );
 
-        let mut message = seal(&alice, &bob, None, Payload::Content(b"default hpke essr")).unwrap();
-        let (_, payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
+        let mut message = seal(&alice, &bob, Payload::Content(b"default hpke essr")).unwrap();
+        let (payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
 
         assert_eq!(payload, Payload::Content(b"default hpke essr" as &[u8]));
         assert_eq!(opened_crypto_type, CryptoType::HpkeEssr);
@@ -889,7 +849,6 @@ mod tests {
         let err = seal_with_crypto_type(
             &alice,
             &bob,
-            None,
             Payload::Content(b"selected backend"),
             CryptoType::X25519Kyber768Draft00,
         )
@@ -906,7 +865,6 @@ mod tests {
         let err = seal_with_crypto_type(
             &alice,
             &bob,
-            None,
             Payload::Content(b"selected backend"),
             CryptoType::Plaintext,
         )
@@ -936,7 +894,6 @@ mod tests {
         let err = seal_with_crypto_type(
             &alice,
             &bob,
-            None,
             Payload::Content(b"selected backend"),
             CryptoType::NaclAuth,
         )
@@ -963,7 +920,7 @@ mod tests {
             Url::parse("tcp://127.0.0.1:13373").unwrap(),
         );
 
-        let mut message = seal(&bob, &alice, None, Payload::Content(b"secret")).unwrap();
+        let mut message = seal(&bob, &alice, Payload::Content(b"secret")).unwrap();
 
         let result = open(&carol, &bob, &mut message);
 
@@ -979,7 +936,7 @@ mod tests {
         );
         let bob = OwnedVid::bind("did:test:bob", Url::parse("tcp://127.0.0.1:13372").unwrap());
 
-        let mut message = seal(&bob, &alice, None, Payload::Content(b"secret")).unwrap();
+        let mut message = seal(&bob, &alice, Payload::Content(b"secret")).unwrap();
 
         let wrong_alice = OwnedVid::from_bytes(
             "did:test:alice",
@@ -1001,7 +958,7 @@ mod tests {
         );
         let bob = OwnedVid::bind("did:test:bob", Url::parse("tcp://127.0.0.1:13372").unwrap());
 
-        let mut message = sign(&alice, None, b"hello").unwrap();
+        let mut message = sign(&alice, Some(&bob), b"hello").unwrap();
 
         let result = open(&bob, &alice, &mut message);
 
@@ -1016,7 +973,7 @@ mod tests {
         );
         let bob = OwnedVid::bind("did:test:bob", Url::parse("tcp://127.0.0.1:13372").unwrap());
 
-        let mut message = seal(&bob, &alice, None, Payload::Content(b"secret")).unwrap();
+        let mut message = seal(&bob, &alice, Payload::Content(b"secret")).unwrap();
 
         let last = message.len() - 1;
         message[last] ^= 0xFF;

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -45,10 +45,8 @@ pub(crate) enum RelationshipDigestAlgorithm {
 impl RelationshipDigestAlgorithm {
     pub(crate) fn for_crypto_type(crypto_type: CryptoType) -> Result<Self, CryptoError> {
         Ok(match crypto_type {
-            CryptoType::NaclAuth | CryptoType::NaclEssr => RelationshipDigestAlgorithm::Blake2b256,
-            CryptoType::HpkeAuth | CryptoType::HpkeEssr | CryptoType::X25519Kyber768Draft00 => {
-                RelationshipDigestAlgorithm::Sha2_256
-            }
+            CryptoType::SealedBox => RelationshipDigestAlgorithm::Blake2b256,
+            CryptoType::HpkeBase => RelationshipDigestAlgorithm::Sha2_256,
             CryptoType::Plaintext => return Err(CryptoError::InvalidCryptoSelection(crypto_type)),
         })
     }
@@ -72,26 +70,14 @@ pub(crate) fn default_outbound_crypto_selection(
     sender: &dyn VerifiedVid,
     receiver: &dyn VerifiedVid,
 ) -> OutboundCryptoSelection {
-    let sender_key_type = sender.encryption_key_type();
     let receiver_key_type = receiver.encryption_key_type();
-    let crypto_type = if matches!(
-        receiver_key_type,
-        VidEncryptionKeyType::X25519Kyber768Draft00
-    ) {
-        CryptoType::X25519Kyber768Draft00
-    } else if cfg!(feature = "nacl")
-        && matches!(sender_key_type, VidEncryptionKeyType::X25519)
-        && matches!(receiver_key_type, VidEncryptionKeyType::X25519)
-    {
-        if cfg!(feature = "essr") {
-            CryptoType::NaclEssr
-        } else {
-            CryptoType::NaclAuth
-        }
-    } else if cfg!(feature = "essr") || !matches!(sender_key_type, VidEncryptionKeyType::X25519) {
-        CryptoType::HpkeEssr
+    let _ = sender;
+    let crypto_type = if matches!(receiver_key_type, VidEncryptionKeyType::X25519MlKem768) {
+        CryptoType::HpkeBase
+    } else if cfg!(feature = "nacl") {
+        CryptoType::SealedBox
     } else {
-        CryptoType::HpkeAuth
+        CryptoType::HpkeBase
     };
 
     OutboundCryptoSelection { crypto_type }
@@ -478,24 +464,11 @@ pub(crate) fn seal_with_selection(
     ensure_selection_matches_key_types(sender, receiver, selection.crypto_type)?;
 
     match selection.crypto_type {
-        CryptoType::NaclAuth | CryptoType::NaclEssr => tsp_nacl::seal(
-            sender,
-            receiver,
-            payload,
-            digest,
-            request_nonce_override,
-            selection.crypto_type,
-        ),
-        CryptoType::HpkeAuth | CryptoType::HpkeEssr => tsp_hpke::seal_x25519(
-            sender,
-            receiver,
-            payload,
-            digest,
-            request_nonce_override,
-            selection.crypto_type,
-        ),
-        CryptoType::X25519Kyber768Draft00 => {
-            tsp_hpke::seal_pq(sender, receiver, payload, digest, request_nonce_override)
+        CryptoType::SealedBox => {
+            tsp_nacl::seal(sender, receiver, payload, digest, request_nonce_override)
+        }
+        CryptoType::HpkeBase => {
+            tsp_hpke::seal(sender, receiver, payload, digest, request_nonce_override)
         }
         CryptoType::Plaintext => Err(CryptoError::InvalidCryptoSelection(selection.crypto_type)),
     }
@@ -506,33 +479,22 @@ fn ensure_selection_matches_key_types(
     receiver: &dyn VerifiedVid,
     crypto_type: CryptoType,
 ) -> Result<(), CryptoError> {
-    let expected_receiver = match crypto_type {
-        CryptoType::NaclAuth
-        | CryptoType::NaclEssr
-        | CryptoType::HpkeAuth
-        | CryptoType::HpkeEssr => VidEncryptionKeyType::X25519,
-        CryptoType::X25519Kyber768Draft00 => VidEncryptionKeyType::X25519Kyber768Draft00,
-        CryptoType::Plaintext => return Err(CryptoError::InvalidCryptoSelection(crypto_type)),
-    };
-
+    let _ = sender;
     let receiver_key_type = receiver.encryption_key_type();
-    if receiver_key_type != expected_receiver {
-        return Err(CryptoError::IncompatibleCryptoSelection {
-            crypto_type,
-            key_type: receiver_key_type,
-        });
-    }
-
-    let sender_requires_x25519 = matches!(
-        crypto_type,
-        CryptoType::NaclAuth | CryptoType::NaclEssr | CryptoType::HpkeAuth
-    );
-    let sender_key_type = sender.encryption_key_type();
-    if sender_requires_x25519 && !matches!(sender_key_type, VidEncryptionKeyType::X25519) {
-        return Err(CryptoError::IncompatibleSenderCryptoSelection {
-            crypto_type,
-            key_type: sender_key_type,
-        });
+    match crypto_type {
+        // the sealed box requires an X25519 recipient key; HPKE-Base accepts
+        // any supported KEM key type. Neither uses the sender's encryption
+        // keys: HPKE-Base and the anonymous sealed box need no sender KEM key.
+        CryptoType::SealedBox => {
+            if receiver_key_type != VidEncryptionKeyType::X25519 {
+                return Err(CryptoError::IncompatibleCryptoSelection {
+                    crypto_type,
+                    key_type: receiver_key_type,
+                });
+            }
+        }
+        CryptoType::HpkeBase => {}
+        CryptoType::Plaintext => return Err(CryptoError::InvalidCryptoSelection(crypto_type)),
     }
 
     Ok(())
@@ -599,15 +561,8 @@ pub(crate) fn open_with_signature_info<'a>(
     }
 
     let result = match envelope.crypto_type {
-        CryptoType::X25519Kyber768Draft00 => {
-            tsp_hpke::open_pq(receiver, sender, raw_header, envelope, ciphertext)
-        }
-        CryptoType::HpkeAuth | CryptoType::HpkeEssr => {
-            tsp_hpke::open_x25519(receiver, sender, raw_header, envelope, ciphertext)
-        }
-        CryptoType::NaclAuth | CryptoType::NaclEssr => {
-            tsp_nacl::open(receiver, sender, raw_header, envelope, ciphertext)
-        }
+        CryptoType::HpkeBase => tsp_hpke::open(receiver, sender, raw_header, envelope, ciphertext),
+        CryptoType::SealedBox => tsp_nacl::open(receiver, sender, raw_header, envelope, ciphertext),
         CryptoType::Plaintext => Err(CryptoError::MissingCiphertext),
     };
     #[cfg(feature = "bench-network-timings")]
@@ -635,7 +590,7 @@ pub fn verify<'a>(
 
 pub fn default_encryption_key_type() -> VidEncryptionKeyType {
     if cfg!(feature = "pq") {
-        VidEncryptionKeyType::X25519Kyber768Draft00
+        VidEncryptionKeyType::X25519MlKem768
     } else {
         VidEncryptionKeyType::X25519
     }
@@ -668,11 +623,10 @@ pub fn gen_encrypt_keypair_for(key_type: VidEncryptionKeyType) -> (PrivateKeyDat
                     .into(),
             )
         }
-        VidEncryptionKeyType::X25519Kyber768Draft00 => {
-            use hpke_pq::Serializable;
+        VidEncryptionKeyType::X25519MlKem768 => {
+            use hpke::Serializable;
 
-            let (private, public) =
-                <hpke_pq::kem::X25519Kyber768Draft00 as hpke_pq::Kem>::gen_keypair(&mut OsRng);
+            let (private, public) = <hpke::kem::XWing as hpke::Kem>::gen_keypair();
 
             let private = private.to_bytes();
             let public = public.to_bytes();
@@ -764,13 +718,13 @@ mod tests {
             "did:test:bob-pq-explicit",
             Url::parse("tcp://127.0.0.1:13383").unwrap(),
             VidSignatureKeyType::Ed25519,
-            VidEncryptionKeyType::X25519Kyber768Draft00,
+            VidEncryptionKeyType::X25519MlKem768,
         );
 
         for (receiver, crypto_type) in [
-            (&bob_x25519, CryptoType::HpkeAuth),
-            (&bob_x25519, CryptoType::NaclAuth),
-            (&bob_pq, CryptoType::X25519Kyber768Draft00),
+            (&bob_x25519, CryptoType::HpkeBase),
+            (&bob_x25519, CryptoType::SealedBox),
+            (&bob_pq, CryptoType::HpkeBase),
         ] {
             let mut message = seal_with_crypto_type(
                 &alice,
@@ -799,23 +753,23 @@ mod tests {
             "did:test:bob-default-pq",
             Url::parse("tcp://127.0.0.1:13387").unwrap(),
             VidSignatureKeyType::Ed25519,
-            VidEncryptionKeyType::X25519Kyber768Draft00,
+            VidEncryptionKeyType::X25519MlKem768,
         );
 
         let mut message = seal(&alice, &bob, Payload::Content(b"default pq")).unwrap();
         let (payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
 
         assert_eq!(payload, Payload::Content(b"default pq" as &[u8]));
-        assert_eq!(opened_crypto_type, CryptoType::X25519Kyber768Draft00);
+        assert_eq!(opened_crypto_type, CryptoType::HpkeBase);
     }
 
     #[test]
-    fn default_selection_avoids_nacl_for_pq_sender_to_x25519_receiver() {
+    fn default_selection_for_pq_sender_to_x25519_receiver() {
         let alice = OwnedVid::bind_with_key_types(
             "did:test:alice-pq-to-x25519-default",
             Url::parse("tcp://127.0.0.1:13388").unwrap(),
             VidSignatureKeyType::Ed25519,
-            VidEncryptionKeyType::X25519Kyber768Draft00,
+            VidEncryptionKeyType::X25519MlKem768,
         );
         let bob = OwnedVid::bind_with_key_types(
             "did:test:bob-x25519-from-pq-default",
@@ -824,11 +778,19 @@ mod tests {
             VidEncryptionKeyType::X25519,
         );
 
-        let mut message = seal(&alice, &bob, Payload::Content(b"default hpke essr")).unwrap();
+        // the anonymous sealed box does not use the sender's encryption keys,
+        // so a PQ-keyed sender can seal to an X25519 receiver with either suite;
+        // the default follows the feature configuration
+        let mut message = seal(&alice, &bob, Payload::Content(b"default suite")).unwrap();
         let (payload, opened_crypto_type, _) = open(&bob, &alice, &mut message).unwrap();
 
-        assert_eq!(payload, Payload::Content(b"default hpke essr" as &[u8]));
-        assert_eq!(opened_crypto_type, CryptoType::HpkeEssr);
+        assert_eq!(payload, Payload::Content(b"default suite" as &[u8]));
+        let expected = if cfg!(feature = "nacl") {
+            CryptoType::SealedBox
+        } else {
+            CryptoType::HpkeBase
+        };
+        assert_eq!(opened_crypto_type, expected);
     }
 
     #[test]
@@ -850,22 +812,6 @@ mod tests {
             &alice,
             &bob,
             Payload::Content(b"selected backend"),
-            CryptoType::X25519Kyber768Draft00,
-        )
-        .unwrap_err();
-
-        assert!(matches!(
-            err,
-            CryptoError::IncompatibleCryptoSelection {
-                crypto_type: CryptoType::X25519Kyber768Draft00,
-                key_type: VidEncryptionKeyType::X25519,
-            }
-        ));
-
-        let err = seal_with_crypto_type(
-            &alice,
-            &bob,
-            Payload::Content(b"selected backend"),
             CryptoType::Plaintext,
         )
         .unwrap_err();
@@ -877,33 +823,33 @@ mod tests {
     }
 
     #[test]
-    fn explicit_crypto_selection_rejects_incompatible_sender_key() {
+    fn sealed_box_rejects_pq_receiver_key() {
         let alice = OwnedVid::bind_with_key_types(
-            "did:test:alice-pq-incompatible",
+            "did:test:alice-sealedbox",
             Url::parse("tcp://127.0.0.1:13390").unwrap(),
             VidSignatureKeyType::Ed25519,
-            VidEncryptionKeyType::X25519Kyber768Draft00,
+            VidEncryptionKeyType::X25519,
         );
         let bob = OwnedVid::bind_with_key_types(
-            "did:test:bob-x25519-incompatible",
+            "did:test:bob-pq-sealedbox",
             Url::parse("tcp://127.0.0.1:13391").unwrap(),
             VidSignatureKeyType::Ed25519,
-            VidEncryptionKeyType::X25519,
+            VidEncryptionKeyType::X25519MlKem768,
         );
 
         let err = seal_with_crypto_type(
             &alice,
             &bob,
             Payload::Content(b"selected backend"),
-            CryptoType::NaclAuth,
+            CryptoType::SealedBox,
         )
         .unwrap_err();
 
         assert!(matches!(
             err,
-            CryptoError::IncompatibleSenderCryptoSelection {
-                crypto_type: CryptoType::NaclAuth,
-                key_type: VidEncryptionKeyType::X25519Kyber768Draft00,
+            CryptoError::IncompatibleCryptoSelection {
+                crypto_type: CryptoType::SealedBox,
+                key_type: VidEncryptionKeyType::X25519MlKem768,
             }
         ));
     }

--- a/tsp_sdk/src/crypto/nonconfidential.rs
+++ b/tsp_sdk/src/crypto/nonconfidential.rs
@@ -1,12 +1,11 @@
 use super::{CryptoError, append_signature, signature_type};
-use crate::crypto::CryptoError::Verify;
 use crate::{
-    cesr::{CryptoType, DecodedEnvelope, Envelope, SignatureType},
+    cesr::{CryptoType, DecodedEnvelope, DecodedPayload, Envelope},
     definitions::{MessageType, PrivateVid, TSPMessage, VerifiedVid},
 };
-use ml_dsa::{EncodedVerifyingKey, MlDsa65};
 
-/// Construct and sign a non-confidential TSP message
+/// Construct and sign a non-confidential TSP message; the payload is carried
+/// as a cleartext -Z## payload in the payload position
 pub fn sign(
     sender: &dyn PrivateVid,
     receiver: Option<&dyn VerifiedVid>,
@@ -15,13 +14,19 @@ pub fn sign(
     let mut data = Vec::with_capacity(64);
 
     crate::cesr::encode_envelope(
-        crate::cesr::Envelope {
+        Envelope {
             crypto_type: CryptoType::Plaintext,
             signature_type: signature_type(sender),
             sender: sender.identifier(),
             receiver: receiver.map(|r| r.identifier()),
-            nonconfidential_data: Some(payload),
         },
+        &mut data,
+    )?;
+
+    crate::cesr::encode_payload(
+        &crate::cesr::Payload::<_, &[u8]>::GenericMessage(payload),
+        None,
+        None,
         &mut data,
     )?;
     crate::cesr::finalize_envelope_frame(&mut data);
@@ -36,49 +41,17 @@ pub fn verify<'a>(
     sender: &dyn VerifiedVid,
     tsp_message: &'a mut [u8],
 ) -> Result<(&'a [u8], MessageType), CryptoError> {
-    #[cfg(feature = "bench-network-timings")]
-    let open_core_started = std::time::Instant::now();
     let view = crate::cesr::decode_envelope(tsp_message)?;
-    #[cfg(feature = "bench-network-timings")]
-    crate::bench::record_open_core(open_core_started);
 
     // verify outer signature
     let verification_challenge = view.as_challenge();
-    #[cfg(feature = "bench-network-timings")]
-    let verify_started = std::time::Instant::now();
-    match view.signature_type() {
-        SignatureType::NoSignature => {}
-        SignatureType::Ed25519 => {
-            let signature = ed25519_dalek::Signature::from_slice(verification_challenge.signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
-            let verifying_key =
-                ed25519_dalek::VerifyingKey::try_from(sender.verifying_key().as_slice())
-                    .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
-            verifying_key
-                .verify_strict(verification_challenge.signed_data, &signature)
-                .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
-        }
-        SignatureType::MlDsa65 => {
-            let signature: ml_dsa::Signature<MlDsa65> =
-                ml_dsa::Signature::try_from(verification_challenge.signature)
-                    .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
-            let verifying_key = ml_dsa::VerifyingKey::decode(
-                &EncodedVerifyingKey::<MlDsa65>::try_from(sender.verifying_key().as_slice())?,
-            );
-            ml_dsa::Verifier::verify(
-                &verifying_key,
-                verification_challenge.signed_data,
-                &signature,
-            )
-            .map_err(|err| Verify(sender.identifier().to_string(), err.to_string()))?;
-        }
-    }
-    #[cfg(feature = "bench-network-timings")]
-    crate::bench::record_verify(verify_started);
+    super::verify_detached(
+        sender,
+        verification_challenge.signed_data,
+        verification_challenge.signature,
+    )?;
 
-    // decode envelope
-    #[cfg(feature = "bench-network-timings")]
-    let open_core_started = std::time::Instant::now();
+    // decode envelope; a non-confidential message has a cleartext payload
     let DecodedEnvelope {
         raw_header: _,
         envelope:
@@ -87,9 +60,8 @@ pub fn verify<'a>(
                 signature_type,
                 sender: _,
                 receiver: _,
-                nonconfidential_data: Some(nonconfidential_data),
             },
-        ciphertext: None,
+        payload_position: Some(payload),
     } = view
         .into_opened::<&[u8]>()
         .map_err(|_| crate::cesr::error::DecodeError::VidError)?
@@ -97,11 +69,20 @@ pub fn verify<'a>(
         return Err(CryptoError::MissingCiphertext);
     };
 
-    #[cfg(feature = "bench-network-timings")]
-    crate::bench::record_open_core(open_core_started);
+    if crypto_type != CryptoType::Plaintext {
+        return Err(CryptoError::MissingCiphertext);
+    }
+
+    let DecodedPayload {
+        payload: decoded, ..
+    } = crate::cesr::decode_payload(payload)?;
+    let crate::cesr::Payload::GenericMessage(message) = decoded else {
+        // other payload types in signed-only messages are not yet surfaced
+        return Err(CryptoError::UnsupportedPayload);
+    };
 
     Ok((
-        nonconfidential_data,
+        message,
         MessageType {
             crypto_type,
             signature_type,

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -1,16 +1,10 @@
 use crate::{
     cesr::{CryptoType, DecodedPayload, Envelope},
-    definitions::{Payload, PrivateVid, TSPMessage, VerifiedVid},
+    definitions::{Payload, PrivateVid, TSPMessage, VerifiedVid, VidEncryptionKeyType},
 };
 use hpke::{
-    Deserializable, OpModeR, OpModeS, Serializable, inout::InOutBuf,
-    single_shot_open_inout_detached, single_shot_seal_inout_detached,
-};
-use hpke_pq::{
-    Deserializable as PqDeserializable, OpModeR as PqOpModeR, OpModeS as PqOpModeS,
-    Serializable as PqSerializable,
-    single_shot_open_in_place_detached as pq_single_shot_open_in_place_detached,
-    single_shot_seal_in_place_detached as pq_single_shot_seal_in_place_detached,
+    Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable, aead::AeadTag,
+    inout::InOutBuf, single_shot_open_inout_detached, single_shot_seal_inout_detached,
 };
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 
@@ -20,13 +14,16 @@ use super::{
     open_relationship_accept, open_relationship_request, signature_type,
 };
 
-type X25519Aead = hpke::aead::ChaCha20Poly1305;
-type X25519Kdf = hpke::kdf::HkdfSha256;
+type Aead = hpke::aead::ChaCha20Poly1305;
+type Kdf = hpke::kdf::HkdfSha256;
 type X25519Kem = hpke::kem::X25519HkdfSha256;
+/// The PQ/T hybrid KEM X25519MLKEM768 (HPKE KEM id 0x647a); there is no separate
+/// post-quantum ciphertext code or mode -- only the KEM differs (spec 8.2.3)
+type PqKem = hpke::kem::XWing;
 
-type PqAead = hpke_pq::aead::ChaCha20Poly1305;
-type PqKdf = hpke_pq::kdf::HkdfSha256;
-type PqKem = hpke_pq::kem::X25519Kyber768Draft00;
+/// The HPKE `info` input: the TSP protocol CESR code (spec 8.2.2, 9.1)
+const HPKE_INFO: &[u8] = b"YTSP-";
+
 type SealPayload<'a> = crate::cesr::Payload<'a, &'a [u8], &'a [u8]>;
 type PreparedPayload<'a> = (SealPayload<'a>, Option<super::Digest>);
 
@@ -91,21 +88,46 @@ fn payload_for_seal<'a>(
     Ok((payload, payload_digest_override))
 }
 
-pub(crate) fn seal_x25519(
+/// Seal a message with HPKE-Base (spec 8.2.2). The KEM is selected by the
+/// recipient VID's encryption key type; everything else is identical.
+pub(crate) fn seal(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
     request_nonce_override: Option<[u8; 16]>,
-    crypto_type: CryptoType,
 ) -> Result<TSPMessage, CryptoError> {
-    if !matches!(crypto_type, CryptoType::HpkeAuth | CryptoType::HpkeEssr) {
-        return Err(CryptoError::InvalidCryptoSelection(crypto_type));
+    match receiver.encryption_key_type() {
+        VidEncryptionKeyType::X25519 => seal_with_kem::<X25519Kem>(
+            sender,
+            receiver,
+            secret_payload,
+            digest,
+            request_nonce_override,
+        ),
+        VidEncryptionKeyType::X25519MlKem768 => seal_with_kem::<PqKem>(
+            sender,
+            receiver,
+            secret_payload,
+            digest,
+            request_nonce_override,
+        ),
     }
+}
 
+fn seal_with_kem<Kem: KemTrait>(
+    sender: &dyn PrivateVid,
+    receiver: &dyn VerifiedVid,
+    secret_payload: Payload<&[u8]>,
+    digest: Option<&mut super::Digest>,
+    request_nonce_override: Option<[u8; 16]>,
+) -> Result<TSPMessage, CryptoError> {
+    let crypto_type = CryptoType::HpkeBase;
     let mut csprng = StdRng::from_entropy();
     let mut data = Vec::with_capacity(64);
 
+    // the envelope fields (version, sender VID, receiver VID); these are
+    // exactly the aad of the spec: aad = CONCAT(TSP_Version, VID_sndr, VID_rcvr)
     crate::cesr::encode_envelope(
         crate::cesr::Envelope {
             crypto_type,
@@ -130,183 +152,84 @@ pub(crate) fn seal_x25519(
         &mut reply_digest_storage,
     )?;
 
-    let mut cesr_message = Vec::with_capacity(
-        secret_payload.calculate_size(sender_in_payload)
-            + hpke::aead::AeadTag::<X25519Aead>::size()
-            + <X25519Kem as hpke::Kem>::EncappedKey::size(),
-    );
+    let mut cesr_message = Vec::with_capacity(secret_payload.calculate_size(sender_in_payload));
     crate::cesr::encode_payload(&secret_payload, sender_in_payload, None, &mut cesr_message)?;
-
-    let mode = if crypto_type == CryptoType::HpkeEssr {
-        OpModeS::Base
-    } else {
-        let sender_decryption_key =
-            <X25519Kem as hpke::Kem>::PrivateKey::from_bytes(sender.decryption_key().as_ref())?;
-        let sender_encryption_key =
-            <X25519Kem as hpke::Kem>::PublicKey::from_bytes(sender.encryption_key().as_ref())?;
-
-        OpModeS::Auth((sender_decryption_key, sender_encryption_key))
-    };
-
-    let message_receiver =
-        <X25519Kem as hpke::Kem>::PublicKey::from_bytes(receiver.encryption_key().as_ref())?;
 
     if let Some(digest) = digest {
         *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
     }
 
-    let (encapped_key, tag) = single_shot_seal_inout_detached::<X25519Aead, X25519Kdf, X25519Kem>(
-        &mode,
+    let message_receiver = Kem::PublicKey::from_bytes(receiver.encryption_key().as_ref())?;
+
+    let (encapped_key, tag) = single_shot_seal_inout_detached::<Aead, Kdf, Kem>(
+        &OpModeS::Base,
         &message_receiver,
-        &data,
+        HPKE_INFO,
         InOutBuf::from(cesr_message.as_mut_slice()),
-        &[],
-    )?;
-
-    cesr_message.extend(tag.to_bytes());
-    cesr_message.extend(encapped_key.to_bytes());
-    crate::cesr::encode_ciphertext(&cesr_message, crypto_type, &mut data)?;
-    crate::cesr::finalize_envelope_frame(&mut data);
-    append_signature(sender, &mut data)?;
-
-    Ok(data)
-}
-
-pub(crate) fn seal_pq(
-    sender: &dyn PrivateVid,
-    receiver: &dyn VerifiedVid,
-    secret_payload: Payload<&[u8]>,
-    digest: Option<&mut super::Digest>,
-    request_nonce_override: Option<[u8; 16]>,
-) -> Result<TSPMessage, CryptoError> {
-    let crypto_type = CryptoType::X25519Kyber768Draft00;
-    let mut csprng = StdRng::from_entropy();
-    let mut data = Vec::with_capacity(64);
-
-    crate::cesr::encode_envelope(
-        crate::cesr::Envelope {
-            crypto_type,
-            signature_type: signature_type(sender),
-            sender: sender.identifier(),
-            receiver: Some(receiver.identifier()),
-        },
-        &mut data,
-    )?;
-
-    let sender_in_payload = Some(sender.identifier().as_bytes());
-    let mut request_digest_storage = [0_u8; 32];
-    let mut reply_digest_storage = [0_u8; 32];
-    let digest_algorithm = RelationshipDigestAlgorithm::for_crypto_type(crypto_type)?;
-    let (secret_payload, payload_digest_override) = payload_for_seal(
-        &secret_payload,
-        sender_in_payload,
-        digest_algorithm,
-        request_nonce_override,
-        &mut csprng,
-        &mut request_digest_storage,
-        &mut reply_digest_storage,
-    )?;
-
-    let mut cesr_message = Vec::with_capacity(
-        secret_payload.calculate_size(sender_in_payload)
-            + hpke_pq::aead::AeadTag::<PqAead>::size()
-            + <PqKem as hpke_pq::Kem>::EncappedKey::size(),
-    );
-    crate::cesr::encode_payload(&secret_payload, sender_in_payload, None, &mut cesr_message)?;
-
-    let message_receiver =
-        <PqKem as hpke_pq::Kem>::PublicKey::from_bytes(receiver.encryption_key().as_ref())?;
-
-    if let Some(digest) = digest {
-        *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
-    }
-
-    let (encapped_key, tag) = pq_single_shot_seal_in_place_detached::<PqAead, PqKdf, PqKem, StdRng>(
-        &PqOpModeS::Base,
-        &message_receiver,
         &data,
-        &mut cesr_message,
-        &[],
-        &mut csprng,
     )?;
 
-    cesr_message.extend(tag.to_bytes());
-    cesr_message.extend(encapped_key.to_bytes());
-    crate::cesr::encode_ciphertext(&cesr_message, crypto_type, &mut data)?;
+    // the wire ciphertext is CONCAT(enc, ct), with the AEAD tag inside ct (spec 9.2.8)
+    let encapped_key = encapped_key.to_bytes();
+    let mut ciphertext =
+        Vec::with_capacity(encapped_key.len() + cesr_message.len() + AeadTag::<Aead>::size());
+    ciphertext.extend(encapped_key.as_slice());
+    ciphertext.extend(&cesr_message);
+    ciphertext.extend(tag.to_bytes());
+
+    crate::cesr::encode_ciphertext(&ciphertext, crypto_type, &mut data)?;
     crate::cesr::finalize_envelope_frame(&mut data);
     append_signature(sender, &mut data)?;
 
     Ok(data)
 }
 
-pub(crate) fn open_x25519<'a>(
+/// Open an HPKE-Base message; the KEM is selected by the receiving VID's key type
+pub(crate) fn open<'a>(
     receiver: &dyn PrivateVid,
     sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
-    let (ciphertext, footer) = ciphertext.split_at_mut(
-        ciphertext.len()
-            - hpke::aead::AeadTag::<X25519Aead>::size()
-            - <X25519Kem as hpke::Kem>::EncappedKey::size(),
-    );
-    let (tag, encapped_key) =
-        footer.split_at(footer.len() - <X25519Kem as hpke::Kem>::EncappedKey::size());
-
-    let receiver_decryption_key =
-        <X25519Kem as hpke::Kem>::PrivateKey::from_bytes(receiver.decryption_key().as_ref())?;
-    let encapped_key = <X25519Kem as hpke::Kem>::EncappedKey::from_bytes(encapped_key)?;
-    let tag = hpke::aead::AeadTag::<X25519Aead>::from_bytes(tag)?;
-
-    let mode = if envelope.crypto_type == CryptoType::HpkeEssr {
-        OpModeR::Base
-    } else {
-        let sender_encryption_key =
-            <X25519Kem as hpke::Kem>::PublicKey::from_bytes(sender.encryption_key().as_ref())?;
-        OpModeR::Auth(sender_encryption_key)
-    };
-
-    single_shot_open_inout_detached::<X25519Aead, X25519Kdf, X25519Kem>(
-        &mode,
-        &receiver_decryption_key,
-        &encapped_key,
-        raw_header,
-        InOutBuf::from(&mut *ciphertext),
-        &[],
-        &tag,
-    )?;
-
-    open_payload(sender, envelope, ciphertext)
+    match receiver.encryption_key_type() {
+        VidEncryptionKeyType::X25519 => {
+            open_with_kem::<X25519Kem>(receiver, sender, raw_header, envelope, ciphertext)
+        }
+        VidEncryptionKeyType::X25519MlKem768 => {
+            open_with_kem::<PqKem>(receiver, sender, raw_header, envelope, ciphertext)
+        }
+    }
 }
 
-pub(crate) fn open_pq<'a>(
+fn open_with_kem<'a, Kem: KemTrait>(
     receiver: &dyn PrivateVid,
     sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
-    let (ciphertext, footer) = ciphertext.split_at_mut(
-        ciphertext.len()
-            - hpke_pq::aead::AeadTag::<PqAead>::size()
-            - <PqKem as hpke_pq::Kem>::EncappedKey::size(),
-    );
-    let (tag, encapped_key) =
-        footer.split_at(footer.len() - <PqKem as hpke_pq::Kem>::EncappedKey::size());
+    // the wire ciphertext is CONCAT(enc, ct); the encapsulated key size is
+    // known from the KEM, and the AEAD tag sits at the end of ct
+    let enc_size = Kem::EncappedKey::size();
+    let tag_size = AeadTag::<Aead>::size();
+    if ciphertext.len() < enc_size + tag_size {
+        return Err(CryptoError::MissingCiphertext);
+    }
+    let (encapped_key, rest) = ciphertext.split_at_mut(enc_size);
+    let (ciphertext, tag) = rest.split_at_mut(rest.len() - tag_size);
 
-    let receiver_decryption_key =
-        <PqKem as hpke_pq::Kem>::PrivateKey::from_bytes(receiver.decryption_key().as_ref())?;
-    let encapped_key = <PqKem as hpke_pq::Kem>::EncappedKey::from_bytes(encapped_key)?;
-    let tag = hpke_pq::aead::AeadTag::<PqAead>::from_bytes(tag)?;
+    let receiver_decryption_key = Kem::PrivateKey::from_bytes(receiver.decryption_key().as_ref())?;
+    let encapped_key = Kem::EncappedKey::from_bytes(encapped_key)?;
+    let tag = AeadTag::<Aead>::from_bytes(tag)?;
 
-    pq_single_shot_open_in_place_detached::<PqAead, PqKdf, PqKem>(
-        &PqOpModeR::Base,
+    single_shot_open_inout_detached::<Aead, Kdf, Kem>(
+        &OpModeR::Base,
         &receiver_decryption_key,
         &encapped_key,
+        HPKE_INFO,
+        InOutBuf::from(&mut *ciphertext),
         raw_header,
-        ciphertext,
-        &[],
         &tag,
     )?;
 
@@ -324,15 +247,12 @@ fn open_payload<'a>(
         sender_identity,
     } = crate::cesr::decode_payload(ciphertext)?;
 
-    if envelope.crypto_type == CryptoType::HpkeEssr {
-        match sender_identity {
-            Some(id) => {
-                if id != sender.identifier().as_bytes() {
-                    return Err(CryptoError::UnexpectedSender);
-                }
-            }
-            None => return Err(CryptoError::MissingSender),
-        }
+    // In HPKE-Base the sender-VID confidential field is optional (the aad binds
+    // the sender identity); when present it MUST match the envelope (spec 8.2.2)
+    if let Some(id) = sender_identity
+        && id != sender.identifier().as_bytes()
+    {
+        return Err(CryptoError::UnexpectedSender);
     }
 
     let (secret_payload, parallel_signature_info) = match payload {

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -27,10 +27,12 @@ const HPKE_INFO: &[u8] = b"YTSP-";
 type SealPayload<'a> = crate::cesr::Payload<'a, &'a [u8], &'a [u8]>;
 type PreparedPayload<'a> = (SealPayload<'a>, Option<super::Digest>);
 
+#[allow(clippy::too_many_arguments)]
 fn payload_for_seal<'a>(
     secret_payload: &'a Payload<'a, &'a [u8]>,
     sender_in_payload: Option<&'a [u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
+    envelope_prefix: &[u8],
     request_nonce_override: Option<[u8; 16]>,
     csprng: &mut StdRng,
     request_digest_storage: &'a mut super::Digest,
@@ -55,6 +57,7 @@ fn payload_for_seal<'a>(
                 sender_in_payload,
                 digest_algorithm,
                 nonce_bytes,
+                envelope_prefix,
                 request_digest_storage,
             )?;
             payload_digest_override = Some(payload_digest);
@@ -70,6 +73,7 @@ fn payload_for_seal<'a>(
                 form,
                 sender_in_payload,
                 digest_algorithm,
+                envelope_prefix,
                 reply_digest_storage,
             )?;
             payload_digest_override = Some(payload_digest);
@@ -146,6 +150,7 @@ fn seal_with_kem<Kem: KemTrait>(
         &secret_payload,
         sender_in_payload,
         digest_algorithm,
+        &data,
         request_nonce_override,
         &mut csprng,
         &mut request_digest_storage,
@@ -233,11 +238,12 @@ fn open_with_kem<'a, Kem: KemTrait>(
         &tag,
     )?;
 
-    open_payload(sender, envelope, ciphertext)
+    open_payload(sender, raw_header, envelope, ciphertext)
 }
 
 fn open_payload<'a>(
     sender: &dyn VerifiedVid,
+    raw_header: &[u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
@@ -246,6 +252,9 @@ fn open_payload<'a>(
         payload,
         sender_identity,
     } = crate::cesr::decode_payload(ciphertext)?;
+
+    // verify the embedded self-referencing digest of relationship payloads
+    super::verify_relationship_digest(&payload, sender_identity, raw_header)?;
 
     // In HPKE-Base the sender-VID confidential field is optional (the aad binds
     // the sender identity); when present it MUST match the envelope (spec 8.2.2)

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -1,6 +1,6 @@
 use crate::{
     cesr::{CryptoType, DecodedPayload, Envelope},
-    definitions::{NonConfidentialData, Payload, PrivateVid, TSPMessage, VerifiedVid},
+    definitions::{Payload, PrivateVid, TSPMessage, VerifiedVid},
 };
 use hpke::{
     Deserializable, OpModeR, OpModeS, Serializable, inout::InOutBuf,
@@ -94,7 +94,6 @@ fn payload_for_seal<'a>(
 pub(crate) fn seal_x25519(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
     request_nonce_override: Option<[u8; 16]>,
@@ -113,7 +112,6 @@ pub(crate) fn seal_x25519(
             signature_type: signature_type(sender),
             sender: sender.identifier(),
             receiver: Some(receiver.identifier()),
-            nonconfidential_data,
         },
         &mut data,
     )?;
@@ -177,7 +175,6 @@ pub(crate) fn seal_x25519(
 pub(crate) fn seal_pq(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
     request_nonce_override: Option<[u8; 16]>,
@@ -192,7 +189,6 @@ pub(crate) fn seal_pq(
             signature_type: signature_type(sender),
             sender: sender.identifier(),
             receiver: Some(receiver.identifier()),
-            nonconfidential_data,
         },
         &mut data,
     )?;
@@ -247,7 +243,7 @@ pub(crate) fn open_x25519<'a>(
     receiver: &dyn PrivateVid,
     sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
-    envelope: Envelope<'a, &[u8]>,
+    envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     let (ciphertext, footer) = ciphertext.split_at_mut(
@@ -288,7 +284,7 @@ pub(crate) fn open_pq<'a>(
     receiver: &dyn PrivateVid,
     sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
-    envelope: Envelope<'a, &[u8]>,
+    envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     let (ciphertext, footer) = ciphertext.split_at_mut(
@@ -319,7 +315,7 @@ pub(crate) fn open_pq<'a>(
 
 fn open_payload<'a>(
     sender: &dyn VerifiedVid,
-    envelope: Envelope<'a, &[u8]>,
+    envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     #[allow(unused_variables)]
@@ -427,7 +423,6 @@ fn open_payload<'a>(
 
     Ok((
         (
-            envelope.nonconfidential_data,
             secret_payload,
             envelope.crypto_type,
             envelope.signature_type,

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -359,3 +359,70 @@ fn open_payload<'a>(
         parallel_signature_info,
     ))
 }
+
+#[cfg(test)]
+mod known_answer_tests {
+    use super::{Aead, Deserializable, Kdf, KemTrait, PqKem, X25519Kem};
+    use hpke::{OpModeR, aead::AeadTag, inout::InOutBuf, single_shot_open_inout_detached};
+
+    fn hex(s: &str) -> Vec<u8> {
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    /// Decrypt one known-answer encryption: the vector's `ct` carries the AEAD
+    /// tag in its final 16 bytes, matching the TSP wire convention (spec 9.2.8)
+    fn open_kat<Kem: KemTrait>(skr: &str, enc: &str, info: &str, aad: &str, ct: &str, pt: &str) {
+        let secret_key = Kem::PrivateKey::from_bytes(&hex(skr)).unwrap();
+        let encapped_key = Kem::EncappedKey::from_bytes(&hex(enc)).unwrap();
+        let ct = hex(ct);
+        let (mut ciphertext, tag) = {
+            let (c, t) = ct.split_at(ct.len() - 16);
+            (c.to_vec(), AeadTag::<Aead>::from_bytes(t).unwrap())
+        };
+
+        single_shot_open_inout_detached::<Aead, Kdf, Kem>(
+            &OpModeR::Base,
+            &secret_key,
+            &encapped_key,
+            &hex(info),
+            InOutBuf::from(ciphertext.as_mut_slice()),
+            &hex(aad),
+            &tag,
+        )
+        .unwrap();
+
+        assert_eq!(ciphertext, hex(pt));
+    }
+
+    /// RFC 9180 test vector A.2 (base mode, DHKEM(X25519, HKDF-SHA256),
+    /// HKDF-SHA256, ChaCha20Poly1305): the classical TSP cipher suite
+    #[test]
+    fn rfc_9180_base_x25519_hkdf_sha256_chacha20poly1305() {
+        open_kat::<X25519Kem>(
+            "8057991eef8f1f1af18f4a9491d16a1ce333f695d4db8e38da75975c4478e0fb",
+            "1afa08d3dec047a643885163f1180476fa7ddb54c6a8029ea33f95796bf2ac4a",
+            "4f6465206f6e2061204772656369616e2055726e",
+            "436f756e742d30",
+            "1c5250d8034ec2b784ba2cfd69dbdb8af406cfe3ff938e131f0def8c8b60b4db21993c62ce81883d2dd1b51a28",
+            "4265617574792069732074727574682c20747275746820626561757479",
+        );
+    }
+
+    /// draft-ietf-hpke-pq test vector (base mode, X25519MLKEM768 KEM 0x647a,
+    /// HKDF-SHA256, ChaCha20Poly1305): the post-quantum TSP cipher suite.
+    /// Source: test-vectors.json of the hpkewg/hpke-pq draft repository
+    #[test]
+    fn hpke_pq_base_x25519mlkem768_hkdf_sha256_chacha20poly1305() {
+        open_kat::<PqKem>(
+            "b6bfa0299b955e85224df2e468f29eeab377ff3b96d4462b39447a22d32b91be",
+            "ab354dd589f74ee0eab7718a630cbec5df1d09058e177cd6dd141d883450ddd70c050d88bed3d07cce23415cab411108cc30906482a71adcb134a56e978a6152a8e063b24acd1534f264f10458152a9ed4f1f32b3d480c4f2453b7fdea7720146b3ee92cf8a13a4840076f68c911c65fa3db5053fb0aabf79e64cd5e7aa71b2b9641e713ec7df552e17d5020f8721ee449b42c888e2a3f87cfd96e3a98c3e7c4cd8f647f899570f596bf17d2b6fa2cad19706d9cc3cf09493e1c7ffa0eb2a4559ae1d940fdbef97bed383e6ccfdb448d9f1a81805166b32c2af2e16878c6dc46ab43323ed9c136b925239782e3c329c31a5cf2a80faf025a80766e244605c27afe4b624d9d8ca99b6ef5439ed1ad044b518c434385acd49f1369ded6624a2832a571ccdd70d08b3c04cb1cd3136166f9a485f536f69ec66f0293e840025ccaac42f8e5f7c9cb818076c272797047f5e50c1e9f1dab81cfb48fe4c4998b2427f009702b145f34ad8dbc3e7ad4e4023057ba31cd02c4c0545ebf71eb02533e8eaa2b2f2690ee1407bf1f66dc5f4d836c45b82f10b720df72d237488a9af1b6dfb4741fd613379c2e211e77f7fae6b3734ad81de2d452005334857c4a3cbc82afc7428fe510495969b296d24e1a7431f557d48578cf92ae86c0392f0ba73755a9e5465c8e3495e4cd2a82d463244341e39414e26c9b242f31d2cf0e46b2aeb11dd5e56ec44834350d151344229e410faff2b2ace5c9b3fa12571db1d28da2c7133492781dac41b7a7e2bac2260fd12f56939033587824c9dfb17d41b3bceea53763193abe0c7c184d5de161ef5312f31fab42478c9a193b868e4d29b2b7624f3ebe740f393d03d843cd5327286a579fd2a6e37aca5b64f9316115d612c7781e704ea7d182701c5019975cad14fbf4ab3904d4a35acaf0be32d716a1ef5d7188fc418ae9e60744325a3e8001655b756df94c24031c3ce32bd90c0ecdac52ca140fdad7f44d04bd0a7e2a726c54cf9793f8784a23296f65da3fd1cbc18300d503c5b27be99b9b0e32d20b3614dc8a999f30c2779dd7886cfd486dc1c93ebcf517b5210a4359d9fa1805381f0f2261ff47de01de555d98bc1a30dda557a83007b61636abaf9041f96890f0f565eefc45859fbcd32d91b203215541227a4fcc3d95be2ddb0702878caa20f2da62c4ff9fe33af591ba1ec241fbe2208e0480f8b1cca1679c096f8f5a02a33e9df445b3274ac112b43d51510135cd3f532a3379e90bb7f0cb43717e90555bb1a80924cc69577455687cceb9b1610c05839541e87ad83d79ef3ff24ace1934cfbe989691959d93ac48c716b672b370dd4c144ca1e32508707a6ef8aa29b55759b3d054c56bee1baa6f41b84b9fc3fd681a1a1528eac578141529836a29dda1501a49ba2455367256d2fe6f74ebb74ef9a49a94a4c6cd1dd09810f0e9bffa69dd8c94d226d0b2977b11a35382888961004a44c60fd602e9ff4271287e9240ba96146515b9db9da60375aeeafeac1eeb764faebacd197df27817c35fe4c5c802e43349d7bc95c8b40c001449d3251c1d92ff6d5c3b08c4b27c",
+            "34663634363532303666366532303631323034373732363536333639363136653230353537323665",
+            "436f756e742d30",
+            "a4ab74475a498ed725f685421f67c09a4783fe76f67bd251e1e73db8eb1452dfad4df3c6453f7edecc7bb055dde561e2efd54d73a3d4f1f2f02eac90ba1e9b84ded66d43aee6393524db",
+            "34323635363137353734373932303639373332303734373237353734363832633230373437323735373436383230363236353631373537343739",
+        );
+    }
+}

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -246,3 +246,33 @@ pub(crate) fn open<'a>(
         parallel_signature_info,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use crypto_box::SecretKey;
+
+    fn hex(s: &str) -> Vec<u8> {
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    /// Interoperability check against libsodium: this sealed box was produced
+    /// by libsodium's crypto_box_seal (via PyNaCl 1.6.1) for the X25519 secret
+    /// key below; unsealing it verifies the ephemeral-key layout and the
+    /// BLAKE2b-derived nonce match libsodium's construction (spec 8.3)
+    #[test]
+    fn libsodium_sealed_box_interop() {
+        let secret_key = SecretKey::from_slice(&hex(
+            "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
+        ))
+        .unwrap();
+        let sealed = hex(
+            "0ab37c2bc1d0be4a9cf418c7bfb4471f0b0989074596b914d507ff8ce16f9546046abf7f210b312b91886842faff87ab6f3437a0865d87147b65ebbb748750b4421abcb8fd2db45dc4e17420",
+        );
+
+        let plaintext = secret_key.unseal(&sealed).unwrap();
+        assert_eq!(plaintext, b"TSP sealed box interop check");
+    }
+}

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -2,7 +2,7 @@ use crate::{
     cesr::{CryptoType, DecodedPayload, Envelope},
     definitions::{Payload, PrivateVid, VerifiedVid},
 };
-use crypto_box::{ChaChaBox, PublicKey, SecretKey, aead::AeadInPlace};
+use crypto_box::{PublicKey, SecretKey};
 
 use super::{
     CryptoError, MessageContents, ParallelSignatureInfo, open_relationship_accept,
@@ -13,7 +13,7 @@ use super::{
     build_relationship_request_payload, signature_type,
 };
 use crate::definitions::TSPMessage;
-use crypto_box::aead::{AeadCore, OsRng};
+use crypto_box::aead::OsRng;
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 pub(crate) fn seal(
@@ -22,12 +22,8 @@ pub(crate) fn seal(
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
     request_nonce_override: Option<[u8; 16]>,
-    crypto_type: CryptoType,
 ) -> Result<TSPMessage, CryptoError> {
-    if !matches!(crypto_type, CryptoType::NaclAuth | CryptoType::NaclEssr) {
-        return Err(CryptoError::InvalidCryptoSelection(crypto_type));
-    }
-
+    let crypto_type = CryptoType::SealedBox;
     let mut csprng = StdRng::from_entropy();
 
     let mut data = Vec::with_capacity(64);
@@ -103,22 +99,15 @@ pub(crate) fn seal(
         *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
     }
 
-    let sender_secret_key = SecretKey::from_slice(sender.decryption_key())?;
+    // the libsodium anonymous sealed box: an ephemeral key pair, the nonce
+    // derived from the ephemeral and recipient public keys, X25519 +
+    // XSalsa20-Poly1305 (spec 8.3). The sender's static keys are not used;
+    // sender authenticity comes from the ESSR sender-VID field and the signature.
     let receiver_public_key = PublicKey::from_slice(receiver.encryption_key())?;
-
-    let sender_box = ChaChaBox::new(&receiver_public_key, &sender_secret_key);
-
-    // Get a random nonce to encrypt the message under
-    let nonce = ChaChaBox::generate_nonce(&mut OsRng);
-
-    // aad not yet supported: https://github.com/RustCrypto/nacl-compat/blob/78b59261458923740724c84937459f0a6017a592/crypto_box/src/lib.rs#L227
-    let tag = sender_box.encrypt_in_place_detached(&nonce, &[], &mut cesr_message);
-
-    cesr_message.extend(tag?);
-    cesr_message.extend(nonce);
+    let ciphertext = receiver_public_key.seal(&mut OsRng, &cesr_message)?;
 
     // encode and append the ciphertext to the envelope data
-    crate::cesr::encode_ciphertext(&cesr_message, crypto_type, &mut data)?;
+    crate::cesr::encode_ciphertext(&ciphertext, crypto_type, &mut data)?;
     crate::cesr::finalize_envelope_frame(&mut data);
 
     append_signature(sender, &mut data)?;
@@ -133,30 +122,28 @@ pub(crate) fn open<'a>(
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
-    let (ciphertext, footer) = ciphertext.split_at_mut(ciphertext.len() - 16 - 24);
-    let (tag, nonce) = footer.split_at(16);
-
     let receiver_secret_key = SecretKey::from_slice(receiver.decryption_key().as_slice())?;
-    let sender_public_key = PublicKey::from_slice(sender.encryption_key().as_slice())?;
-    let receiver_box = ChaChaBox::new(&sender_public_key, &receiver_secret_key);
+    let plaintext = receiver_secret_key.unseal(ciphertext)?;
 
-    receiver_box.decrypt_in_place_detached(nonce.into(), &[], ciphertext, tag.into())?;
+    // the sealed box decrypts into a fresh buffer; copy back into the message
+    // buffer so the payload can borrow from it
+    let ciphertext = &mut ciphertext[..plaintext.len()];
+    ciphertext.copy_from_slice(&plaintext);
 
-    #[allow(unused_variables)]
     let DecodedPayload {
         payload,
         sender_identity,
     } = crate::cesr::decode_payload(ciphertext)?;
 
-    if envelope.crypto_type == CryptoType::NaclEssr {
-        match sender_identity {
-            Some(id) => {
-                if id != sender.identifier().as_bytes() {
-                    return Err(CryptoError::UnexpectedSender);
-                }
+    // the sealed box is anonymous: the ESSR sender-VID confidential field is
+    // required and MUST match the envelope (spec 8.3.2)
+    match sender_identity {
+        Some(id) => {
+            if id != sender.identifier().as_bytes() {
+                return Err(CryptoError::UnexpectedSender);
             }
-            None => return Err(CryptoError::MissingSender),
         }
+        None => return Err(CryptoError::MissingSender),
     }
 
     let (secret_payload, parallel_signature_info) = match payload {

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -12,14 +12,13 @@ use super::{
     RelationshipDigestAlgorithm, append_signature, build_relationship_accept_payload,
     build_relationship_request_payload, signature_type,
 };
-use crate::definitions::{NonConfidentialData, TSPMessage};
+use crate::definitions::TSPMessage;
 use crypto_box::aead::{AeadCore, OsRng};
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 pub(crate) fn seal(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<NonConfidentialData>,
     secret_payload: Payload<&[u8]>,
     digest: Option<&mut super::Digest>,
     request_nonce_override: Option<[u8; 16]>,
@@ -38,7 +37,6 @@ pub(crate) fn seal(
             signature_type: signature_type(sender),
             sender: sender.identifier(),
             receiver: Some(receiver.identifier()),
-            nonconfidential_data,
         },
         &mut data,
     )?;
@@ -132,7 +130,7 @@ pub(crate) fn open<'a>(
     receiver: &dyn PrivateVid,
     sender: &dyn VerifiedVid,
     _raw_header: &'a [u8],
-    envelope: Envelope<'a, &[u8]>,
+    envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     let (ciphertext, footer) = ciphertext.split_at_mut(ciphertext.len() - 16 - 24);
@@ -249,7 +247,6 @@ pub(crate) fn open<'a>(
 
     Ok((
         (
-            envelope.nonconfidential_data,
             secret_payload,
             envelope.crypto_type,
             envelope.signature_type,

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -61,6 +61,7 @@ pub(crate) fn seal(
                 sender_in_payload,
                 digest_algorithm,
                 nonce_bytes,
+                &data,
                 &mut request_digest_storage,
             )?;
             payload_digest_override = Some(payload_digest);
@@ -76,6 +77,7 @@ pub(crate) fn seal(
                 &form,
                 sender_in_payload,
                 digest_algorithm,
+                &data,
                 &mut reply_digest_storage,
             )?;
             payload_digest_override = Some(payload_digest);
@@ -118,7 +120,7 @@ pub(crate) fn seal(
 pub(crate) fn open<'a>(
     receiver: &dyn PrivateVid,
     sender: &dyn VerifiedVid,
-    _raw_header: &'a [u8],
+    raw_header: &'a [u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
@@ -134,6 +136,9 @@ pub(crate) fn open<'a>(
         payload,
         sender_identity,
     } = crate::cesr::decode_payload(ciphertext)?;
+
+    // verify the embedded self-referencing digest of relationship payloads
+    super::verify_relationship_digest(&payload, sender_identity, raw_header)?;
 
     // the sealed box is anonymous: the ESSR sender-VID confidential field is
     // required and MUST match the envelope (spec 8.3.2)

--- a/tsp_sdk/src/definitions/conversions.rs
+++ b/tsp_sdk/src/definitions/conversions.rs
@@ -21,13 +21,11 @@ impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
             GenericMessage {
                 sender,
                 receiver,
-                nonconfidential_data,
                 message,
                 message_type,
             } => GenericMessage {
                 sender,
                 receiver,
-                nonconfidential_data: nonconfidential_data.map(&f),
                 message: f(message),
                 message_type,
             },

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -28,7 +28,6 @@ pub struct PrivateSigningKeyData(Vec<u8>);
 pub struct PublicVerificationKeyData(Vec<u8>);
 
 pub type VidData<'a> = &'a [u8];
-pub type NonConfidentialData<'a> = &'a [u8];
 pub type TSPMessage = Vec<u8>;
 
 #[cfg(feature = "async")]
@@ -120,7 +119,6 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
     GenericMessage {
         sender: String,
         receiver: Option<String>,
-        nonconfidential_data: Option<Data>,
         message: Data,
         message_type: MessageType,
     },

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -252,7 +252,7 @@ impl<Bytes: AsRef<[u8]>> fmt::Display for Payload<'_, Bytes> {
 pub enum VidEncryptionKeyType {
     #[default]
     X25519,
-    X25519Kyber768Draft00,
+    X25519MlKem768,
 }
 
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
@@ -267,13 +267,13 @@ impl VidEncryptionKeyType {
     fn jwk_key_type(self) -> &'static str {
         match self {
             VidEncryptionKeyType::X25519 => "OKP",
-            VidEncryptionKeyType::X25519Kyber768Draft00 => "X25519Kyber768Draft00",
+            VidEncryptionKeyType::X25519MlKem768 => "X25519MlKem768",
         }
     }
 
     fn jwk_curve(self) -> &'static str {
         match self {
-            VidEncryptionKeyType::X25519 | VidEncryptionKeyType::X25519Kyber768Draft00 => "X25519",
+            VidEncryptionKeyType::X25519 | VidEncryptionKeyType::X25519MlKem768 => "X25519",
         }
     }
 }

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -53,7 +53,6 @@
 //!     alice_db.send(
 //!         "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
 //!         "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
-//!         Some(b"extra non-confidential data"),
 //!         b"hello world",
 //!     ).await?;
 //!

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -212,10 +212,12 @@ struct ParallelSignatureMaterial {
 enum ParallelSignatureContext<'a> {
     Request {
         sender_identity: &'a str,
+        receiver_identity: &'a str,
         nonce: [u8; 16],
     },
     Accept {
         sender_identity: &'a str,
+        receiver_identity: &'a str,
         thread_id: Digest,
     },
 }
@@ -1426,30 +1428,52 @@ impl SecureStore {
         let (signed_data, request_nonce) = match context {
             ParallelSignatureContext::Request {
                 sender_identity,
+                receiver_identity,
                 nonce,
-            } => (
-                crate::crypto::build_parallel_request_signed_data(
-                    Some(sender_identity.as_bytes()),
-                    digest_algorithm,
-                    nonce,
-                    &mut digest,
-                    sender_new_vid.identifier().as_bytes(),
-                )?,
-                Some(nonce),
-            ),
+            } => {
+                let mut envelope_prefix = Vec::with_capacity(64);
+                crate::cesr::encode_envelope_prefix(
+                    sender_identity.as_bytes(),
+                    Some(receiver_identity.as_bytes()),
+                    &mut envelope_prefix,
+                )
+                .map_err(crate::crypto::CryptoError::from)?;
+                (
+                    crate::crypto::build_parallel_request_signed_data(
+                        Some(sender_identity.as_bytes()),
+                        digest_algorithm,
+                        nonce,
+                        &envelope_prefix,
+                        &mut digest,
+                        sender_new_vid.identifier().as_bytes(),
+                    )?,
+                    Some(nonce),
+                )
+            }
             ParallelSignatureContext::Accept {
                 sender_identity,
+                receiver_identity,
                 thread_id,
-            } => (
-                crate::crypto::build_parallel_accept_signed_data(
-                    &thread_id,
-                    Some(sender_identity.as_bytes()),
-                    digest_algorithm,
-                    &mut digest,
-                    sender_new_vid.identifier().as_bytes(),
-                )?,
-                None,
-            ),
+            } => {
+                let mut envelope_prefix = Vec::with_capacity(64);
+                crate::cesr::encode_envelope_prefix(
+                    sender_identity.as_bytes(),
+                    Some(receiver_identity.as_bytes()),
+                    &mut envelope_prefix,
+                )
+                .map_err(crate::crypto::CryptoError::from)?;
+                (
+                    crate::crypto::build_parallel_accept_signed_data(
+                        &thread_id,
+                        Some(sender_identity.as_bytes()),
+                        digest_algorithm,
+                        &envelope_prefix,
+                        &mut digest,
+                        sender_new_vid.identifier().as_bytes(),
+                    )?,
+                    None,
+                )
+            }
         };
 
         let sig_new_vid = crate::crypto::sign_detached(sender_new_vid, &signed_data)?;
@@ -1488,6 +1512,7 @@ impl SecureStore {
             &*sender_new_vid,
             ParallelSignatureContext::Request {
                 sender_identity: sender.identifier(),
+                receiver_identity: receiver.identifier(),
                 nonce: random_nonce_bytes(),
             },
             digest_algorithm,
@@ -1569,6 +1594,7 @@ impl SecureStore {
             &*sender_new_vid,
             ParallelSignatureContext::Accept {
                 sender_identity: outer_sender.identifier(),
+                receiver_identity: receiver_new_vid.identifier(),
                 thread_id,
             },
             digest_algorithm,
@@ -2059,6 +2085,20 @@ mod test {
         assert_eq!(url.as_str(), expected_receiver.endpoint().as_str());
     }
 
+    fn test_envelope_prefix(
+        sender: &(impl VerifiedVid + ?Sized),
+        receiver: &(impl VerifiedVid + ?Sized),
+    ) -> Vec<u8> {
+        let mut prefix = Vec::with_capacity(64);
+        crate::cesr::encode_envelope_prefix(
+            sender.identifier().as_bytes(),
+            Some(receiver.identifier().as_bytes()),
+            &mut prefix,
+        )
+        .unwrap();
+        prefix
+    }
+
     fn relationship_digest_algorithm(
         sender: &dyn VerifiedVid,
         receiver: &dyn VerifiedVid,
@@ -2391,7 +2431,13 @@ mod test {
             alice_parallel.identifier()
         );
         assert!(received_request_digest.iter().any(|byte| *byte != 0));
-        assert_eq!(sig_new_vid.len(), 64);
+        assert_eq!(
+            sig_new_vid.len(),
+            match alice_parallel.signature_key_type() {
+                crate::definitions::VidSignatureKeyType::Ed25519 => 64,
+                crate::definitions::VidSignatureKeyType::MlDsa65 => 3309,
+            }
+        );
     }
 
     #[test]
@@ -2478,7 +2524,13 @@ mod test {
         );
         assert_eq!(request_digest, thread_id);
         assert!(received_reply_digest.iter().any(|byte| *byte != 0));
-        assert_eq!(sig_new_vid.len(), 64);
+        assert_eq!(
+            sig_new_vid.len(),
+            match alice_parallel.signature_key_type() {
+                crate::definitions::VidSignatureKeyType::Ed25519 => 64,
+                crate::definitions::VidSignatureKeyType::MlDsa65 => 3309,
+            }
+        );
 
         let RelationshipStatus::Bidirectional {
             thread_id: receiver_thread_id,
@@ -2688,6 +2740,7 @@ mod test {
             &thread_id,
             Some(charlie.identifier().as_bytes()),
             relationship_digest_algorithm(&charlie, &*forged_receiver),
+            &test_envelope_prefix(&charlie, &*forged_receiver),
             &mut reply_thread_id,
             charlie_parallel.identifier().as_bytes(),
         )
@@ -2813,6 +2866,7 @@ mod test {
             Some(alice.identifier().as_bytes()),
             relationship_digest_algorithm(&alice, &bob),
             nonce_bytes,
+            &test_envelope_prefix(&alice, &bob),
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),
         )
@@ -2873,6 +2927,7 @@ mod test {
             Some(alice.identifier().as_bytes()),
             relationship_digest_algorithm(&alice, &bob),
             nonce_bytes,
+            &test_envelope_prefix(&alice, &bob),
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),
         )

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -114,7 +114,6 @@ fn digest_algorithm_for_selection(
 fn seal_envelope(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
-    nonconfidential_data: Option<&[u8]>,
     payload: Payload<&[u8]>,
     digest: Option<&mut Digest>,
     request_nonce_override: Option<[u8; 16]>,
@@ -123,7 +122,6 @@ fn seal_envelope(
     Ok(crate::crypto::seal_with_selection(
         sender,
         receiver,
-        nonconfidential_data,
         payload,
         digest,
         request_nonce_override,
@@ -650,7 +648,6 @@ impl SecureStore {
         &self,
         sender: &str,
         receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
         message: &[u8],
     ) -> Result<(Url, Vec<u8>), Error> {
         #[cfg(feature = "bench-network-timings")]
@@ -658,12 +655,7 @@ impl SecureStore {
         #[cfg(feature = "bench-network-timings")]
         let started = std::time::Instant::now();
 
-        let result = self.seal_message_payload(
-            sender,
-            receiver,
-            nonconfidential_data,
-            Payload::Content(message),
-        );
+        let result = self.seal_message_payload(sender, receiver, Payload::Content(message));
 
         #[cfg(feature = "bench-network-timings")]
         crate::bench::record_seal_core(started, signature_before);
@@ -675,14 +667,12 @@ impl SecureStore {
         &self,
         sender: &str,
         receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
         message: &[u8],
         crypto_type: crate::cesr::CryptoType,
     ) -> Result<(Url, Vec<u8>), Error> {
         self.seal_message_payload_and_hash_with_selection(
             sender,
             receiver,
-            nonconfidential_data,
             Payload::Content(message),
             None,
             Some(OutboundCryptoSelection { crypto_type }),
@@ -696,10 +686,9 @@ impl SecureStore {
         &self,
         sender: &str,
         receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
         payload: Payload<&[u8]>,
     ) -> Result<(url::Url, Vec<u8>), Error> {
-        self.seal_message_payload_and_hash(sender, receiver, nonconfidential_data, payload, None)
+        self.seal_message_payload_and_hash(sender, receiver, payload, None)
     }
 
     /// Seal a TSP message and return the digest of the payload
@@ -707,25 +696,16 @@ impl SecureStore {
         &self,
         sender: &str,
         receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
         payload: Payload<&[u8]>,
         digest: Option<&mut Digest>,
     ) -> Result<(url::Url, Vec<u8>), Error> {
-        self.seal_message_payload_and_hash_with_selection(
-            sender,
-            receiver,
-            nonconfidential_data,
-            payload,
-            digest,
-            None,
-        )
+        self.seal_message_payload_and_hash_with_selection(sender, receiver, payload, digest, None)
     }
 
     pub(crate) fn seal_message_payload_and_hash_with_selection(
         &self,
         sender: &str,
         receiver: &str,
-        nonconfidential_data: Option<&[u8]>,
         payload: Payload<&[u8]>,
         digest: Option<&mut Digest>,
         selection: Option<OutboundCryptoSelection>,
@@ -747,7 +727,6 @@ impl SecureStore {
                     let tsp_message = seal_envelope(
                         &*inner_sender,
                         &*receiver_context.vid,
-                        nonconfidential_data,
                         payload,
                         digest,
                         None,
@@ -769,7 +748,6 @@ impl SecureStore {
             return self.seal_message_payload_and_hash_with_selection(
                 sender.identifier(),
                 first_hop.vid.identifier(),
-                None,
                 Payload::RoutedMessage(hops, &inner_message),
                 None,
                 None,
@@ -805,7 +783,6 @@ impl SecureStore {
                 seal_envelope(
                     &*inner_sender,
                     &*receiver_context.vid,
-                    None,
                     payload,
                     digest,
                     None,
@@ -819,7 +796,6 @@ impl SecureStore {
             return self.seal_message_payload_and_hash_with_selection(
                 parent_sender.identifier(),
                 parent_receiver.identifier(),
-                nonconfidential_data,
                 Payload::NestedMessage(&inner_message),
                 None,
                 if content_payload { selection } else { None },
@@ -830,7 +806,6 @@ impl SecureStore {
         let tsp_message = seal_envelope(
             &*sender,
             &*receiver_context.vid,
-            nonconfidential_data,
             payload,
             digest,
             None,
@@ -1069,7 +1044,6 @@ impl SecureStore {
             self.seal_message_payload(
                 sender_private.identifier(),
                 recipient.identifier(),
-                None,
                 Payload::NestedMessage(opaque_payload),
             )
         } else {
@@ -1086,7 +1060,6 @@ impl SecureStore {
             self.seal_message_payload(
                 sender.identifier(),
                 next_hop_context.vid.identifier(),
-                None,
                 Payload::RoutedMessage(route, opaque_payload),
             )
         }
@@ -1129,14 +1102,12 @@ impl SecureStore {
                     unverified_source_error(&sender)
                 })?;
 
-                let (
-                    (nonconfidential_data, payload, crypto_type, signature_type),
-                    parallel_signature_info,
-                ) = crate::crypto::open_with_signature_info(
-                    &*receiver_pid,
-                    sender_vid.as_verified(),
-                    message,
-                )?;
+                let ((payload, crypto_type, signature_type), parallel_signature_info) =
+                    crate::crypto::open_with_signature_info(
+                        &*receiver_pid,
+                        sender_vid.as_verified(),
+                        message,
+                    )?;
 
                 let parallel_sender_vid = parallel_signature_info
                     .map(|parallel_signature_info| {
@@ -1149,7 +1120,6 @@ impl SecureStore {
                     Payload::Content(message) => Ok(ReceivedTspMessage::GenericMessage {
                         sender,
                         receiver: Some(intended_receiver),
-                        nonconfidential_data,
                         message,
                         message_type: MessageType {
                             crypto_type,
@@ -1376,7 +1346,6 @@ impl SecureStore {
                 Ok(ReceivedTspMessage::GenericMessage {
                     sender,
                     receiver: intended_receiver,
-                    nonconfidential_data: None,
                     message,
                     message_type,
                 })
@@ -1428,7 +1397,6 @@ impl SecureStore {
         let tsp_message = seal_envelope(
             &*sender,
             &*receiver,
-            None,
             Payload::RequestRelationship {
                 thread_id: Default::default(),
                 form: RelationshipForm::Direct,
@@ -1529,7 +1497,6 @@ impl SecureStore {
         let tsp_message = seal_envelope(
             &*sender,
             &*receiver,
-            None,
             Payload::RequestRelationship {
                 thread_id: Default::default(),
                 form: RelationshipForm::Parallel {
@@ -1571,7 +1538,6 @@ impl SecureStore {
         let (transport, tsp_message) = self.seal_message_payload_and_hash(
             sender,
             receiver,
-            None,
             Payload::AcceptRelationship {
                 thread_id,
                 reply_thread_id: Default::default(),
@@ -1612,7 +1578,6 @@ impl SecureStore {
         let tsp_message = seal_envelope(
             &*outer_sender,
             &*receiver_new_vid,
-            None,
             Payload::AcceptRelationship {
                 thread_id,
                 reply_thread_id: Default::default(),
@@ -1656,12 +1621,8 @@ impl SecureStore {
             }
         };
 
-        let (transport, message) = self.seal_message_payload(
-            sender,
-            receiver,
-            None,
-            Payload::CancelRelationship { thread_id },
-        )?;
+        let (transport, message) =
+            self.seal_message_payload(sender, receiver, Payload::CancelRelationship { thread_id })?;
 
         Ok((transport, message))
     }
@@ -1684,7 +1645,6 @@ impl SecureStore {
         let (endpoint, tsp_message) = self.seal_message_payload_and_hash_with_selection(
             sender.identifier(),
             receiver.identifier(),
-            None,
             Payload::NestedMessage(&inner_message),
             None,
             Some(selection),
@@ -1727,7 +1687,6 @@ impl SecureStore {
         let (transport, tsp_message) = self.seal_message_payload_and_hash_with_selection(
             parent_sender,
             parent_receiver,
-            None,
             Payload::NestedMessage(&inner_message),
             None,
             Some(selection),
@@ -2198,7 +2157,7 @@ mod test {
         let message = b"hello world";
 
         let (url, mut sealed) = store
-            .seal_message(alice.identifier(), bob.identifier(), None, message)
+            .seal_message(alice.identifier(), bob.identifier(), message)
             .unwrap();
 
         assert_url_matches(&url, &bob);
@@ -2738,7 +2697,6 @@ mod test {
         let mut forged_accept = crate::crypto::seal_and_hash(
             &*forged_sender,
             &*forged_receiver,
-            None,
             Payload::AcceptRelationship {
                 thread_id,
                 reply_thread_id: Default::default(),
@@ -2868,7 +2826,6 @@ mod test {
         let mut sealed = crate::crypto::seal_and_hash_with_relationship_nonce(
             &*sender_vid,
             &*receiver_vid,
-            None,
             Payload::RequestRelationship {
                 thread_id: Default::default(),
                 form: RelationshipForm::Parallel {
@@ -2928,7 +2885,6 @@ mod test {
         let mut sealed = crate::crypto::seal_and_hash_with_relationship_nonce(
             &*sender_vid,
             &*receiver_vid,
-            None,
             Payload::RequestRelationship {
                 thread_id: Default::default(),
                 form: RelationshipForm::Parallel {
@@ -2972,7 +2928,7 @@ mod test {
             .unwrap();
 
         let (_url, mut sealed) = sender_store
-            .seal_message(sender.identifier(), receiver.identifier(), None, b"hello")
+            .seal_message(sender.identifier(), receiver.identifier(), b"hello")
             .unwrap();
         let last = sealed
             .last_mut()
@@ -3223,12 +3179,7 @@ mod test {
         let hello_world = b"hello world";
 
         let (_url, mut sealed) = a_store
-            .seal_message(
-                sneaky_a.identifier(),
-                sneaky_d.identifier(),
-                None,
-                hello_world,
-            )
+            .seal_message(sneaky_a.identifier(), sneaky_d.identifier(), hello_world)
             .unwrap();
 
         let received = b_store.open_message(&mut sealed).unwrap();
@@ -3282,7 +3233,6 @@ mod test {
         let ReceivedTspMessage::GenericMessage {
             sender,
             receiver,
-            nonconfidential_data,
             message,
             message_type,
         } = received
@@ -3292,7 +3242,6 @@ mod test {
 
         assert_eq!(sender, sneaky_a.identifier());
         assert_eq!(receiver.unwrap(), sneaky_d.identifier());
-        assert!(nonconfidential_data.is_none());
         assert_eq!(message, hello_world);
         assert_ne!(message_type.crypto_type, crate::cesr::CryptoType::Plaintext);
         assert_ne!(
@@ -3350,12 +3299,7 @@ mod test {
         let hello_world = b"hello world";
 
         let (_url, mut sealed) = a_store
-            .seal_message(
-                nested_a.identifier(),
-                nested_b.identifier(),
-                None,
-                hello_world,
-            )
+            .seal_message(nested_a.identifier(), nested_b.identifier(), hello_world)
             .unwrap();
 
         let received = b_store.open_message(&mut sealed).unwrap();
@@ -3363,7 +3307,6 @@ mod test {
         let ReceivedTspMessage::GenericMessage {
             sender,
             receiver,
-            nonconfidential_data,
             message,
             message_type,
         } = received
@@ -3373,7 +3316,6 @@ mod test {
 
         assert_eq!(sender, nested_a.identifier());
         assert_eq!(receiver.unwrap(), nested_b.identifier());
-        assert!(nonconfidential_data.is_none());
         assert_eq!(message, hello_world);
         assert_ne!(message_type.crypto_type, crate::cesr::CryptoType::Plaintext);
         assert_ne!(
@@ -3498,12 +3440,7 @@ mod test {
         let hello_world = b"hello world";
 
         let (_url, mut sealed) = a_store
-            .seal_message(
-                nested_a.identifier(),
-                nested_b.identifier(),
-                None,
-                hello_world,
-            )
+            .seal_message(nested_a.identifier(), nested_b.identifier(), hello_world)
             .unwrap();
 
         let received = b_store.open_message(&mut sealed).unwrap();
@@ -3511,7 +3448,6 @@ mod test {
         let ReceivedTspMessage::GenericMessage {
             sender,
             receiver,
-            nonconfidential_data,
             message,
             message_type,
         } = received
@@ -3521,7 +3457,6 @@ mod test {
 
         assert_eq!(sender, nested_a.identifier());
         assert_eq!(receiver.unwrap(), nested_b.identifier());
-        assert!(nonconfidential_data.is_none());
         assert_eq!(message, hello_world);
         assert_ne!(message_type.crypto_type, crate::cesr::CryptoType::Plaintext);
         assert_ne!(

--- a/tsp_sdk/src/test.rs
+++ b/tsp_sdk/src/test.rs
@@ -35,7 +35,6 @@ async fn test_direct_mode() {
         .send(
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
-            Some(b"extra non-confidential data"),
             b"hello world",
         )
         .await
@@ -100,7 +99,6 @@ async fn test_large_messages() {
             .send(
                 "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
                 "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
-                None,
                 sent_message.as_bytes(),
             )
             .await
@@ -258,7 +256,6 @@ async fn test_nested_mode() {
         .send(
             nested_alice_vid.identifier(),
             nested_bob_vid.identifier(),
-            Some(b"extra non-confidential data"),
             b"hello nested world",
         )
         .await
@@ -356,7 +353,6 @@ async fn test_routed_mode() {
         .send(
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
-            None,
             b"hello self (via bob)",
         )
         .await
@@ -537,7 +533,7 @@ async fn attack_failures() {
 
     for i in 0.. {
         let mut faulty_message =
-            crate::crypto::seal(&alice, &bob, None, super::Payload::Content(payload)).unwrap();
+            crate::crypto::seal(&alice, &bob, super::Payload::Content(payload)).unwrap();
 
         if i >= faulty_message.len() {
             break;
@@ -676,7 +672,6 @@ async fn test_unverified_receiver_in_direct_mode() {
         .send(
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
-            Some(b"extra non-confidential data"),
             b"hello world",
         )
         .await
@@ -786,7 +781,7 @@ async fn test_persisted_store_roundtrip_reopens_dirty_wallet() {
         .unwrap();
 
     let (_endpoint, sealed_message) = reopened_store
-        .seal_message(&local_vid, &receiver_vid, None, b"persisted-wallet-message")
+        .seal_message(&local_vid, &receiver_vid, b"persisted-wallet-message")
         .unwrap();
     assert!(!sealed_message.is_empty());
 }
@@ -962,7 +957,6 @@ async fn test_routed_delivery_after_reopen_uses_persisted_route_metadata() {
         .send(
             &topology.sender_vid,
             &topology.receiver_vid,
-            None,
             b"dirty-routed-message",
         )
         .await
@@ -1023,7 +1017,6 @@ async fn test_routed_failure_path_after_reopen_keeps_snapshot_stable() {
         .send(
             &topology.sender_vid,
             &topology.receiver_vid,
-            None,
             b"dirty-routed-message",
         )
         .await
@@ -1086,7 +1079,6 @@ async fn test_high_entropy_dirty_store_multi_reopen_consistency() {
         .seal_message(
             &seed.local_vid,
             &seed.bidirectional_remote_vid,
-            None,
             b"high-entropy-persisted-message",
         )
         .unwrap();

--- a/tsp_sdk/src/test_utils.rs
+++ b/tsp_sdk/src/test_utils.rs
@@ -949,7 +949,6 @@ mod tests {
             .seal_message(
                 &topology.sender_vid,
                 &topology.receiver_vid,
-                None,
                 b"direct-open-flow",
             )
             .unwrap();

--- a/tsp_sdk/src/vid/did/peer.rs
+++ b/tsp_sdk/src/vid/did/peer.rs
@@ -45,9 +45,9 @@ pub fn encode_did_peer(vid: &Vid) -> String {
             // key bytes length
             v.push(0x20);
         }
-        VidEncryptionKeyType::X25519Kyber768Draft00 => {
+        VidEncryptionKeyType::X25519MlKem768 => {
             #[cfg(feature = "async")]
-            trace!("serializing X25519Kyber768Draft00 encryption key");
+            trace!("serializing X25519MlKem768 encryption key");
             // private use area (0x300000) => encoded as unsigned varint, see: https://github.com/multiformats/unsigned-varint
             v.extend_from_slice(&0x8080c001u32.to_be_bytes());
             // key bytes length (1216 bytes) => encoded as unsigned varint, see: https://github.com/multiformats/unsigned-varint
@@ -123,9 +123,9 @@ pub fn verify_did_peer(parts: &[&str]) -> Result<Vid, VidError> {
                         rest @ ..,
                     ] => {
                         #[cfg(feature = "async")]
-                        trace!("found X25519Kyber768Draft00 encryption key");
+                        trace!("found X25519MlKem768 encryption key");
                         public_enckey = rest[..1216].to_vec().into();
-                        enc_key_type = Some(VidEncryptionKeyType::X25519Kyber768Draft00)
+                        enc_key_type = Some(VidEncryptionKeyType::X25519MlKem768)
                     }
                     _ => {
                         return Err(VidError::ResolveVid(

--- a/tsp_sdk/src/vid/did/web.rs
+++ b/tsp_sdk/src/vid/did/web.rs
@@ -81,7 +81,7 @@ impl From<VidEncryptionKeyType> for KeyType {
     fn from(value: VidEncryptionKeyType) -> Self {
         match value {
             VidEncryptionKeyType::X25519 => KeyType::OKP,
-            VidEncryptionKeyType::X25519Kyber768Draft00 => KeyType::X25519Kyber768Draft00,
+            VidEncryptionKeyType::X25519MlKem768 => KeyType::X25519MlKem768,
         }
     }
 }
@@ -101,14 +101,14 @@ pub enum KeyType {
     APK,
 
     // Unofficial placeholder as nothing is official is assigned yet
-    X25519Kyber768Draft00,
+    X25519MlKem768,
 }
 
 impl From<VidEncryptionKeyType> for Curve {
     fn from(value: VidEncryptionKeyType) -> Self {
         match value {
             VidEncryptionKeyType::X25519 => Curve::X25519,
-            VidEncryptionKeyType::X25519Kyber768Draft00 => Curve::X25519,
+            VidEncryptionKeyType::X25519MlKem768 => Curve::X25519,
         }
     }
 }
@@ -242,7 +242,7 @@ fn find_first_key(
         .and_then(|method| {
             if method.public_key_jwk.usage == usage {
                 match method.public_key_jwk.kty {
-                    KeyType::OKP | KeyType::X25519Kyber768Draft00 => {
+                    KeyType::OKP | KeyType::X25519MlKem768 => {
                         if let Some(x) = &method.public_key_jwk.x {
                             Base64UrlUnpadded::decode_vec(x)
                                 .map(|b| {
@@ -318,8 +318,8 @@ pub fn resolve_document(did_document: DidDocument, target_id: &str) -> Result<Vi
 
     let enc_key_type = match (enc_key_type, enc_curve, enc_alg) {
         (KeyType::OKP, Some(Curve::X25519), None) => VidEncryptionKeyType::X25519,
-        (KeyType::X25519Kyber768Draft00, Some(Curve::X25519), None) => {
-            VidEncryptionKeyType::X25519Kyber768Draft00
+        (KeyType::X25519MlKem768, Some(Curve::X25519), None) => {
+            VidEncryptionKeyType::X25519MlKem768
         }
         _ => return Err(VidError::ResolveVid("Unsupported key type or curve")),
     };


### PR DESCRIPTION
Second PR of the Rev 3 series, into the `rev3` integration branch. Conforms the crypto layer (`tsp_sdk/src/crypto/`) to spec Rev 3, in four commits:

## 1. Remove the non-confidential data field

Per the Rev 3 ruling, a TSP message is either all-confidential or all-non-confidential: the `Non_Confidential_Data` envelope field is removed everywhere (crypto, store, async store, bindings, CLI `-n` flag, demo server). Signed-only messages carry a cleartext `-Z##` payload in the payload position. The mixed-mode timestamp demo is reworked to seal its attestation to the receiver.

## 2. Cipher suites per spec §8

- **HPKE-Base only** (code `4F`): HPKE-Auth is removed. `aad = CONCAT(TSP_Version, VID_sndr, VID_rcvr)` passed as real AAD, `info = "YTSP-"`, wire ciphertext = `CONCAT(enc, ct)` with the AEAD tag inside `ct`.
- **PQ = X25519MLKEM768** (KEM 0x647a) on the same HPKE-Base path via `hpke::kem::XWing`, selected by the recipient VID's encryption key type — no separate wire code.
- **Sealed box** (code `4C`): the NaCl backend is now libsodium's true anonymous sealed box (`crypto_box` `seal` feature). The ESSR sender-VID confidential field is mandatory for sealed box and optional-but-must-match for HPKE-Base.

## 3. Thread ids as embedded self-referencing digests (spec §7.2.1)

Relationship-forming messages now carry the spec's SAID: computed over the envelope prefix (version + VIDs) and the payload fields with the digest's own slot filled with the `0x23` dummy; the `-E##` frame, padding field, and new-VID signature are excluded; the hash is identified by the digest primitive's code (SHA2-256 `I` / Blake2b-256 `F`). Receivers recompute and verify the embedded digest and reject mismatches. The parallel-relationship signature challenge is built in one pass over the final digest. This replaces the old out-of-band hash of the encrypted payload.

## 4. Known-answer tests

- HPKE decryption validated against the official vectors for both exact TSP suites: RFC 9180 A.2 (X25519) and the draft-ietf-hpke-pq vector for KEM 0x647a, base mode, HKDF-SHA256 + ChaCha20Poly1305. Both pass byte-exactly, confirming the `hpke` 0.14 `XWing` implementation matches the draft and the tag-inside-ct wire convention.
- Sealed box cross-checked against libsodium: a box produced by `crypto_box_seal` (via PyNaCl) unseals correctly.

Reply_Digest state (`Bidirectional { thread_id, remote_thread_id }`) and the real `Signature_new` verification were already in place from the parallel-relationships work (#303) and are adapted, not reworked. Nested-relationship digest conformance (XHOP-wrapped RFI/RFA) is deferred to PR 3 with the rest of the nesting rework.

Verified: full test matrix (default, no-default `async,resolve`, `pq`) green; clippy `--deny warnings` and fmt clean.
