### PR TITLE
Fix silent message loss and dual-stack connect in cached transport connections

### DIFF
--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -525,7 +525,11 @@ async fn new_message(
             if let Err(e) =
                 handle_relationship_request(sender.clone(), form, delivery, thread_id).await
             {
-                state.log_error(e.to_string()).await;
+                state
+                    .log_error(format!(
+                        "error delivering relationship accept to {sender}: {e}"
+                    ))
+                    .await;
                 return (StatusCode::BAD_REQUEST, "error accepting relationship").into_response();
             }
 

--- a/tsp_sdk/src/transport/quic.rs
+++ b/tsp_sdk/src/transport/quic.rs
@@ -54,10 +54,6 @@ async fn get_or_create_connection(url: &Url) -> Result<quinn::Connection, Transp
         .socket_addrs(|| None)
         .map_err(|_| TransportError::InvalidTransportAddress(url.to_string()))?;
 
-    let Some(address) = addresses.first().cloned() else {
-        return Err(TransportError::InvalidTransportAddress(url.to_string()));
-    };
-
     let domain = url
         .domain()
         .ok_or(TransportError::InvalidTransportAddress(format!(
@@ -65,25 +61,47 @@ async fn get_or_create_connection(url: &Url) -> Result<quinn::Connection, Transp
         )))?
         .to_owned();
 
-    // passing 0 as port number opens a random port
-    let listen_address: SocketAddr = if address.is_ipv6() {
-        (Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 0).into()
-    } else {
-        (Ipv4Addr::new(127, 0, 0, 1), 0).into()
-    };
+    // A host like `localhost` can resolve to both IPv6 and IPv4 addresses in
+    // nondeterministic order, while the server may listen on only one of them;
+    // try each address in turn.
+    let mut last_error = None;
+    for address in addresses.iter().cloned() {
+        // passing 0 as port number opens a random port
+        let listen_address: SocketAddr = if address.is_ipv6() {
+            (Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 0).into()
+        } else {
+            (Ipv4Addr::new(127, 0, 0, 1), 0).into()
+        };
 
-    let mut endpoint = Endpoint::client(listen_address).map_err(|_| TransportError::ListenPort)?;
-    endpoint.set_default_client_config(QUIC_CONFIG.clone());
+        let mut endpoint = match Endpoint::client(listen_address) {
+            Ok(endpoint) => endpoint,
+            Err(_) => {
+                last_error = Some(TransportError::ListenPort);
+                continue;
+            }
+        };
+        endpoint.set_default_client_config(QUIC_CONFIG.clone());
 
-    let connection = endpoint
-        .connect(address, &domain)
-        .map_err(|e| TransportError::QuicConnection(address.to_string(), e))?
-        .await
-        .map_err(|e| TransportError::Connection(address.to_string(), e.into()))?;
+        let connecting = match endpoint.connect(address, &domain) {
+            Ok(connecting) => connecting,
+            Err(e) => {
+                last_error = Some(TransportError::QuicConnection(address.to_string(), e));
+                continue;
+            }
+        };
 
-    cache.insert(key, (endpoint, connection.clone()));
+        match connecting.await {
+            Ok(connection) => {
+                cache.insert(key, (endpoint, connection.clone()));
+                return Ok(connection);
+            }
+            Err(e) => {
+                last_error = Some(TransportError::Connection(address.to_string(), e.into()));
+            }
+        }
+    }
 
-    Ok(connection)
+    Err(last_error.unwrap_or_else(|| TransportError::InvalidTransportAddress(url.to_string())))
 }
 
 /// Evict a cached connection so the next send will reconnect.

--- a/tsp_sdk/src/transport/tcp.rs
+++ b/tsp_sdk/src/transport/tcp.rs
@@ -36,14 +36,22 @@ pub(super) async fn connect_any(
 }
 
 /// Check whether the peer has closed (or otherwise poisoned) a cached
-/// connection. A healthy idle connection returns `WouldBlock`; EOF, an error,
-/// or unexpected inbound data all mean the connection must not be reused.
+/// connection, without consuming any inbound bytes (MSG_PEEK): a healthy idle
+/// connection is not readable, and inbound data — which a TLS session
+/// legitimately receives, e.g. session tickets — does not poison anything.
 /// This check must happen before sending: a write shortly after the peer
 /// closed can be accepted by the kernel and reported as success even though
 /// the message is lost, which would bypass the send retry path.
-pub(super) fn peer_closed(stream: &TcpStream) -> bool {
+pub(super) async fn peer_closed(stream: &TcpStream) -> bool {
     let mut buf = [0u8; 1];
-    !matches!(stream.try_read(&mut buf), Err(e) if e.kind() == std::io::ErrorKind::WouldBlock)
+    match tokio::time::timeout(std::time::Duration::ZERO, stream.peek(&mut buf)).await {
+        // not readable: healthy idle connection
+        Err(_elapsed) => false,
+        // EOF or socket error: the peer is gone
+        Ok(Ok(0)) | Ok(Err(_)) => true,
+        // inbound data with the connection still open
+        Ok(Ok(_)) => false,
+    }
 }
 
 /// Get an existing cached connection or create a new one.
@@ -57,7 +65,7 @@ async fn get_or_create_connection(
     let mut cache = TCP_CONNECTIONS.lock().await;
 
     if let Some(framed) = cache.get(&key)
-        && peer_closed(framed.get_ref())
+        && peer_closed(framed.get_ref()).await
     {
         cache.remove(&key);
     }

--- a/tsp_sdk/src/transport/tcp.rs
+++ b/tsp_sdk/src/transport/tcp.rs
@@ -3,6 +3,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{SinkExt, StreamExt};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex as TokioMutex, mpsc};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
@@ -16,6 +17,35 @@ pub(crate) const SCHEME: &str = "tcp";
 static TCP_CONNECTIONS: Lazy<TokioMutex<HashMap<String, Framed<TcpStream, LengthDelimitedCodec>>>> =
     Lazy::new(|| TokioMutex::new(HashMap::new()));
 
+/// Connect to the first address that accepts the connection.
+/// A host like `localhost` can resolve to both IPv6 and IPv4 addresses in
+/// nondeterministic order, while the listener may be bound to only one of them.
+pub(super) async fn connect_any(
+    addresses: &[SocketAddr],
+    url: &Url,
+) -> Result<TcpStream, TransportError> {
+    let mut last_error = None;
+    for address in addresses {
+        match TcpStream::connect(address).await {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_error = Some(TransportError::Connection(address.to_string(), e)),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| TransportError::InvalidTransportAddress(url.to_string())))
+}
+
+/// Check whether the peer has closed (or otherwise poisoned) a cached
+/// connection. A healthy idle connection returns `WouldBlock`; EOF, an error,
+/// or unexpected inbound data all mean the connection must not be reused.
+/// This check must happen before sending: a write shortly after the peer
+/// closed can be accepted by the kernel and reported as success even though
+/// the message is lost, which would bypass the send retry path.
+pub(super) fn peer_closed(stream: &TcpStream) -> bool {
+    let mut buf = [0u8; 1];
+    !matches!(stream.try_read(&mut buf), Err(e) if e.kind() == std::io::ErrorKind::WouldBlock)
+}
+
 /// Get an existing cached connection or create a new one.
 async fn get_or_create_connection(
     url: &Url,
@@ -26,18 +56,18 @@ async fn get_or_create_connection(
     let key = url.to_string();
     let mut cache = TCP_CONNECTIONS.lock().await;
 
+    if let Some(framed) = cache.get(&key)
+        && peer_closed(framed.get_ref())
+    {
+        cache.remove(&key);
+    }
+
     if let std::collections::hash_map::Entry::Vacant(entry) = cache.entry(key) {
         let addresses = url
             .socket_addrs(|| None)
             .map_err(|_| TransportError::InvalidTransportAddress(url.to_string()))?;
 
-        let Some(address) = addresses.first() else {
-            return Err(TransportError::InvalidTransportAddress(url.to_string()));
-        };
-
-        let stream = TcpStream::connect(address)
-            .await
-            .map_err(|e| TransportError::Connection(address.to_string(), e))?;
+        let stream = connect_any(&addresses, url).await?;
 
         let framed = Framed::new(stream, LengthDelimitedCodec::new());
         entry.insert(framed);
@@ -162,6 +192,82 @@ mod test {
         for expected in &messages {
             let received = incoming_stream.next().await.unwrap().unwrap();
             assert_eq!(expected.as_slice(), received.iter().as_slice());
+        }
+    }
+
+    async fn accept_and_read_one(listener: TcpListener) -> Vec<u8> {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+        framed.next().await.unwrap().unwrap().to_vec()
+    }
+
+    /// Regression test: a cached connection whose peer exited must not
+    /// swallow the next message. The kernel can accept a write on a
+    /// half-closed connection and report success, so the send has to detect
+    /// the closed peer up front and reconnect to the new listener.
+    #[tokio::test]
+    #[serial_test::serial(tcp)]
+    async fn test_tcp_reconnect_after_peer_close() {
+        let allocator = TestPortAllocator::new();
+        let port = allocator.allocate();
+        let url = Url::parse(&format!("tcp://127.0.0.1:{port}")).unwrap();
+
+        // First peer: accept one connection, read one message, then exit
+        let listener = TcpListener::bind(("127.0.0.1", port)).await.unwrap();
+        let first_peer = tokio::spawn(accept_and_read_one(listener));
+
+        send_message(b"first message", &url).await.unwrap();
+        assert_eq!(first_peer.await.unwrap(), b"first message");
+
+        // Give the FIN from the exited peer time to reach the cached connection
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Second peer on the same port; the send must reach it promptly
+        let listener = TcpListener::bind(("127.0.0.1", port)).await.unwrap();
+        let second_peer = tokio::spawn(accept_and_read_one(listener));
+
+        send_message(b"second message", &url).await.unwrap();
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), second_peer)
+            .await
+            .expect("message was lost on the stale cached connection")
+            .unwrap();
+        assert_eq!(received, b"second message");
+    }
+
+    /// Regression test: `localhost` resolves to both IPv6 and IPv4 addresses
+    /// in nondeterministic order; a listener bound to only one address family
+    /// must still be reachable by hostname.
+    #[tokio::test]
+    #[serial_test::serial(tcp)]
+    async fn test_tcp_dual_stack_hostname() {
+        let allocator = TestPortAllocator::new();
+
+        for bind_address in ["::1", "127.0.0.1"] {
+            let port = allocator.allocate();
+            let url = Url::parse(&format!("tcp://localhost:{port}")).unwrap();
+
+            let want_ipv6 = bind_address == "::1";
+            let addresses = url.socket_addrs(|| None).unwrap();
+            if !addresses.iter().any(|a| a.is_ipv6() == want_ipv6) {
+                // localhost does not resolve to this address family here
+                continue;
+            }
+
+            let listener = match TcpListener::bind((bind_address, port)).await {
+                Ok(listener) => listener,
+                // this address family is not available on this host
+                Err(_) => continue,
+            };
+            let peer = tokio::spawn(accept_and_read_one(listener));
+
+            send_message(b"hello", &url).await.unwrap();
+
+            let received = tokio::time::timeout(std::time::Duration::from_secs(5), peer)
+                .await
+                .expect("connect went to the wrong address family")
+                .unwrap();
+            assert_eq!(received, b"hello");
         }
     }
 }

--- a/tsp_sdk/src/transport/tls.rs
+++ b/tsp_sdk/src/transport/tls.rs
@@ -108,16 +108,35 @@ type TlsFramed = Framed<TlsStream<tokio::net::TcpStream>, LengthDelimitedCodec>;
 static TLS_CONNECTIONS: Lazy<TokioMutex<HashMap<String, TlsFramed>>> =
     Lazy::new(|| TokioMutex::new(HashMap::new()));
 
+/// Check whether the peer of a cached TLS connection has closed it. This
+/// probes at the TLS layer (a single zero-timeout read poll) rather than at
+/// the TCP layer: post-handshake records such as TLS 1.3 session tickets sit
+/// unread in the socket buffer of a send-only connection, so raw-TCP
+/// readability does not distinguish a healthy connection from a closed one,
+/// and a raw read would corrupt the TLS record stream. The poll lets rustls
+/// consume such records; end-of-stream, an error, or unexpected application
+/// data mean the connection must not be reused.
+async fn tls_peer_closed(framed: &mut TlsFramed) -> bool {
+    use tokio::io::AsyncReadExt;
+
+    let mut buf = [0u8; 1];
+    match tokio::time::timeout(std::time::Duration::ZERO, framed.get_mut().read(&mut buf)).await {
+        // no application data pending: healthy connection
+        Err(_elapsed) => false,
+        // clean close, error, or application data on a send-only connection
+        Ok(_) => true,
+    }
+}
+
 /// Get an existing cached TLS connection or create a new one.
 async fn get_or_create_connection(url: &Url) -> Result<(), TransportError> {
     let key = url.to_string();
     let mut cache = TLS_CONNECTIONS.lock().await;
 
-    if let Some(framed) = cache.get(&key) {
-        let (tcp_stream, _) = framed.get_ref().get_ref();
-        if super::tcp::peer_closed(tcp_stream) {
-            cache.remove(&key);
-        }
+    if let Some(framed) = cache.get_mut(&key)
+        && tls_peer_closed(framed).await
+    {
+        cache.remove(&key);
     }
 
     if let std::collections::hash_map::Entry::Vacant(entry) = cache.entry(key) {
@@ -307,6 +326,44 @@ mod tests {
         let stream = acceptor.accept(stream).await.unwrap();
         let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
         framed.next().await.unwrap().unwrap().to_vec()
+    }
+
+    /// Regression test: TLS 1.3 servers send session tickets after the
+    /// handshake; those records sit unread in the socket buffer of a
+    /// send-only connection. They must not be mistaken for a closed peer —
+    /// the cached connection has to survive and both messages must arrive on
+    /// the same server-side connection.
+    #[tokio::test]
+    #[serial_test::serial(tcp)]
+    async fn test_tls_session_tickets_do_not_evict_connection() {
+        let allocator = TestPortAllocator::new();
+        let port = allocator.allocate();
+        let url = Url::parse(&format!("tls://localhost:{port}")).unwrap();
+
+        let listener = TcpListener::bind(("127.0.0.1", port)).await.unwrap();
+        let acceptor = test_acceptor();
+        // accept a single connection and expect BOTH messages on it
+        let peer = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let stream = acceptor.accept(stream).await.unwrap();
+            let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+            let first = framed.next().await.unwrap().unwrap().to_vec();
+            let second = framed.next().await.unwrap().unwrap().to_vec();
+            (first, second)
+        });
+
+        send_message(b"first", &url).await.unwrap();
+        // let the server's post-handshake records (session tickets) reach
+        // the client's socket buffer before the next send probes the cache
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        send_message(b"second", &url).await.unwrap();
+
+        let (first, second) = tokio::time::timeout(std::time::Duration::from_secs(2), peer)
+            .await
+            .expect("connection was evicted between sends")
+            .unwrap();
+        assert_eq!(first, b"first");
+        assert_eq!(second, b"second");
     }
 
     /// Regression test: a cached connection whose peer exited must not

--- a/tsp_sdk/src/transport/tls.rs
+++ b/tsp_sdk/src/transport/tls.rs
@@ -113,18 +113,23 @@ async fn get_or_create_connection(url: &Url) -> Result<(), TransportError> {
     let key = url.to_string();
     let mut cache = TLS_CONNECTIONS.lock().await;
 
+    if let Some(framed) = cache.get(&key) {
+        let (tcp_stream, _) = framed.get_ref().get_ref();
+        if super::tcp::peer_closed(tcp_stream) {
+            cache.remove(&key);
+        }
+    }
+
     if let std::collections::hash_map::Entry::Vacant(entry) = cache.entry(key) {
         let addresses = url
             .socket_addrs(|| None)
             .map_err(|_| TransportError::InvalidTransportAddress(url.to_string()))?;
 
-        let Some(address) = addresses.first().cloned() else {
-            return Err(TransportError::InvalidTransportAddress(url.to_string()));
-        };
+        let tcp_stream = super::tcp::connect_any(&addresses, url).await?;
 
-        let tcp_stream = tokio::net::TcpStream::connect(address)
-            .await
-            .map_err(|e| TransportError::Connection(address.to_string(), e))?;
+        let address = tcp_stream
+            .peer_addr()
+            .map_err(|e| TransportError::Connection(url.to_string(), e))?;
 
         let domain = url
             .domain()
@@ -284,5 +289,54 @@ mod tests {
             let received = incoming_stream.next().await.unwrap().unwrap();
             assert_eq!(expected.as_slice(), received.iter().as_slice());
         }
+    }
+
+    fn test_acceptor() -> TlsAcceptor {
+        let (cert, key) = load_certificate().unwrap();
+        let config = rustls::ServerConfig::builder_with_provider(CRYPTO_PROVIDER.clone())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(cert, key)
+            .unwrap();
+        TlsAcceptor::from(Arc::new(config))
+    }
+
+    async fn accept_and_read_one(listener: TcpListener, acceptor: TlsAcceptor) -> Vec<u8> {
+        let (stream, _) = listener.accept().await.unwrap();
+        let stream = acceptor.accept(stream).await.unwrap();
+        let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+        framed.next().await.unwrap().unwrap().to_vec()
+    }
+
+    /// Regression test: a cached connection whose peer exited must not
+    /// swallow the next message (see the TCP variant for details).
+    #[tokio::test]
+    async fn test_tls_reconnect_after_peer_close() {
+        let allocator = TestPortAllocator::new();
+        let port = allocator.allocate();
+        let url = Url::parse(&format!("tls://localhost:{port}")).unwrap();
+
+        // First peer: accept one connection, read one message, then exit
+        let listener = TcpListener::bind(("127.0.0.1", port)).await.unwrap();
+        let first_peer = tokio::spawn(accept_and_read_one(listener, test_acceptor()));
+
+        send_message(b"first message", &url).await.unwrap();
+        assert_eq!(first_peer.await.unwrap(), b"first message");
+
+        // Give the close from the exited peer time to reach the cached connection
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Second peer on the same port; the send must reach it promptly
+        let listener = TcpListener::bind(("127.0.0.1", port)).await.unwrap();
+        let second_peer = tokio::spawn(accept_and_read_one(listener, test_acceptor()));
+
+        send_message(b"second message", &url).await.unwrap();
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), second_peer)
+            .await
+            .expect("message was lost on the stale cached connection")
+            .unwrap();
+        assert_eq!(received, b"second message");
     }
 }


### PR DESCRIPTION
Two message-delivery bugs in the cached transport connections, found by running the routed-mode scenario (CLI + two demo-intermediary processes) end to end. Both predate the rev3 branch.

## 1. Silent message loss on stale cached connections

`TCP_CONNECTIONS` (and the TLS equivalent) cache outbound connections by URL. When the peer process exits and a new one later listens on the same port, the next send through the cached dead connection can be **accepted by the kernel and reported as success** (the write is buffered before the peer's RST is processed), so `send_message` returns `Ok`, the retry path never runs, and the message is lost.

Observed live: the demo-intermediary's nested-relationship accept never reached a CLI whose previous `request --wait` process had exited ~2 seconds earlier — `lsof` showed the intermediary holding CLOSED-state sockets that were still in the cache. With a long enough gap the stale send errors and the retry path delivers, which made the bug intermittent and timing-dependent.

Fix: before reusing a cached connection, probe the socket with a non-blocking read. A healthy idle connection returns `WouldBlock`; EOF, an error, or unexpected inbound data evict the connection so the send re-establishes it. QUIC already detects this via `close_reason()`.

## 2. Dual-stack first-address connect

`get_or_create_connection` connected to only the **first** resolved address. `localhost` resolves to `::1` and `127.0.0.1` in nondeterministic order, while the listening side may be bound to only one family, so connects intermittently landed on the wrong family and were refused. Fixed in TCP, TLS, and QUIC by trying every resolved address and using the first that accepts.

Also: the intermediary now includes the operation and sender VID when logging a failed reply delivery (previously a bare "connection refused" with no context).

## Verification

- New regression tests: `test_tcp_reconnect_after_peer_close` / `test_tls_reconnect_after_peer_close` (peer exits, new listener on the same port, a send within 1s must be delivered — fails on main) and `test_tcp_dual_stack_hostname` (listener bound to a single address family, reached via hostname).
- Full `tsp_sdk` suite green; clippy/fmt clean.
- Live validation: the routed scenario a → P → Q → Q2 → b through two local demo-intermediary processes, which on main requires ~90-second waits between steps to avoid the message loss, completes immediately with this fix.
