### PR TITLE
Rev 3 protocol behavior: relationship gating, RFD, key state, route exit, discard rules

### DIFF
--- a/docs/src/cli/routed.md
+++ b/docs/src/cli/routed.md
@@ -24,11 +24,15 @@ messages to the final recipient `b`. This can be achieved in two ways:
 When this set up is done, the only thing left to send a routed message from `a` to `b`, is to set up a route.
 
 ```sh
-tsp -w a set-route b VID-FOR-P,VID-FOR-Q,VID-FOR-Q2
+tsp -w a set-route b VID-FOR-P,VID-FOR-Q,VID-FOR-B2
 ```
 
-Note, this requires `a` to have verified the VID of `p`, but it does not need to have verified the VID's `q` or `q2`. In fact, if
-the VID `q2` is an inner vid for a nested relationship, `a` will not have a way to verify it at all.
+The last entry is the *exit* of the route: `b`'s own VID at its intermediary `q`, not a VID of `q` itself
+(spec 5.3.3). `q` delivers the message over the relationship it holds with that VID, which is how it knows
+where the last hop goes.
+
+Note, this requires `a` to have verified the VID of `p`, but it does not need to have verified the VID's `q` or `b2`. In fact, if
+the VID `b2` is an inner vid for a nested relationship, `a` will not have a way to verify it at all.
 
 When this route is set up properly, sending a message proceeds as normal:
 
@@ -105,10 +109,10 @@ echo "DID_Q2=$DID_Q2"
 
 ## Send a message
 
-Now that we have set up all the relations between the nodes, we can configure the route for messages that are to be delivered from `a` to `b`. We will route these messages via `p` to `q`, and then `q2` will drop it off at `b`:
+Now that we have set up all the relations between the nodes, we can configure the route for messages that are to be delivered from `a` to `b`. We will route these messages via `p` to `q`, which drops them off at `b`'s nested VID `b2`:
 
 ```sh
-tsp -w a set-route b "p,did:web:q.teaspoon.world,$DID_Q2"
+tsp -w a set-route b "p,did:web:q.teaspoon.world,$DID_B2"
 ```
 
 Sending the routed message is trivial, now we have configured the relations and route.

--- a/examples/cli-demo-routed-cli-only.sh
+++ b/examples/cli-demo-routed-cli-only.sh
@@ -97,7 +97,8 @@ else
 fi
 
 echo "---- setup the route"
-tsp --wallet a set-route b "p,$DID_Q,$DID_Q2"
+# the exit entry of the hop list is b's own VID at q (spec 5.3.3)
+tsp --wallet a set-route b "p,$DID_Q,$DID_B2"
 
 wait
 sleep 5

--- a/examples/cli-demo-routed-external.sh
+++ b/examples/cli-demo-routed-external.sh
@@ -50,7 +50,8 @@ echo "DID_B2=$DID_B2"
 echo "DID_Q2=$DID_Q2"
 
 echo "---- setup the route"
-tsp --wallet a set-route b "p,$DID_Q,$DID_Q2"
+# the exit entry of the hop list is b's own VID at q (spec 5.3.3)
+tsp --wallet a set-route b "p,$DID_Q,$DID_B2"
 
 wait
 sleep 5

--- a/examples/cli-demo-routed-local.sh
+++ b/examples/cli-demo-routed-local.sh
@@ -50,7 +50,8 @@ echo "DID_B2=$DID_B2"
 echo "DID_Q2=$DID_Q2"
 
 echo "---- setup the route"
-tsp --wallet a set-route b "p,$DID_Q,$DID_Q2"
+# the exit entry of the hop list is b's own VID at q (spec 5.3.3)
+tsp --wallet a set-route b "p,$DID_Q,$DID_B2"
 
 wait
 sleep 5

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -1092,6 +1092,7 @@ async fn run() -> Result<(), Error> {
                 VerifyAndOpen(String, BytesMut),
                 Forward(String, Vec<BytesMut>, BytesMut),
                 AssignDefaultRelation(String, Digest),
+                ReplyCancel(String),
             }
 
             while let Some(message) = messages.next().await {
@@ -1234,8 +1235,16 @@ async fn run() -> Result<(), Error> {
                         ReceivedTspMessage::CancelRelationship {
                             sender,
                             receiver: _,
+                            reply_expected,
                         } => {
                             info!("received cancel relationship from {sender}");
+
+                            // a bidirectional relationship is cancelled in both
+                            // directions, and the specification expects the
+                            // cancellation to be echoed back (spec 7.3)
+                            if reply_expected {
+                                return Action::ReplyCancel(sender);
+                            }
                         }
                         ReceivedTspMessage::ForwardRequest {
                             sender,
@@ -1294,6 +1303,14 @@ async fn run() -> Result<(), Error> {
                             .forward_routed_message(&next_hop, route, &payload)
                             .await?;
                         info!("forwarding to next hop: {next_hop}");
+                    }
+                    Action::ReplyCancel(remote_vid) => {
+                        if let Err(e) = vid_wallet.send_relationship_cancel(&vid, &remote_vid).await
+                        {
+                            info!("could not reply to the cancellation from {remote_vid}: {e}");
+                        } else {
+                            info!("replied to the cancellation from {remote_vid}");
+                        }
                     }
                     Action::AssignDefaultRelation(remote_vid, thread_id) => {
                         // if we do not yet have a relationship with the remote VID, create a reverse unidirectional relationship

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -1099,7 +1099,15 @@ async fn run() -> Result<(), Error> {
                 trace!("Received message: {message:?}");
                 let message = match message {
                     Ok(m) => m,
-                    Err(_) => break,
+                    // one message was discarded; the next one may be fine
+                    Err(e) if !e.ends_stream() => {
+                        debug!("discarded an incoming message: {e}");
+                        continue;
+                    }
+                    Err(e) => {
+                        info!("stopped listening: {e}");
+                        break;
+                    }
                 };
                 let handle_message = |message: ReceivedTspMessage| {
                     match message {

--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -386,22 +386,32 @@ async fn new_message(
 ) -> Response {
     let mut message: BytesMut = body.into();
 
+    // A message that fails verification or validation is discarded without a
+    // distinguishing response: answering would tell whoever sent it what the
+    // node knows and which of its checks failed (spec 3.7). The reason is
+    // logged locally instead.
+    fn discard(reason: &str) -> Response {
+        tracing::debug!("discarded an incoming message: {reason}");
+
+        StatusCode::OK.into_response()
+    }
+
     let Ok((sender, Some(receiver))) = cesr::get_sender_receiver(&message) else {
         tracing::error!(
             "{} encountered invalid message, receiver missing",
             state.domain,
         );
 
-        return (StatusCode::BAD_REQUEST, "invalid message, receiver missing").into_response();
+        return discard("invalid message, receiver missing");
     };
 
     let Ok(sender) = std::str::from_utf8(sender) else {
-        return (StatusCode::BAD_REQUEST, "invalid sender").into_response();
+        return discard("invalid sender");
     };
     let sender = sender.to_string();
 
     let Ok(receiver) = std::str::from_utf8(receiver) else {
-        return (StatusCode::BAD_REQUEST, "invalid receiver").into_response();
+        return discard("invalid receiver");
     };
     let receiver = receiver.to_string();
 
@@ -446,7 +456,7 @@ async fn new_message(
     tracing::debug!("verifying VID {sender} for {receiver}");
     if let Err(e) = state.verify_vid(&sender).await {
         tracing::error!("error verifying VID {sender}: {e}");
-        return (StatusCode::BAD_REQUEST, "error verifying VID").into_response();
+        return discard("error verifying VID");
     }
 
     let handle_relationship_request =
@@ -530,7 +540,7 @@ async fn new_message(
                         "error delivering relationship accept to {sender}: {e}"
                     ))
                     .await;
-                return (StatusCode::BAD_REQUEST, "error accepting relationship").into_response();
+                return discard("error accepting relationship");
             }
 
             state.log(if let Some(nested_vid) = nested_vid {
@@ -565,8 +575,7 @@ async fn new_message(
                 tracing::debug!("verifying VID next hop {next_hop}");
                 if let Err(e) = state.verify_vid(&next_hop).await {
                     tracing::error!("error verifying VID {next_hop}: {e}");
-                    return (StatusCode::BAD_REQUEST, "error verifying next hop VID")
-                        .into_response();
+                    return discard("error verifying next hop VID");
                 }
 
                 let store = state.db.read().await;
@@ -580,7 +589,7 @@ async fn new_message(
                 {
                     let err = format!("error forming relation with VID {next_hop}: {err}");
                     state.log_error(err).await;
-                    return (StatusCode::BAD_REQUEST, "error forwarding message").into_response();
+                    return discard("error forwarding message");
                 }
                 tracing::trace!("Releasing lock guard on AsyncStore");
                 drop(store);
@@ -594,7 +603,7 @@ async fn new_message(
                 Ok(res) => res,
                 Err(e) => {
                     state.log_error(e.to_string()).await;
-                    return (StatusCode::BAD_REQUEST, "error forwarding message").into_response();
+                    return discard("error forwarding message");
                 }
             };
 
@@ -606,8 +615,7 @@ async fn new_message(
 
                 if let Err(e) = transport::send_message(&transport, &message).await {
                     state.log_error(e.to_string()).await;
-                    return (StatusCode::BAD_REQUEST, "error sending forwarded message")
-                        .into_response();
+                    return discard("error sending forwarded message");
                 }
 
                 state

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -476,6 +476,7 @@ pub struct FlatReceivedTspMessage {
     nested_vid: Option<String>,
     thread_id: Option<Vec<u8>>,
     reply_thread_id: Option<Vec<u8>>,
+    pub reply_expected: Option<bool>,
     next_hop: Option<String>,
     payload: Option<Vec<u8>>,
     opaque_payload: Option<Vec<u8>>,
@@ -621,6 +622,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             opaque_payload: None,
             unknown_vid: None,
             new_vid: None,
+            reply_expected: None,
         };
 
         if let Some((unknown_vid, payload)) = value.pending_message_parts() {
@@ -687,9 +689,14 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.reply_thread_id = Some(reply_thread_id.to_vec());
                 this.new_vid = new_vid;
             }
-            tsp_sdk::ReceivedTspMessage::CancelRelationship { sender, receiver } => {
+            tsp_sdk::ReceivedTspMessage::CancelRelationship {
+                sender,
+                receiver,
+                reply_expected,
+            } => {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
+                this.reply_expected = Some(reply_expected);
             }
             tsp_sdk::ReceivedTspMessage::ForwardRequest {
                 sender,

--- a/tsp_node/test.js
+++ b/tsp_node/test.js
@@ -54,6 +54,11 @@ describe('tsp node tests', function() {
         store.add_private_vid(alice);
         store.add_private_vid(bob);
 
+        // an application message is only accepted inside a relationship, and a
+        // sender forms one with its first message (spec 3.6, 7.2.2)
+        let { sealed: request } = store.make_relationship_request(alice_identifier, bob_identifier, null);
+        store.open_message(request);
+
         let message = "hello world";
 
         let { url, sealed } = store.seal_message(alice_identifier, bob_identifier, message);
@@ -261,11 +266,15 @@ describe('tsp node tests', function() {
         // Set relations and routes
         a_store.make_relationship_request(nette_a.identifier(), b.identifier());
         a_store.make_relationship_request(sneaky_a.identifier(), sneaky_d.identifier());
-        a_store.set_route_for_vid(sneaky_d.identifier(), [b.identifier(), c.identifier(), mailbox_c.identifier()]);
+        // the exit entry is the destination's own VID at its intermediary
+        a_store.set_route_for_vid(sneaky_d.identifier(), [b.identifier(), c.identifier(), nette_d.identifier()]);
 
         b_store.make_relationship_request(b.identifier(), c.identifier());
 
         c_store.make_relationship_request(mailbox_c.identifier(), nette_d.identifier());
+
+        // the destination has an endpoint-to-endpoint relationship with the source
+        d_store.make_relationship_request(sneaky_d.identifier(), sneaky_a.identifier());
 
         // Prepare a message to be sent from a_store
         let hello_world = "hello world";

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -445,6 +445,8 @@ struct FlatReceivedTspMessage {
     #[pyo3(get, set)]
     reply_thread_id: Option<[u8; 32]>,
     #[pyo3(get, set)]
+    reply_expected: Option<bool>,
+    #[pyo3(get, set)]
     next_hop: Option<String>,
     #[pyo3(get, set)]
     payload: Option<Vec<u8>>,
@@ -508,6 +510,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             opaque_payload: None,
             unknown_vid: None,
             new_vid: None,
+            reply_expected: None,
         };
 
         match value {
@@ -567,9 +570,14 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.reply_thread_id = Some(reply_thread_id);
                 this.new_vid = new_vid;
             }
-            tsp_sdk::ReceivedTspMessage::CancelRelationship { sender, receiver } => {
+            tsp_sdk::ReceivedTspMessage::CancelRelationship {
+                sender,
+                receiver,
+                reply_expected,
+            } => {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
+                this.reply_expected = Some(reply_expected);
             }
             tsp_sdk::ReceivedTspMessage::ForwardRequest {
                 sender,

--- a/tsp_python/test.py
+++ b/tsp_python/test.py
@@ -48,6 +48,13 @@ class AliceBob(unittest.TestCase):
     def test_open_seal(self):
         message = b"hello world"
 
+        # an application message is only accepted inside a relationship, and a
+        # sender forms one with its first message (spec 3.6, 7.2.2)
+        _url, request = self.store.make_relationship_request(
+            self.alice.identifier(), self.bob.identifier(), None
+        )
+        self.store.open_message(request)
+
         url, sealed = self.store.seal_message(
             self.alice.identifier(), self.bob.identifier(), message
         )
@@ -262,8 +269,7 @@ class AliceBob(unittest.TestCase):
         b_store.add_verified_owned_vid(c)
 
         c_store.add_verified_owned_vid(b)
-        c_store.add_private_vid(nette_d)
-        # TODO: fix routed mode (should not require private vid for setting drop off)
+        c_store.add_verified_owned_vid(nette_d)
 
         d_store.add_verified_owned_vid(sneaky_a)
         d_store.add_verified_owned_vid(mailbox_c)
@@ -276,15 +282,21 @@ class AliceBob(unittest.TestCase):
             sneaky_a.identifier(), sneaky_d.identifier(), None
         )
 
+        # the exit entry is the destination's own VID at its intermediary
         a_store.set_route_for_vid(
             sneaky_d.identifier(),
-            [b.identifier(), c.identifier(), mailbox_c.identifier()],
+            [b.identifier(), c.identifier(), nette_d.identifier()],
         )
 
         b_store.make_relationship_request(b.identifier(), c.identifier(), None)
 
         c_store.make_relationship_request(
-            nette_d.identifier(), mailbox_c.identifier(), None
+            mailbox_c.identifier(), nette_d.identifier(), None
+        )
+
+        # the destination has an endpoint-to-endpoint relationship with the source
+        d_store.make_relationship_request(
+            sneaky_d.identifier(), sneaky_a.identifier(), None
         )
 
         # that was all the setup, now let's run some things

--- a/tsp_sdk/benches/common/bench.rs
+++ b/tsp_sdk/benches/common/bench.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use tsp_sdk::{
-    ReceivedTspMessage, SecureStore, VerifiedVid,
+    ReceivedTspMessage, RelationshipStatus, SecureStore, VerifiedVid,
     cesr::decode_envelope,
     crypto::{blake2b256, sha256},
     definitions::Payload,
@@ -39,6 +39,23 @@ pub fn setup_store(_benchmark_id: &'static str, payload_len: usize) -> StoreCase
     let store = SecureStore::new();
     store.add_private_vid(alice.clone(), None).unwrap();
     store.add_private_vid(bob.clone(), None).unwrap();
+
+    // application messages are only accepted within an established
+    // relationship (spec 7.2.2); the benchmark measures the message path, not
+    // the relationship forming that precedes it
+    for (local, remote) in [(&alice, &bob), (&bob, &alice)] {
+        store
+            .set_relation_and_status_for_vid(
+                remote.identifier(),
+                RelationshipStatus::Bidirectional {
+                    thread_id: [0x11; 32],
+                    remote_thread_id: [0x22; 32],
+                    outstanding_nested_requests: vec![],
+                },
+                local.identifier(),
+            )
+            .unwrap();
+    }
 
     StoreCase {
         store,

--- a/tsp_sdk/benches/throughput_cli.rs
+++ b/tsp_sdk/benches/throughput_cli.rs
@@ -64,10 +64,12 @@ fn fixture_owned_vid_with_transport(which: &str, transport: &Url) -> OwnedVid {
     serde_json::from_str(&value.to_string()).expect("fixture must deserialize as OwnedVid")
 }
 
-fn relationship_bi_default() -> RelationshipStatus {
+fn relationship_bi_bench() -> RelationshipStatus {
+    // distinct non-zero thread ids: the all-zero digest is the NULL digest of
+    // a TSP_RFD, not a thread id a relationship would hold
     RelationshipStatus::Bidirectional {
-        thread_id: [0u8; 32],
-        remote_thread_id: [0u8; 32],
+        thread_id: [0x11u8; 32],
+        remote_thread_id: [0x22u8; 32],
         outstanding_nested_requests: vec![],
     }
 }
@@ -113,9 +115,9 @@ fn bench_send_receive_direct(c: &mut Criterion, backend: &'static str, payload_l
                 .unwrap();
 
                 alice
-                    .set_relation_and_status_for_vid(&bob_id, relationship_bi_default(), &alice_id)
+                    .set_relation_and_status_for_vid(&bob_id, relationship_bi_bench(), &alice_id)
                     .unwrap();
-                bob.set_relation_and_status_for_vid(&alice_id, relationship_bi_default(), &bob_id)
+                bob.set_relation_and_status_for_vid(&alice_id, relationship_bi_bench(), &bob_id)
                     .unwrap();
 
                 let payload = bench_utils::seeded_bytes(

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -1,4 +1,6 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 
 use crate::{
     ExportVid, OwnedVid, PrivateVid, RelationshipStatus,
@@ -41,15 +43,128 @@ use url::Url;
 ///     ).await;
 /// }
 /// ```
+/// Local policy for when a peer's VID is re-resolved to obtain its current key
+/// state (spec 7.4.2). It applies to VID types whose key state the endpoint
+/// resolves for itself; where the VID implementation tracks key state
+/// continuously, resolution returns current state and these bounds do no harm.
+///
+/// The thresholds are a local choice: endpoints need not agree on them, and
+/// they are not communicated.
+#[derive(Clone, Copy, Debug)]
+pub struct KeyStatePolicy {
+    /// Re-resolve a peer's VID before acting on a message that arrives after a
+    /// silence longer than this. A peer that has been silent may have rotated
+    /// its keys without the endpoint having had any occasion to observe it, and
+    /// this bounds how long such a change may remain unobserved. `None`
+    /// disables the check.
+    pub re_verification_threshold: Option<Duration>,
+    /// The shortest interval between two resolutions of the same peer's VID.
+    /// Re-resolution can be provoked by messages that have not been
+    /// authenticated, so the rate at which any one peer is resolved is bounded.
+    pub resolution_rate_limit: Duration,
+}
+
+impl Default for KeyStatePolicy {
+    fn default() -> Self {
+        Self {
+            re_verification_threshold: Some(Duration::from_secs(24 * 60 * 60)),
+            resolution_rate_limit: Duration::from_secs(60),
+        }
+    }
+}
+
+/// When each peer was last heard from and last resolved, which is what the
+/// thresholds in [KeyStatePolicy] are measured against.
+#[derive(Default)]
+struct KeyStateTracker {
+    last_seen: HashMap<String, Instant>,
+    last_resolved: HashMap<String, Instant>,
+}
+
 #[derive(Default, Clone)]
 pub struct AsyncSecureStore {
     inner: SecureStore,
+    key_state_policy: Arc<RwLock<KeyStatePolicy>>,
+    key_state: Arc<RwLock<KeyStateTracker>>,
 }
 
 impl AsyncSecureStore {
     /// Create a new and empty store
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Set the policy for re-resolving peers' key state; see [KeyStatePolicy]
+    pub fn set_key_state_policy(&self, policy: KeyStatePolicy) -> Result<(), Error> {
+        *self.key_state_policy.write()? = policy;
+
+        Ok(())
+    }
+
+    /// The current key-state policy; see [KeyStatePolicy]
+    pub fn key_state_policy(&self) -> Result<KeyStatePolicy, Error> {
+        Ok(*self.key_state_policy.read()?)
+    }
+
+    /// Whether this peer may be resolved now, per the policy's rate limit. When
+    /// it may, the attempt is recorded, so a caller that asks must resolve.
+    fn claim_resolution_slot(&self, vid: &str) -> Result<bool, Error> {
+        let rate_limit = self.key_state_policy()?.resolution_rate_limit;
+        let mut key_state = self.key_state.write()?;
+
+        if let Some(last) = key_state.last_resolved.get(vid)
+            && last.elapsed() < rate_limit
+        {
+            return Ok(false);
+        }
+        key_state
+            .last_resolved
+            .insert(vid.to_string(), Instant::now());
+
+        Ok(true)
+    }
+
+    /// Whether this peer has been silent for longer than the re-verification
+    /// threshold, so its key state should be refreshed before we act on it.
+    fn silent_beyond_threshold(&self, vid: &str) -> Result<bool, Error> {
+        let Some(threshold) = self.key_state_policy()?.re_verification_threshold else {
+            return Ok(false);
+        };
+
+        Ok(match self.key_state.read()?.last_seen.get(vid) {
+            Some(last_seen) => last_seen.elapsed() > threshold,
+            // the rule is about acting after an observed silence; with no
+            // record of this peer there is no silence to measure, and
+            // resolving every peer on startup would make the cost of a restart
+            // grow with the size of the wallet. Verifying a VID records it, so
+            // this is the case of a wallet loaded from storage.
+            None => false,
+        })
+    }
+
+    fn record_seen(&self, vid: &str) -> Result<(), Error> {
+        self.key_state
+            .write()?
+            .last_seen
+            .insert(vid.to_string(), Instant::now());
+
+        Ok(())
+    }
+
+    /// Re-resolve a peer's VID to refresh its key state, subject to the rate
+    /// limit. Returns whether a resolution actually happened.
+    async fn refresh_key_state(&self, vid: &str) -> Result<bool, Error> {
+        if !self.claim_resolution_slot(vid)? {
+            debug!("not re-resolving {vid}: rate limited");
+            return Ok(false);
+        }
+
+        let options = VerifyVidOptions {
+            resolution_context: self.get_resolution_context(vid)?,
+        };
+        self.verify_vid_with_options(vid, None, options).await?;
+
+        Ok(true)
     }
 
     /// Export the wallet to serializable default types
@@ -169,6 +284,14 @@ impl AsyncSecureStore {
 
         let verified_vid_id = verified_vid.identifier().to_string();
         self.inner.add_verified_vid(verified_vid, metadata)?;
+
+        // resolving is how key state is confirmed: this peer's state is fresh
+        // as of now, for both of the policy's thresholds
+        self.record_seen(&verified_vid_id)?;
+        self.key_state
+            .write()?
+            .last_resolved
+            .insert(verified_vid_id.clone(), Instant::now());
 
         if let Some(context) = resolution_context {
             self.register_resolution_context(verified_vid_id.clone(), context)?;
@@ -711,32 +834,58 @@ impl AsyncSecureStore {
                         tracing::trace!("CESR-encoded message: {}", colored);
                     }
 
-                    match db_inner.open_message(&mut message) {
+                    // a peer that has been silent longer than the
+                    // re-verification threshold may have rotated its keys
+                    // unobserved; refresh its key state before acting on this
+                    // message (spec 7.4.2)
+                    if let Ok((sender, _)) = crate::cesr::get_sender_receiver(&message)
+                        && let Ok(sender) = std::str::from_utf8(sender)
+                        && db_inner.has_verified_vid(sender)?
+                        && self_inner.silent_beyond_threshold(sender)?
+                    {
+                        debug!("re-resolving {sender} after silence");
+                        if let Err(e) = self_inner.refresh_key_state(sender).await {
+                            // acting on a message whose key state could not be
+                            // confirmed is exactly what the rule forbids
+                            debug!("could not confirm the key state of {sender}: {e}");
+                            return Err(e);
+                        }
+                    }
+
+                    let opened = match db_inner.open_message(&mut message) {
+                        // first contact: the sender is not in the wallet yet,
+                        // so it has to be resolved before the message can be
+                        // opened at all
                         Err(Error::UnverifiedSource(unknown_vid, _)) => {
                             debug!("Verifying VID: {}", unknown_vid);
-                            let options = VerifyVidOptions {
-                                resolution_context: self_inner
-                                    .get_resolution_context(&unknown_vid)?,
-                            };
-                            self_inner
-                                .verify_vid_with_options(&unknown_vid, None, options)
-                                .await?;
+                            if !self_inner.refresh_key_state(&unknown_vid).await? {
+                                return Err(Error::UnverifiedVid(unknown_vid));
+                            }
                             db_inner.open_message(&mut message)
                         }
-                        Err(Error::Crypto(CryptoError::Verify(vid, _))) => {
-                            debug!("Re-verifying VID: {}", vid);
-                            let options = VerifyVidOptions {
-                                resolution_context: self_inner.get_resolution_context(&vid)?,
-                            };
-                            self_inner
-                                .verify_vid_with_options(&vid, None, options)
-                                .await?;
-                            db_inner.open_message(&mut message)
+                        // a signature that does not verify may be the result of
+                        // a rotation we have not observed: within an
+                        // established relationship, re-resolve and retry once
+                        // before discarding (spec 3.7, 7.4.2)
+                        Err(Error::Crypto(CryptoError::Verify(vid, reason))) => {
+                            if db_inner.has_relationship_with(&vid)? {
+                                debug!("Re-verifying VID: {}", vid);
+                                self_inner.refresh_key_state(&vid).await?;
+                                db_inner.open_message(&mut message)
+                            } else {
+                                Err(Error::Crypto(CryptoError::Verify(vid, reason)))
+                            }
                         }
                         maybe_message => maybe_message,
+                    };
+
+                    if let Ok(message) = &opened
+                        && let Some(sender) = message.sender()
+                    {
+                        self_inner.record_seen(sender)?;
                     }
-                    .map(|msg| msg.into_owned())
-                    .map_err(|e| {
+
+                    opened.map(|msg| msg.into_owned()).map_err(|e| {
                         tracing::debug!("Message processing error (non-fatal): {}", e);
                         e
                     })
@@ -880,6 +1029,55 @@ fn verification_resolution_context(
 mod tests {
     use super::*;
     use crate::vid::did::scid::{ScidLocator, ScidMethod, ScidResolutionContext, ScidSourceMethod};
+
+    #[test]
+    fn resolution_is_rate_limited_per_peer() {
+        let store = AsyncSecureStore::new();
+        store
+            .set_key_state_policy(KeyStatePolicy {
+                re_verification_threshold: None,
+                resolution_rate_limit: Duration::from_millis(80),
+            })
+            .unwrap();
+
+        assert!(store.claim_resolution_slot("did:test:alice").unwrap());
+        // a second attempt within the interval is refused ...
+        assert!(!store.claim_resolution_slot("did:test:alice").unwrap());
+        // ... but the limit is per peer
+        assert!(store.claim_resolution_slot("did:test:bob").unwrap());
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(store.claim_resolution_slot("did:test:alice").unwrap());
+    }
+
+    #[test]
+    fn silence_beyond_the_threshold_is_detected() {
+        let store = AsyncSecureStore::new();
+        store
+            .set_key_state_policy(KeyStatePolicy {
+                re_verification_threshold: Some(Duration::from_millis(80)),
+                resolution_rate_limit: Duration::from_secs(60),
+            })
+            .unwrap();
+
+        // a peer we have no record of has no observed silence to measure
+        assert!(!store.silent_beyond_threshold("did:test:alice").unwrap());
+
+        store.record_seen("did:test:alice").unwrap();
+        assert!(!store.silent_beyond_threshold("did:test:alice").unwrap());
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(store.silent_beyond_threshold("did:test:alice").unwrap());
+
+        // the check is disabled when no threshold is set
+        store
+            .set_key_state_policy(KeyStatePolicy {
+                re_verification_threshold: None,
+                resolution_rate_limit: Duration::from_secs(60),
+            })
+            .unwrap();
+        assert!(!store.silent_beyond_threshold("did:test:alice").unwrap());
+    }
 
     #[test]
     fn verification_context_prefers_explicit_options() {

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -390,14 +390,18 @@ impl AsyncSecureStore {
     /// }
     /// ```
     pub async fn send(&self, sender: &str, receiver: &str, message: &[u8]) -> Result<(), Error> {
+        // the first message of a relationship must carry the relationship
+        // forming fields (spec 3.6), so form the relationship first
         match self.inner.relation_status_for_vid_pair(sender, receiver) {
             Ok(relation) => {
                 if matches!(relation, RelationshipStatus::Unrelated) {
+                    self.warn_on_direct_relationship_forming(receiver)?;
                     self.send_relationship_request(sender, receiver, None)
                         .await?
                 }
             }
             Err(Error::Relationship(_)) => {
+                self.warn_on_direct_relationship_forming(receiver)?;
                 self.send_relationship_request(sender, receiver, None)
                     .await?
             }
@@ -409,6 +413,24 @@ impl AsyncSecureStore {
         tracing::info!("sending message to {endpoint}");
 
         crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
+    /// Warn when a relationship is about to be formed directly with a receiver
+    /// for which a route is configured. The specification requires the
+    /// relationship forming message itself to travel the route in that case
+    /// (spec 7.2.4), carrying a Reply_Path; sending it directly reveals to the
+    /// destination, and to anyone observing, an endpoint the route exists to
+    /// keep out of view. Routed relationship forming is not implemented yet.
+    fn warn_on_direct_relationship_forming(&self, receiver: &str) -> Result<(), Error> {
+        if self.inner.has_route_for_vid(receiver)? {
+            tracing::warn!(
+                "forming a relationship with {receiver} directly although a route is set for it: \
+                 routed relationship forming is not implemented, so this message does not take \
+                 the route"
+            );
+        }
 
         Ok(())
     }
@@ -823,74 +845,97 @@ impl AsyncSecureStore {
 
         let db = self.inner.clone();
         let self_clone = self.clone();
-        let stream: TSPStream<ReceivedTspMessage, Error> =
-            Box::pin(messages.then(move |message| {
-                let db_inner = db.clone();
-                let self_inner = self_clone.clone();
-                async move {
-                    let mut message = message?;
+        // A message that fails any verification or validation step is discarded
+        // silently, which is a rule about the wire: nothing is sent in
+        // response, since a response would disclose information to whoever
+        // sent it (spec 3.7). It says nothing about the local caller, so the
+        // failure is passed on and what to make of it is the caller's to
+        // decide. It does not end the stream.
+        let stream: TSPStream<ReceivedTspMessage, Error> = Box::pin(
+            messages
+                .then(move |message| {
+                    let db_inner = db.clone();
+                    let self_inner = self_clone.clone();
+                    async move {
+                        let mut message = message?;
 
-                    if let Ok(colored) = crate::cesr::color_format(&message) {
-                        tracing::trace!("CESR-encoded message: {}", colored);
-                    }
-
-                    // a peer that has been silent longer than the
-                    // re-verification threshold may have rotated its keys
-                    // unobserved; refresh its key state before acting on this
-                    // message (spec 7.4.2)
-                    if let Ok((sender, _)) = crate::cesr::get_sender_receiver(&message)
-                        && let Ok(sender) = std::str::from_utf8(sender)
-                        && db_inner.has_verified_vid(sender)?
-                        && self_inner.silent_beyond_threshold(sender)?
-                    {
-                        debug!("re-resolving {sender} after silence");
-                        if let Err(e) = self_inner.refresh_key_state(sender).await {
-                            // acting on a message whose key state could not be
-                            // confirmed is exactly what the rule forbids
-                            debug!("could not confirm the key state of {sender}: {e}");
-                            return Err(e);
+                        if let Ok(colored) = crate::cesr::color_format(&message) {
+                            tracing::trace!("CESR-encoded message: {}", colored);
                         }
-                    }
 
-                    let opened = match db_inner.open_message(&mut message) {
-                        // first contact: the sender is not in the wallet yet,
-                        // so it has to be resolved before the message can be
-                        // opened at all
-                        Err(Error::UnverifiedSource(unknown_vid, _)) => {
-                            debug!("Verifying VID: {}", unknown_vid);
-                            if !self_inner.refresh_key_state(&unknown_vid).await? {
-                                return Err(Error::UnverifiedVid(unknown_vid));
-                            }
-                            db_inner.open_message(&mut message)
-                        }
-                        // a signature that does not verify may be the result of
-                        // a rotation we have not observed: within an
-                        // established relationship, re-resolve and retry once
-                        // before discarding (spec 3.7, 7.4.2)
-                        Err(Error::Crypto(CryptoError::Verify(vid, reason))) => {
-                            if db_inner.has_relationship_with(&vid)? {
-                                debug!("Re-verifying VID: {}", vid);
-                                self_inner.refresh_key_state(&vid).await?;
-                                db_inner.open_message(&mut message)
-                            } else {
-                                Err(Error::Crypto(CryptoError::Verify(vid, reason)))
+                        // a peer that has been silent longer than the
+                        // re-verification threshold may have rotated its keys
+                        // unobserved; refresh its key state before acting on this
+                        // message (spec 7.4.2)
+                        if let Ok((sender, _)) = crate::cesr::get_sender_receiver(&message)
+                            && let Ok(sender) = std::str::from_utf8(sender)
+                            && db_inner.has_verified_vid(sender)?
+                            && self_inner.silent_beyond_threshold(sender)?
+                        {
+                            debug!("re-resolving {sender} after silence");
+                            if let Err(e) = self_inner.refresh_key_state(sender).await {
+                                // acting on a message whose key state could not be
+                                // confirmed is exactly what the rule forbids
+                                debug!("could not confirm the key state of {sender}: {e}");
+                                return Ok(None);
                             }
                         }
-                        maybe_message => maybe_message,
-                    };
 
-                    if let Ok(message) = &opened
-                        && let Some(sender) = message.sender()
-                    {
-                        self_inner.record_seen(sender)?;
+                        let opened = match db_inner.open_message(&mut message) {
+                            // first contact: the sender is not in the wallet yet,
+                            // so it has to be resolved before the message can be
+                            // opened at all
+                            Err(Error::UnverifiedSource(unknown_vid, _)) => {
+                                debug!("Verifying VID: {}", unknown_vid);
+                                match self_inner.refresh_key_state(&unknown_vid).await {
+                                    Ok(true) => db_inner.open_message(&mut message),
+                                    Ok(false) => Err(Error::UnverifiedVid(unknown_vid)),
+                                    Err(e) => Err(e),
+                                }
+                            }
+                            // a signature that does not verify may be the result of
+                            // a rotation we have not observed: within an
+                            // established relationship, re-resolve and retry once
+                            // before discarding (spec 3.7, 7.4.2)
+                            Err(Error::Crypto(CryptoError::Verify(vid, reason))) => {
+                                if db_inner.has_relationship_with(&vid)?
+                                    && self_inner.refresh_key_state(&vid).await.is_ok()
+                                {
+                                    debug!("Re-verifying VID: {}", vid);
+                                    db_inner.open_message(&mut message)
+                                } else {
+                                    Err(Error::Crypto(CryptoError::Verify(vid, reason)))
+                                }
+                            }
+                            maybe_message => maybe_message,
+                        };
+
+                        match opened {
+                            Ok(message) => {
+                                if let Some(sender) = message.sender() {
+                                    self_inner.record_seen(sender)?;
+                                }
+
+                                Ok(Some(message.into_owned()))
+                            }
+                            Err(e) => {
+                                debug!("discarded a message that failed validation: {e}");
+
+                                Ok(None)
+                            }
+                        }
                     }
-
-                    opened.map(|msg| msg.into_owned()).map_err(|e| {
-                        tracing::debug!("Message processing error (non-fatal): {}", e);
-                        e
-                    })
-                }
-            }));
+                })
+                .filter_map(|result| async move {
+                    match result {
+                        Ok(Some(message)) => Some(Ok(message)),
+                        // silently discarded
+                        Ok(None) => None,
+                        // a transport failure, which is not a message failure
+                        Err(e) => Some(Err(e)),
+                    }
+                }),
+        );
 
         Ok((stream, cursor))
     }

--- a/tsp_sdk/src/definitions/conversions.rs
+++ b/tsp_sdk/src/definitions/conversions.rs
@@ -87,7 +87,15 @@ impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
                     ReceivedRelationshipDelivery::Routed => ReceivedRelationshipDelivery::Routed,
                 },
             },
-            CancelRelationship { sender, receiver } => CancelRelationship { sender, receiver },
+            CancelRelationship {
+                sender,
+                receiver,
+                reply_expected,
+            } => CancelRelationship {
+                sender,
+                receiver,
+                reply_expected,
+            },
             ForwardRequest {
                 sender,
                 receiver,

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -64,7 +64,6 @@ pub struct PendingIncomingParallelRelationship {
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub enum RelationshipStatus {
-    _Controlled,
     Bidirectional {
         thread_id: Digest,
         remote_thread_id: Digest,
@@ -92,7 +91,6 @@ impl RelationshipStatus {
 impl Display for RelationshipStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RelationshipStatus::_Controlled => write!(f, "Controlled"),
             RelationshipStatus::Bidirectional { .. } => write!(f, "Bidirectional"),
             RelationshipStatus::Unidirectional { .. } => write!(f, "Unidirectional"),
             RelationshipStatus::ReverseUnidirectional { .. } => write!(f, "ReverseUnidirectional"),

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -159,6 +159,22 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
 }
 
 impl<Data: AsRef<[u8]>> ReceivedTspMessage<Data> {
+    /// The VID that sent this message, where the message names one. A pending
+    /// message names a VID that could not be resolved, so it has no sender.
+    pub fn sender(&self) -> Option<&str> {
+        match self {
+            ReceivedTspMessage::GenericMessage { sender, .. }
+            | ReceivedTspMessage::RequestRelationship { sender, .. }
+            | ReceivedTspMessage::AcceptRelationship { sender, .. }
+            | ReceivedTspMessage::CancelRelationship { sender, .. }
+            | ReceivedTspMessage::ForwardRequest { sender, .. } => Some(sender),
+            #[cfg(feature = "async")]
+            ReceivedTspMessage::PendingMessage { .. } => None,
+        }
+    }
+}
+
+impl<Data: AsRef<[u8]>> ReceivedTspMessage<Data> {
     pub fn pending_message_parts(&self) -> Option<(&str, &[u8])> {
         #[cfg(feature = "async")]
         {

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -140,6 +140,11 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
     CancelRelationship {
         sender: String,
         receiver: String,
+        /// Whether the specification expects a `TSP_RFD` in reply: it does when
+        /// the cancelled relationship was bidirectional, and does not when it
+        /// was one-way (spec 7.3). The relationship has already been removed
+        /// either way; sending the reply is the application's to do.
+        reply_expected: bool,
     },
     ForwardRequest {
         sender: String,

--- a/tsp_sdk/src/error.rs
+++ b/tsp_sdk/src/error.rs
@@ -49,6 +49,21 @@ pub enum Error {
     Internal,
 }
 
+impl Error {
+    /// Whether this error describes the message stream itself failing, rather
+    /// than a single message that was discarded. Discarding one message does
+    /// not end a stream, so a caller can distinguish the two and go on
+    /// listening after the first.
+    pub fn ends_stream(&self) -> bool {
+        #[cfg(feature = "async")]
+        let ends_stream = matches!(self, Error::Transport(_));
+        #[cfg(not(feature = "async"))]
+        let ends_stream = false;
+
+        ends_stream
+    }
+}
+
 impl<T> From<std::sync::PoisonError<T>> for Error {
     fn from(_: std::sync::PoisonError<T>) -> Self {
         Self::Internal

--- a/tsp_sdk/src/error.rs
+++ b/tsp_sdk/src/error.rs
@@ -43,6 +43,8 @@ pub enum Error {
     InvalidNextHop(String),
     #[error("Error: no relation established for {0}")]
     MissingDropOff(String),
+    #[error("Error: no relationship from {0} to {1}; the message is dropped")]
+    UnestablishedRelationship(String, String),
     #[error("Internal error")]
     Internal,
 }

--- a/tsp_sdk/src/secure_storage.rs
+++ b/tsp_sdk/src/secure_storage.rs
@@ -120,7 +120,8 @@ impl From<LegacyMetadata> for Metadata {
 impl From<LegacyRelationshipStatus> for RelationshipStatus {
     fn from(value: LegacyRelationshipStatus) -> Self {
         match value {
-            LegacyRelationshipStatus::_Controlled => RelationshipStatus::_Controlled,
+            // a state that was never entered and carried no relationship
+            LegacyRelationshipStatus::_Controlled => RelationshipStatus::Unrelated,
             LegacyRelationshipStatus::Bidirectional {
                 thread_id,
                 remote_thread_id,

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -1070,21 +1070,20 @@ impl SecureStore {
         opaque_payload: &[u8],
     ) -> Result<(Url, Vec<u8>), Error> {
         if route.is_empty() {
-            // we are the final delivery point, we should be the 'next_hop'
-            let sender = self.get_vid(next_hop)?;
+            // We are the destination's intermediary. The exit entry of a hop
+            // list is the destination's own VID at this intermediary (spec
+            // 5.3.3), so deliver over the relationship this intermediary holds
+            // with it; if there is none, the specification calls it an error.
+            let destination = self.get_vid(next_hop)?;
 
-            let Some(sender_private) = &sender.private else {
-                return Err(Error::MissingPrivateVid(next_hop.to_string()));
+            let Some(local_vid) = destination.get_relation_vid() else {
+                return Err(Error::MissingDropOff(next_hop.to_string()));
             };
-
-            let recipient = match sender.get_relation_vid() {
-                Some(destination) => self.get_verified_vid(destination)?,
-                None => return Err(Error::MissingDropOff(sender.vid.identifier().to_string())),
-            };
+            let sender_private = self.get_private_vid(local_vid)?;
 
             self.seal_message_payload(
                 sender_private.identifier(),
-                recipient.identifier(),
+                destination.vid.identifier(),
                 Payload::NestedMessage(opaque_payload),
             )
         } else {
@@ -3597,7 +3596,7 @@ mod test {
         a_store
             .set_route_for_vid(
                 sneaky_d.identifier(),
-                &[b.identifier(), c.identifier(), mailbox_c.identifier()],
+                &[b.identifier(), c.identifier(), nette_d.identifier()],
             )
             .unwrap();
 
@@ -3613,11 +3612,11 @@ mod test {
 
         c_store
             .set_relation_and_status_for_vid(
-                mailbox_c.identifier(),
+                nette_d.identifier(),
                 RelationshipStatus::Unidirectional {
                     thread_id: Default::default(),
                 },
-                nette_d.identifier(),
+                mailbox_c.identifier(),
             )
             .unwrap();
 

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -1255,8 +1255,7 @@ impl SecureStore {
                         if let ReceivedRelationshipForm::Parallel { new_vid, .. } = &form {
                             match self.relation_status_for_vid_pair(&intended_receiver, &sender)? {
                                 RelationshipStatus::Bidirectional { .. } => {}
-                                RelationshipStatus::_Controlled
-                                | RelationshipStatus::Unidirectional { .. }
+                                RelationshipStatus::Unidirectional { .. }
                                 | RelationshipStatus::ReverseUnidirectional { .. }
                                 | RelationshipStatus::Unrelated => {
                                     return Err(requires_existing_parallel_relationship_error());
@@ -1520,8 +1519,7 @@ impl SecureStore {
 
         match self.relation_status_for_vid_pair(sender.identifier(), receiver.identifier())? {
             RelationshipStatus::Bidirectional { .. } => {}
-            RelationshipStatus::_Controlled
-            | RelationshipStatus::Unidirectional { .. }
+            RelationshipStatus::Unidirectional { .. }
             | RelationshipStatus::ReverseUnidirectional { .. }
             | RelationshipStatus::Unrelated => {
                 return Err(requires_existing_parallel_relationship_error());
@@ -1664,7 +1662,7 @@ impl SecureStore {
             RelationshipStatus::Bidirectional { thread_id, .. } => thread_id,
             RelationshipStatus::Unidirectional { thread_id } => thread_id,
             RelationshipStatus::ReverseUnidirectional { thread_id } => thread_id,
-            RelationshipStatus::_Controlled | RelationshipStatus::Unrelated => {
+            RelationshipStatus::Unrelated => {
                 return Err(Error::Relationship("no relationship to cancel".into()));
             }
         };
@@ -1875,8 +1873,7 @@ impl SecureStore {
             // a repeated or renewed invite in an existing relationship: the
             // status already permits this direction, so leave it untouched
             RelationshipStatus::ReverseUnidirectional { .. }
-            | RelationshipStatus::Bidirectional { .. }
-            | RelationshipStatus::_Controlled => Ok(()),
+            | RelationshipStatus::Bidirectional { .. } => Ok(()),
         }
     }
 
@@ -1923,7 +1920,7 @@ impl SecureStore {
 
                 false
             }
-            RelationshipStatus::Unrelated | RelationshipStatus::_Controlled => return ignore(),
+            RelationshipStatus::Unrelated => return ignore(),
         };
 
         if let Some(context) = self.vids.write()?.get_mut(remote_vid) {

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -621,6 +621,17 @@ impl SecureStore {
         }))
     }
 
+    /// Whether a route is configured for this VID
+    pub fn has_route_for_vid(&self, vid: &str) -> Result<bool, Error> {
+        let vid = self.try_resolve_alias(vid)?;
+
+        Ok(self
+            .vids
+            .read()?
+            .get(&vid)
+            .is_some_and(|context| context.get_route().is_some()))
+    }
+
     pub fn has_verified_vid(&self, vid: &str) -> Result<bool, Error> {
         match self.get_verified_vid(vid) {
             Ok(_) => Ok(true),

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -612,6 +612,15 @@ impl SecureStore {
     }
 
     /// Check whether the [VerifiedVid] identified by `vid` exists in the wallet
+    /// Whether any relationship exists in which this VID takes part
+    pub fn has_relationship_with(&self, vid: &str) -> Result<bool, Error> {
+        let vid = self.try_resolve_alias(vid)?;
+
+        Ok(self.vids.read()?.get(&vid).is_some_and(|context| {
+            !matches!(context.relation_status, RelationshipStatus::Unrelated)
+        }))
+    }
+
     pub fn has_verified_vid(&self, vid: &str) -> Result<bool, Error> {
         match self.get_verified_vid(vid) {
             Ok(_) => Ok(true),

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -243,6 +243,22 @@ pub struct WalletMethodState {
     pub resolution_contexts: ResolutionContexts,
 }
 
+/// Whether application messages from a VID with no established relationship
+/// are accepted (spec 7.2.2).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RelationshipPolicy {
+    /// Drop an application message whose sender has no relationship with the
+    /// receiving VID. A relationship must first be formed with `TSP_RFI`.
+    /// This is the behavior the specification requires of an endpoint.
+    #[default]
+    Gated,
+    /// Accept application messages from any verified sender. Intended for
+    /// nodes that are not endpoints in the specification's sense — an
+    /// intermediary accepting drop-off traffic, or a relay under upper-layer
+    /// admission control — and for tests.
+    Ungated,
+}
+
 /// Holds private and verified VIDs
 ///
 /// A Store contains verified VIDs, our relationship status to them,
@@ -255,6 +271,7 @@ pub struct SecureStore {
     pub(crate) vids: Arc<RwLock<HashMap<String, VidContext>>>,
     pub(crate) aliases: Arc<RwLock<Aliases>>,
     pub(crate) method_state: Arc<RwLock<WalletMethodState>>,
+    pub(crate) relationship_policy: Arc<RwLock<RelationshipPolicy>>,
 }
 
 /// This wallet is used to store and resolve VIDs
@@ -262,6 +279,19 @@ impl SecureStore {
     /// Create a new, empty VID wallet
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Set whether application messages from senders without an established
+    /// relationship are accepted; see [RelationshipPolicy]
+    pub fn set_relationship_policy(&self, policy: RelationshipPolicy) -> Result<(), Error> {
+        *self.relationship_policy.write()? = policy;
+
+        Ok(())
+    }
+
+    /// The current relationship policy; see [RelationshipPolicy]
+    pub fn relationship_policy(&self) -> Result<RelationshipPolicy, Error> {
+        Ok(*self.relationship_policy.read()?)
     }
 
     /// Export the wallet to serializable default types
@@ -1119,15 +1149,21 @@ impl SecureStore {
                 sender_vid.persist(self)?;
 
                 match payload {
-                    Payload::Content(message) => Ok(ReceivedTspMessage::GenericMessage {
-                        sender,
-                        receiver: Some(intended_receiver),
-                        message,
-                        message_type: MessageType {
-                            crypto_type,
-                            signature_type,
-                        },
-                    }),
+                    Payload::Content(message) => {
+                        // an application message is only accepted within an
+                        // established relationship (spec 7.2.2)
+                        self.check_relationship_gate(&intended_receiver, &sender)?;
+
+                        Ok(ReceivedTspMessage::GenericMessage {
+                            sender,
+                            receiver: Some(intended_receiver),
+                            message,
+                            message_type: MessageType {
+                                crypto_type,
+                                signature_type,
+                            },
+                        })
+                    }
                     Payload::NestedMessage(inner) => {
                         if let Some(received_message) =
                             self.try_open_nested_relationship_message(&sender, inner)?
@@ -1208,6 +1244,14 @@ impl SecureStore {
                     Payload::RequestRelationship { thread_id, form } => {
                         let form = received_relationship_form(form)?;
 
+                        if matches!(form, ReceivedRelationshipForm::Direct) {
+                            self.record_incoming_relationship_request(
+                                &intended_receiver,
+                                &sender,
+                                thread_id,
+                            )?;
+                        }
+
                         if let ReceivedRelationshipForm::Parallel { new_vid, .. } = &form {
                             match self.relation_status_for_vid_pair(&intended_receiver, &sender)? {
                                 RelationshipStatus::Bidirectional { .. } => {}
@@ -1287,35 +1331,13 @@ impl SecureStore {
                         })
                     }
                     Payload::CancelRelationship { thread_id } => {
-                        if let Some(context) = self.vids.write()?.get_mut(&sender) {
-                            match context.relation_status {
-                                RelationshipStatus::Bidirectional {
-                                    remote_thread_id: digest,
-                                    ..
-                                }
-                                | RelationshipStatus::Unidirectional { thread_id: digest }
-                                | RelationshipStatus::ReverseUnidirectional { thread_id: digest } =>
-                                {
-                                    if thread_id != digest {
-                                        return Err(Error::Relationship(
-                                            "invalid attempt to end the relationship, wrong thread_id".into(),
-                                        ));
-                                    }
-                                    context.relation_status = RelationshipStatus::Unrelated;
-                                    context.relation_vid = None;
-                                }
-                                RelationshipStatus::_Controlled => {
-                                    return Err(Error::Relationship(
-                                        "you cannot cancel a relationship with yourself".into(),
-                                    ));
-                                }
-                                RelationshipStatus::Unrelated => {}
-                            }
-                        }
+                        let reply_expected =
+                            self.cancel_relationship(&intended_receiver, &sender, thread_id)?;
 
                         Ok(ReceivedTspMessage::CancelRelationship {
                             sender,
                             receiver: intended_receiver,
+                            reply_expected,
                         })
                     }
                 }
@@ -1795,6 +1817,123 @@ impl SecureStore {
         )
     }
 
+    /// Refuse an application message from a sender with which the receiving VID
+    /// has no relationship (spec 7.2.2: a relationship must be formed with a
+    /// `TSP_RFI` first, and an application message that arrives outside one
+    /// SHOULD be dropped). Callers treat the error as a silent discard.
+    fn check_relationship_gate(&self, local_vid: &str, remote_vid: &str) -> Result<(), Error> {
+        if self.relationship_policy()? == RelationshipPolicy::Ungated {
+            return Ok(());
+        }
+
+        match self.relation_status_for_vid_pair(local_vid, remote_vid)? {
+            RelationshipStatus::Unrelated => Err(Error::UnestablishedRelationship(
+                remote_vid.to_string(),
+                local_vid.to_string(),
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    /// Record the relationship an incoming `TSP_RFI` establishes, and resolve
+    /// the race in which both endpoints sent one for the same VID pair.
+    ///
+    /// The receiving endpoint records `<VID_local, VID_remote>` so that
+    /// application messages in this direction are accepted (spec 3.5). When an
+    /// invite of our own is still outstanding for the same pair, both endpoints
+    /// keep the invite whose digest is lexicographically lower and discard the
+    /// other (spec 7.2.3); if ours wins, the incoming invite is dropped.
+    fn record_incoming_relationship_request(
+        &self,
+        local_vid: &str,
+        remote_vid: &str,
+        thread_id: Digest,
+    ) -> Result<(), Error> {
+        match self.relation_status_for_vid_pair(local_vid, remote_vid)? {
+            RelationshipStatus::Unrelated => self.set_relation_and_status_for_vid(
+                remote_vid,
+                RelationshipStatus::ReverseUnidirectional { thread_id },
+                local_vid,
+            ),
+            // our own invite is still outstanding: the lower digest wins
+            RelationshipStatus::Unidirectional {
+                thread_id: our_thread_id,
+            } => {
+                if thread_id < our_thread_id {
+                    self.set_relation_and_status_for_vid(
+                        remote_vid,
+                        RelationshipStatus::ReverseUnidirectional { thread_id },
+                        local_vid,
+                    )
+                } else {
+                    Err(Error::Relationship(format!(
+                        "concurrent relationship request from {remote_vid} discarded: \
+                         our own outstanding request has the lower digest"
+                    )))
+                }
+            }
+            // a repeated or renewed invite in an existing relationship: the
+            // status already permits this direction, so leave it untouched
+            RelationshipStatus::ReverseUnidirectional { .. }
+            | RelationshipStatus::Bidirectional { .. }
+            | RelationshipStatus::_Controlled => Ok(()),
+        }
+    }
+
+    /// Apply an incoming `TSP_RFD` (spec 7.3). A bidirectional relationship is
+    /// removed and a reply is expected; a one-way relationship is removed with
+    /// no reply; a relationship that does not exist or is not recognized is
+    /// ignored, which the caller sees as a discard. Returns whether a reply is
+    /// expected.
+    ///
+    /// The digest identifies the relationship being cancelled, but MAY be NULL
+    /// when the canceling endpoint never received one, in which case the VID
+    /// pair identifies it on its own.
+    fn cancel_relationship(
+        &self,
+        local_vid: &str,
+        remote_vid: &str,
+        thread_id: Digest,
+    ) -> Result<bool, Error> {
+        let ignore = || {
+            Err(Error::Relationship(format!(
+                "unrecognized relationship cancellation from {remote_vid}; ignored"
+            )))
+        };
+        let recognized = |expected: Digest| thread_id == Digest::default() || thread_id == expected;
+
+        let reply_expected = match self.relation_status_for_vid_pair(local_vid, remote_vid)? {
+            RelationshipStatus::Bidirectional {
+                thread_id: local,
+                remote_thread_id: remote,
+                ..
+            } => {
+                // either direction's digest identifies the relationship
+                if !recognized(local) && !recognized(remote) {
+                    return ignore();
+                }
+
+                true
+            }
+            RelationshipStatus::Unidirectional { thread_id: digest }
+            | RelationshipStatus::ReverseUnidirectional { thread_id: digest } => {
+                if !recognized(digest) {
+                    return ignore();
+                }
+
+                false
+            }
+            RelationshipStatus::Unrelated | RelationshipStatus::_Controlled => return ignore(),
+        };
+
+        if let Some(context) = self.vids.write()?.get_mut(remote_vid) {
+            context.relation_status = RelationshipStatus::Unrelated;
+            context.relation_vid = None;
+        }
+
+        Ok(reply_expected)
+    }
+
     fn upgrade_relation(
         &self,
         my_vid: &str,
@@ -2078,7 +2217,7 @@ mod test {
     use crate::{
         Error, Payload, PendingParallelRelationship, ReceivedRelationshipDelivery,
         ReceivedRelationshipForm, ReceivedTspMessage, RelationshipForm, RelationshipStatus,
-        SecureStore, VerifiedVid, crypto::CryptoError,
+        SecureStore, VerifiedVid, crypto::CryptoError, store::RelationshipPolicy,
     };
 
     fn assert_url_matches(url: &url::Url, expected_receiver: &dyn VerifiedVid) {
@@ -2187,12 +2326,245 @@ mod test {
 
     #[test]
     #[wasm_bindgen_test]
+    fn test_application_message_without_relationship_is_dropped() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        let (_url, mut sealed) = a_store
+            .seal_message(alice.identifier(), bob.identifier(), b"hello world")
+            .unwrap();
+        // open_message decrypts in place, so the second attempt needs its own copy
+        let (_url, mut sealed_again) = a_store
+            .seal_message(alice.identifier(), bob.identifier(), b"hello world")
+            .unwrap();
+
+        // bob has verified alice, but no relationship was ever formed
+        let Err(Error::UnestablishedRelationship(sender, receiver)) =
+            b_store.open_message(&mut sealed)
+        else {
+            panic!("an application message without a relationship must be dropped");
+        };
+        assert_eq!(sender, alice.identifier());
+        assert_eq!(receiver, bob.identifier());
+
+        // the same message is accepted once the receiver opts out of gating
+        b_store
+            .set_relationship_policy(RelationshipPolicy::Ungated)
+            .unwrap();
+        let received = b_store.open_message(&mut sealed_again).unwrap();
+        assert!(matches!(
+            received,
+            ReceivedTspMessage::GenericMessage { .. }
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_relationship_request_admits_following_application_message() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        let (_url, mut request) = a_store
+            .make_relationship_request(alice.identifier(), bob.identifier(), None)
+            .unwrap();
+        let (_url, mut sealed) = a_store
+            .seal_message(alice.identifier(), bob.identifier(), b"hello world")
+            .unwrap();
+
+        // receiving the invite records <bob, alice>, so the message that
+        // follows is inside an established relationship
+        assert!(matches!(
+            b_store.open_message(&mut request).unwrap(),
+            ReceivedTspMessage::RequestRelationship { .. }
+        ));
+        assert!(matches!(
+            b_store
+                .relation_status_for_vid_pair(bob.identifier(), alice.identifier())
+                .unwrap(),
+            RelationshipStatus::ReverseUnidirectional { .. }
+        ));
+        assert!(matches!(
+            b_store.open_message(&mut sealed).unwrap(),
+            ReceivedTspMessage::GenericMessage { .. }
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_concurrent_relationship_requests_keep_the_lower_digest() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        // both endpoints invite each other for the same VID pair
+        let (_url, mut a_request) = a_store
+            .make_relationship_request(alice.identifier(), bob.identifier(), None)
+            .unwrap();
+        let (_url, mut b_request) = b_store
+            .make_relationship_request(bob.identifier(), alice.identifier(), None)
+            .unwrap();
+
+        let RelationshipStatus::Unidirectional {
+            thread_id: a_digest,
+        } = a_store
+            .relation_status_for_vid_pair(alice.identifier(), bob.identifier())
+            .unwrap()
+        else {
+            panic!("alice should have an outstanding request");
+        };
+        let RelationshipStatus::Unidirectional {
+            thread_id: b_digest,
+        } = b_store
+            .relation_status_for_vid_pair(bob.identifier(), alice.identifier())
+            .unwrap()
+        else {
+            panic!("bob should have an outstanding request");
+        };
+        assert_ne!(a_digest, b_digest);
+
+        let a_result = a_store.open_message(&mut b_request);
+        let b_result = b_store.open_message(&mut a_request);
+
+        // exactly one invite survives on both sides: the one with the lower digest
+        if a_digest < b_digest {
+            assert!(a_result.is_err(), "alice keeps her own lower-digest invite");
+            assert!(b_result.is_ok(), "bob adopts alice's lower-digest invite");
+            assert!(matches!(
+                b_store
+                    .relation_status_for_vid_pair(bob.identifier(), alice.identifier())
+                    .unwrap(),
+                RelationshipStatus::ReverseUnidirectional { thread_id } if thread_id == a_digest
+            ));
+        } else {
+            assert!(b_result.is_err(), "bob keeps his own lower-digest invite");
+            assert!(a_result.is_ok(), "alice adopts bob's lower-digest invite");
+            assert!(matches!(
+                a_store
+                    .relation_status_for_vid_pair(alice.identifier(), bob.identifier())
+                    .unwrap(),
+                RelationshipStatus::ReverseUnidirectional { thread_id } if thread_id == b_digest
+            ));
+        }
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_cancel_relationship_follows_the_relationship_direction() {
+        // bidirectional: the relationship is removed and a reply is expected
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let (_url, mut cancel) = a_store
+            .make_relationship_cancel(alice.identifier(), bob.identifier())
+            .unwrap();
+        let ReceivedTspMessage::CancelRelationship { reply_expected, .. } =
+            b_store.open_message(&mut cancel).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+        assert!(
+            reply_expected,
+            "a bidirectional cancellation is echoed back"
+        );
+        assert!(matches!(
+            b_store
+                .relation_status_for_vid_pair(bob.identifier(), alice.identifier())
+                .unwrap(),
+            RelationshipStatus::Unrelated
+        ));
+
+        // one-way: the relationship is removed, but no reply is expected
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        let (_url, mut request) = a_store
+            .make_relationship_request(alice.identifier(), bob.identifier(), None)
+            .unwrap();
+        b_store.open_message(&mut request).unwrap();
+        let (_url, mut cancel) = a_store
+            .make_relationship_cancel(alice.identifier(), bob.identifier())
+            .unwrap();
+        let ReceivedTspMessage::CancelRelationship { reply_expected, .. } =
+            b_store.open_message(&mut cancel).unwrap()
+        else {
+            panic!("unexpected message type");
+        };
+        assert!(!reply_expected, "a one-way cancellation is not echoed back");
+        assert!(matches!(
+            b_store
+                .relation_status_for_vid_pair(bob.identifier(), alice.identifier())
+                .unwrap(),
+            RelationshipStatus::Unrelated
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_cancel_of_unknown_relationship_is_ignored() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        // alice believes there is a relationship; bob has none
+        a_store
+            .set_relation_and_status_for_vid(
+                bob.identifier(),
+                RelationshipStatus::Unidirectional { thread_id: [9; 32] },
+                alice.identifier(),
+            )
+            .unwrap();
+
+        let (_url, mut cancel) = a_store
+            .make_relationship_cancel(alice.identifier(), bob.identifier())
+            .unwrap();
+
+        assert!(
+            b_store.open_message(&mut cancel).is_err(),
+            "a cancellation for a relationship bob does not have is ignored"
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
     fn test_open_seal() {
         let store = create_test_store();
         let (alice, bob) = create_test_vid_pair();
 
         store.add_private_vid(alice.clone(), None).unwrap();
         store.add_private_vid(bob.clone(), None).unwrap();
+        establish_existing_relationship(&store, &alice, &store, &bob);
 
         let message = b"hello world";
 
@@ -3183,6 +3555,18 @@ mod test {
 
         d_store.add_verified_vid(sneaky_a.clone(), None).unwrap();
         d_store.add_verified_vid(mailbox_c.clone(), None).unwrap();
+
+        // the destination endpoint has an endpoint-to-endpoint relationship
+        // with the source; without it the arriving message is gated (spec 7.2.2)
+        d_store
+            .set_relation_and_status_for_vid(
+                sneaky_a.identifier(),
+                RelationshipStatus::ReverseUnidirectional {
+                    thread_id: Default::default(),
+                },
+                sneaky_d.identifier(),
+            )
+            .unwrap();
 
         a_store
             .set_relation_and_status_for_vid(

--- a/tsp_sdk/src/test.rs
+++ b/tsp_sdk/src/test.rs
@@ -468,17 +468,19 @@ async fn test_routed_mode() {
     );
     assert!(route.is_empty());
 
-    // test3: alice is the recipient (using "bob" as the 'final hop')
+    // test3: alice is the recipient; the exit entry of the hop list is her own
+    // VID at this intermediary (spec 5.3.3), and bob delivers over the
+    // relationship he holds with it
     bob_db
         .set_relation_and_status_for_vid(
-            "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
-            RelationshipStatus::Unrelated,
             "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
+            RelationshipStatus::Unrelated,
+            "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
         )
         .unwrap();
     bob_db
         .forward_routed_message(
-            "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:bob",
+            "did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice",
             Vec::<&[u8]>::new(),
             &opaque_payload,
         )
@@ -974,7 +976,8 @@ async fn test_routed_delivery_after_reopen_uses_persisted_route_metadata() {
     };
     assert_eq!(forwarded_sender, topology.sender_vid);
     assert_eq!(forwarded_receiver, topology.intermediary_vid);
-    assert_eq!(next_hop, topology.intermediary_vid);
+    // the exit entry names the receiver's own VID at the intermediary (spec 5.3.3)
+    assert_eq!(next_hop, topology.receiver_vid);
     assert!(route.is_empty());
 
     let intermediary = persist_reopen_cycle(&intermediary, &fixture_intermediary, 1).await;

--- a/tsp_sdk/src/test.rs
+++ b/tsp_sdk/src/test.rs
@@ -719,7 +719,7 @@ async fn test_prepopulated_store_import_preserves_dirty_state() {
                 found_reverse_unidirectional += 1;
             }
             RelationshipStatus::Bidirectional { .. } => found_bidirectional += 1,
-            RelationshipStatus::_Controlled | RelationshipStatus::Unrelated => {}
+            RelationshipStatus::Unrelated => {}
         }
     }
 

--- a/tsp_sdk/src/test_utils.rs
+++ b/tsp_sdk/src/test_utils.rs
@@ -151,10 +151,13 @@ fn relationship_status_for(index: usize) -> RelationshipStatus {
 }
 
 impl RelationshipStatus {
-    fn bi_default() -> Self {
+    /// A bidirectional relationship for tests. The two thread ids are distinct
+    /// and non-zero: the all-zero digest is the NULL digest of a `TSP_RFD`
+    /// (spec 7.3), not a thread id any relationship would hold.
+    fn bi_test(thread_id: u8, remote_thread_id: u8) -> Self {
         Self::Bidirectional {
-            thread_id: Default::default(),
-            remote_thread_id: Default::default(),
+            thread_id: [thread_id; 32],
+            remote_thread_id: [remote_thread_id; 32],
             outstanding_nested_requests: vec![],
         }
     }
@@ -259,7 +262,6 @@ pub type StoreExportSnapshot = (
 /// Return a stable string form for a relationship status.
 pub fn relationship_status_signature(status: RelationshipStatus) -> String {
     match status {
-        RelationshipStatus::_Controlled => "Controlled".to_string(),
         RelationshipStatus::Unrelated => "Unrelated".to_string(),
         RelationshipStatus::Unidirectional { thread_id } => format!("Uni:{thread_id:?}"),
         RelationshipStatus::ReverseUnidirectional { thread_id } => format!("RevUni:{thread_id:?}"),
@@ -420,7 +422,7 @@ pub fn create_high_entropy_dirty_store() -> (AsyncSecureStore, HighEntropyDirtyS
         store
             .set_relation_and_status_for_vid(
                 hop.identifier(),
-                RelationshipStatus::bi_default(),
+                RelationshipStatus::bi_test(0x11, 0x22),
                 local_vid.identifier(),
             )
             .unwrap();
@@ -568,14 +570,14 @@ pub fn create_routed_dirty_topology() -> RoutedDirtyTopology {
     sender
         .set_relation_and_status_for_vid(
             intermediary_vid.identifier(),
-            RelationshipStatus::bi_default(),
+            RelationshipStatus::bi_test(0x11, 0x22),
             sender_vid.identifier(),
         )
         .unwrap();
     sender
         .set_relation_and_status_for_vid(
             receiver_vid.identifier(),
-            RelationshipStatus::bi_default(),
+            RelationshipStatus::bi_test(0x11, 0x22),
             sender_vid.identifier(),
         )
         .unwrap();
@@ -595,14 +597,14 @@ pub fn create_routed_dirty_topology() -> RoutedDirtyTopology {
     intermediary
         .set_relation_and_status_for_vid(
             receiver_vid.identifier(),
-            RelationshipStatus::bi_default(),
+            RelationshipStatus::bi_test(0x11, 0x22),
             intermediary_vid.identifier(),
         )
         .unwrap();
     intermediary
         .set_relation_and_status_for_vid(
             intermediary_vid.identifier(),
-            RelationshipStatus::bi_default(),
+            RelationshipStatus::bi_test(0x11, 0x22),
             receiver_vid.identifier(),
         )
         .unwrap();
@@ -621,14 +623,14 @@ pub fn create_routed_dirty_topology() -> RoutedDirtyTopology {
     receiver
         .set_relation_and_status_for_vid(
             sender_vid.identifier(),
-            RelationshipStatus::bi_default(),
+            RelationshipStatus::bi_test(0x11, 0x22),
             receiver_vid.identifier(),
         )
         .unwrap();
     receiver
         .set_relation_and_status_for_vid(
             intermediary_vid.identifier(),
-            RelationshipStatus::bi_default(),
+            RelationshipStatus::bi_test(0x11, 0x22),
             receiver_vid.identifier(),
         )
         .unwrap();

--- a/tsp_sdk/src/test_utils.rs
+++ b/tsp_sdk/src/test_utils.rs
@@ -581,10 +581,11 @@ pub fn create_routed_dirty_topology() -> RoutedDirtyTopology {
             sender_vid.identifier(),
         )
         .unwrap();
+    // the exit entry is the receiver's own VID at the intermediary (spec 5.3.3)
     sender
         .set_route_for_vid(
             receiver_vid.identifier(),
-            &[intermediary_vid.identifier(), intermediary_vid.identifier()],
+            &[intermediary_vid.identifier(), receiver_vid.identifier()],
         )
         .unwrap();
 


### PR DESCRIPTION
Third PR of the Rev 3 series, into the `rev3` integration branch: the receiver-side protocol behavior of sections 3 and 7, in five commits.

## 1. Relationship gating, the RFI race, and RFD

- **Gating (§7.2.2).** An application message whose sender has no relationship with the receiving VID is dropped. Receiving a `TSP_RFI` records the inbound relationship, so an invite admits the messages that follow it — which §3.6 requires, since a sender may pack user data with the invite rather than wait a round trip. This enforces protocol ordering, not admission control: whether to keep a relationship an invite proposes stays a local decision, made by the application on the `RequestRelationship` it receives. A node that is not an endpoint in the specification's sense can opt out with `RelationshipPolicy::Ungated`.
- **Race (§7.2.3).** When both endpoints invite each other for the same VID pair at once, both keep the invite whose digest is lexicographically lower and discard the other, so the two sides converge on one exchange and one thread id.
- **RFD (§7.3).** A cancellation removes the relationship and is echoed back only when it was bidirectional; one naming a relationship the receiver does not have is ignored rather than answered. The identifying digest MAY be NULL, in which case the VID pair identifies the relationship. `ReceivedTspMessage::CancelRelationship` gained `reply_expected`; the CLI now sends the reply.

## 2. Remove the Controlled state and the all-zero thread id

`RelationshipStatus::_Controlled` was never constructed and its match arms were unreachable; wallets written earlier still deserialize, with that state read as `Unrelated`. Test helpers no longer build relationships whose thread ids are the all-zero digest, which now means something of its own as the NULL digest of an RFD.

## 3. Key-state staleness (§3.7, §7.4.2)

For VID types whose key state the endpoint resolves itself:

- A signature that does not verify may be a rotation not yet observed, so **within an established relationship** the VID is re-resolved and the verification retried once before discarding. Outside a relationship it is discarded at once; previously any failure triggered a resolution.
- A message arriving after a peer has been silent longer than the **re-verification threshold** prompts a refresh before it is acted on. A peer with no record has no observed silence to measure, so a wallet loaded from storage does not resolve everything it holds; verifying a VID records it as freshly confirmed.
- Resolution of any one peer is **rate limited**, because re-resolution can be provoked by unauthenticated messages. When key state cannot be confirmed, the message is not acted on.

Both thresholds are local policy (`KeyStatePolicy`), defaulting to a day and a minute.

## 4. The exit of a route is the destination's VID (§5.3.3)

The last entry of a hop list identifies the destination to its own intermediary and is a VID of the destination, not of the intermediary. The intermediary delivers over the relationship it holds with that VID. The drop-off previously read that entry as one of the intermediary's own VIDs, which required storing that one relationship inverted with respect to every other relationship in the wallet; it is now stored and read like all the others. Routes accordingly end in `b2` rather than `q2` — CLI demos and the routed-mode documentation updated.

## 5. Failed messages: no answer, and no end of session

Discarding silently is a rule about the wire: nothing is sent in response, because a response tells whoever sent it which check failed. The intermediary answered each failure with its own status and reason; it now returns the same acknowledgement whatever happens and logs the reason locally. Whether the local caller hears about a discard is the caller's business, so the stream still reports it — but one discarded message is not the stream failing, and `Error::ends_stream` separates the two. The CLI stopped listening at the first error of any kind, so a single unsolicited or corrupt message would have ended a session; it now logs and continues.

## Verification

- Full matrix green (default, no-default `async,resolve`, `pq`), workspace tests, clippy `--deny warnings`, fmt.
- New tests: gating and the ungated opt-out, invite-then-message admission, the race tiebreaker in both orders, RFD in each relationship direction and for an unknown relationship, resolution rate limiting, silence detection.
- Live, multi-process against two real `demo-intermediary` servers: direct, nested, and routed (a → P → Q → b) all pass. A separate run confirmed that garbage frames sent to a listener are discarded and reported without ending the session, after which a legitimate message still arrives.

## Not in this PR

- **Routed relationship forming (§7.2.4) is not implemented**, and this PR makes its absence visible: `send()` now warns when it forms a relationship directly with a receiver that has a route configured. The invite takes the direct path and so discloses to the destination, and to observers, an endpoint the route exists to keep out of view. Closing this needs the `Reply_Path` payload field, so it is wire work rather than receiver behavior — worth deciding on next.
- Nested-relationship forming still uses its own path rather than an `XHOP`-wrapped RFI/RFA, and `XCTL`/`XPAD`/padding are decoded but not surfaced through the API. Both were deferred out of PRs 1 and 2 and remain open.
