### PR TITLE
Resync the wire format with the Rev 3 spec edits

### DIFF
--- a/examples/src/bench.rs
+++ b/examples/src/bench.rs
@@ -1253,7 +1253,7 @@ async fn run_server(
                             frame.seq,
                         );
                         let ((ack_transport, ack_message), _) =
-                            run_measured(|| store.seal_message(&vid, &sender, None, &ack_payload))?;
+                            run_measured(|| store.seal_message(&vid, &sender, &ack_payload))?;
                         if let Err(e) = transport::send_message(&ack_transport, &ack_message).await {
                             eprintln!("bench server failed to send ack: {e}");
                         }
@@ -1353,7 +1353,7 @@ async fn run_client_throughput(
         let payload = build_frame(payload_size, FrameKind::ThroughputData, seq);
 
         let ((_, message), timings) =
-            run_measured(|| store.seal_message(&sender, &receiver, None, &payload))?;
+            run_measured(|| store.seal_message(&sender, &receiver, &payload))?;
         let signature_us = timings.signature_ns as f64 / 1_000.0;
         let seal_core_us = timings.seal_core_ns as f64 / 1_000.0;
 
@@ -1474,7 +1474,7 @@ async fn run_client_latency(
 
         let payload = build_frame(payload_size, FrameKind::LatencyRequest, seq);
         let ((_, message), timings) =
-            run_measured(|| store.seal_message(&sender, &receiver, None, &payload))?;
+            run_measured(|| store.seal_message(&sender, &receiver, &payload))?;
         let signature_us = timings.signature_ns as f64 / 1_000.0;
         let seal_core_us = timings.seal_core_ns as f64 / 1_000.0;
         let sent_bytes = message.len() as u64;

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -1451,8 +1451,13 @@ async fn run() -> Result<(), Error> {
                                 }
                                 _ => None,
                             };
+                            // a parallel accept arrives from the peer's new VID
+                            // over the new relationship, so the sender is it
                             let parallel_vid = match form {
                                 ReceivedRelationshipForm::Parallel { new_vid, .. } => Some(new_vid),
+                                ReceivedRelationshipForm::Direct if parallel => {
+                                    Some(sender.clone())
+                                }
                                 ReceivedRelationshipForm::Direct => None,
                             };
                             info!(

--- a/tsp_node/test.js
+++ b/tsp_node/test.js
@@ -163,13 +163,14 @@ describe('tsp node tests', function() {
         received = store.open_message(sealed);
 
         if (received instanceof AcceptRelationship) {
-            assert.strictEqual(received.sender, bob.identifier());
+            // the accept travels the new relationship, so bob's new VID is the
+            // sender rather than a payload field
+            assert.strictEqual(received.sender, bobParallel.identifier());
             assert.strictEqual(received.receiver, aliceParallel.identifier());
             assert.deepStrictEqual(received.thread_id, requestThreadId);
-            assert.strictEqual(received.form, RelationshipForm.Parallel);
+            assert.strictEqual(received.form, RelationshipForm.Direct);
             assert.strictEqual(received.delivery, RelationshipDelivery.Direct);
             assert.strictEqual(received.nested_vid, null);
-            assert.strictEqual(received.new_vid, bobParallel.identifier());
         } else {
             assert.fail(`Unexpected message type: ${received}`);
         }

--- a/tsp_python/test.py
+++ b/tsp_python/test.py
@@ -153,14 +153,15 @@ class AliceBob(unittest.TestCase):
 
         received = self.store.open_message(sealed)
         match received:
-            case tsp.AcceptRelationship(sender, receiver, received_thread_id, _reply_thread_id, form, delivery, nested_vid, parallel_vid):
-                self.assertEqual(sender, self.bob.identifier())
+            case tsp.AcceptRelationship(sender, receiver, received_thread_id, _reply_thread_id, form, delivery, nested_vid, _parallel_vid):
+                # the accept travels the new relationship, so bob's new VID is
+                # the sender rather than a payload field
+                self.assertEqual(sender, bob_parallel.identifier())
                 self.assertEqual(receiver, alice_parallel.identifier())
                 self.assertEqual(received_thread_id, thread_id)
-                self.assertEqual(form, tsp.RelationshipForm.Parallel)
+                self.assertEqual(form, tsp.RelationshipForm.Direct)
                 self.assertEqual(delivery, tsp.RelationshipDelivery.Direct)
                 self.assertIsNone(nested_vid)
-                self.assertEqual(parallel_vid, bob_parallel.identifier())
 
             case other:
                 self.fail(f"unexpected message type {other}")

--- a/tsp_sdk/src/cesr/decode.rs
+++ b/tsp_sdk/src/cesr/decode.rs
@@ -153,8 +153,9 @@ pub fn decode_count(identifier: u16, stream: &mut &[u8]) -> Option<u32> {
     let index = word & mask(12);
 
     let expected = (DASH << 18) | (bits(identifier, 6) << 12) | bits(index, 12);
+    // the long form is a double dash, `--X#####` (CESR master table for -_AAACAA)
     let expected_long =
-        (DASH << 18) | D0 << 12 | (bits(identifier, 6) << 6) | bits(index & 0x3F, 6);
+        (DASH << 18) | DASH << 12 | (bits(identifier, 6) << 6) | bits(index & 0x3F, 6);
     if word == expected {
         *stream = &stream[3..];
 

--- a/tsp_sdk/src/cesr/encode.rs
+++ b/tsp_sdk/src/cesr/encode.rs
@@ -80,7 +80,8 @@ pub fn encode_count(
 
         stream.extend(&u32::to_be_bytes(word)[1..]);
     } else {
-        let word1 = (DASH << 18) | (D0 << 12) | (bits(identifier, 6) << 6) | bits(count >> 24, 6);
+        // the long form is a double dash, `--X#####` (CESR master table for -_AAACAA)
+        let word1 = (DASH << 18) | (DASH << 12) | (bits(identifier, 6) << 6) | bits(count >> 24, 6);
         let word2 = bits(count, 24);
 
         stream.extend(&u32::to_be_bytes(word1)[1..]);

--- a/tsp_sdk/src/cesr/mod.rs
+++ b/tsp_sdk/src/cesr/mod.rs
@@ -396,6 +396,27 @@ ACDD7NDX93ZGTkZBBuSeSGsAQ7u0hngpNTZTK_Um7rUZGnLRNJvo5oOnnC1J2iBQHuxoq8PyjdT3BHS2
     }
 
     #[test]
+    fn long_form_count_code_is_double_dash() {
+        // In the CESR master table for genus -_AAACAA the long-form count codes
+        // are `--X#####`. The `-0X#####` of the earlier draft was replaced in
+        // 2025-05; a round-trip cannot tell the two apart, so pin the bytes.
+        let mut stream = Vec::new();
+        encode_count(4, 4096usize, &mut stream); // identifier 4 = "E"
+        assert_eq!(
+            stream.len(),
+            6,
+            "counts at or above 4096 take the long form"
+        );
+
+        let text = Base64UrlUnpadded::encode_string(&stream);
+        assert_eq!(
+            &text[..3],
+            "--E",
+            "long-form count code must be `--X#####`, got `{text}`"
+        );
+    }
+
+    #[test]
     fn decode_count_long_form_round_trips() {
         // All counts below 4096 use the short 3-byte form; counts >= 4096 use the
         // long 6-byte form where the header word encodes both the identifier and the

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -122,8 +122,8 @@ pub enum Payload<'a, Bytes, Vid> {
         sig_new_vid: &'a Signature,
         new_vid: Vid,
     },
-    /// A TSP cancellation message; the nonce guards against replay when the digest is absent
-    RelationshipCancel { nonce: Nonce, reply: Digest<'a> },
+    /// A TSP cancellation message, naming the relationship it ends
+    RelationshipCancel { reply: Digest<'a> },
 }
 
 impl<Bytes: AsRef<[u8]>, Vid: AsRef<[u8]>> Payload<'_, Bytes, Vid> {
@@ -454,10 +454,9 @@ pub fn encode_payload(
             encode_embedded_signature(sig_new_vid, &mut temp)?;
             encode_padding(padding, &mut temp)?;
         }
-        Payload::RelationshipCancel { nonce, reply } => {
+        Payload::RelationshipCancel { reply } => {
             temp.extend(&XRFD);
             encode_sender_identity(sender_identity, &mut temp)?;
-            encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
             encode_digest(reply, &mut temp);
             encode_padding(padding, &mut temp)?;
         }
@@ -706,16 +705,11 @@ pub fn decode_payload(stream: &mut [u8]) -> Result<DecodedPayload<'_>, DecodeErr
             }
         }
         XRFD => {
-            let nonce;
-            (nonce, stream) =
-                decode_fixed_data_mut(TSP_NONCE, stream).ok_or(DecodeError::UnexpectedData)?;
-            let nonce = Nonce(*nonce);
-
             let reply;
             (reply, stream) = decode_digest(stream)?;
             stream = decode_padding(stream)?;
 
-            Payload::RelationshipCancel { nonce, reply }
+            Payload::RelationshipCancel { reply }
         }
         _ => return Err(DecodeError::UnexpectedMsgType),
     };
@@ -1888,11 +1882,9 @@ mod test {
             reply_digest: Digest::Blake2b256(digest),
         });
         test_turn_around(Payload::RelationshipCancel {
-            nonce: Nonce(nonce),
             reply: Digest::Sha2_256(digest),
         });
         test_turn_around(Payload::RelationshipCancel {
-            nonce: Nonce(nonce),
             reply: Digest::Blake2b256(digest),
         });
     }

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -98,29 +98,22 @@ pub enum Payload<'a, Bytes, Vid> {
     NestedMessage(Bytes),
     /// A routed payload; same as above but with routing information attached
     RoutedMessage(Vec<Vid>, Bytes),
-    /// A TSP message requesting a relationship
-    DirectRelationProposal {
-        nonce: Nonce,
+    /// A TSP message requesting a relationship (spec 9.4.1). One layout covers
+    /// the direct, routed and referral forms: `reply_path` is empty unless the
+    /// sender asks for the reply to travel a route, and `referral` is present
+    /// only when the invite introduces a new VID over an existing relationship.
+    RelationProposal {
         request_digest: Digest<'a>,
+        nonce: Nonce,
+        reply_path: Vec<Vid>,
+        referral: Option<Referral<'a, Vid>>,
     },
-    /// A TSP message confirming a relationship
-    DirectRelationAffirm {
+    /// A TSP message confirming a relationship (spec 9.4.2). An accept has one
+    /// form: where it accepts a referral, the accepting endpoint's new VID is
+    /// the sender of the message rather than a payload field.
+    RelationAffirm {
         request_digest: Digest<'a>,
         reply_digest: Digest<'a>,
-    },
-    /// A TSP message requesting a secondary relationship alongside an existing one.
-    ParallelRelationProposal {
-        nonce: Nonce,
-        request_digest: Digest<'a>,
-        sig_new_vid: &'a Signature,
-        new_vid: Vid,
-    },
-    /// A TSP message accepting a secondary relationship request.
-    ParallelRelationAffirm {
-        request_digest: Digest<'a>,
-        reply_digest: Digest<'a>,
-        sig_new_vid: &'a Signature,
-        new_vid: Vid,
     },
     /// A TSP cancellation message, naming the relationship it ends
     RelationshipCancel { reply: Digest<'a> },
@@ -249,6 +242,7 @@ pub(crate) fn encode_parallel_relation_proposal_challenge(
     sender_identity: Option<&[u8]>,
     nonce: &Nonce,
     request_digest: Digest<'_>,
+    reply_path: &[impl AsRef<[u8]>],
     new_vid: &[u8],
 ) -> Result<Vec<u8>, EncodeError> {
     let mut temp = Vec::new();
@@ -256,23 +250,7 @@ pub(crate) fn encode_parallel_relation_proposal_challenge(
     checked_encode_variable_data(TSP_VID, sender_identity.unwrap_or(&[]), &mut temp)?;
     encode_digest(&request_digest, &mut temp);
     encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
-    checked_encode_variable_data(TSP_VID, new_vid, &mut temp)?;
-    Ok(temp)
-}
-
-/// The signable fields of a parallel (referral) relationship accept:
-/// {XRFA, VID_sndr, Digest, Reply_Digest, VID_new}, in the unified field order.
-pub(crate) fn encode_parallel_relation_affirm_challenge(
-    sender_identity: Option<&[u8]>,
-    request_digest: Digest<'_>,
-    reply_digest: Digest<'_>,
-    new_vid: &[u8],
-) -> Result<Vec<u8>, EncodeError> {
-    let mut temp = Vec::new();
-    temp.extend(&XRFA);
-    checked_encode_variable_data(TSP_VID, sender_identity.unwrap_or(&[]), &mut temp)?;
-    encode_digest(&request_digest, &mut temp);
-    encode_digest(&reply_digest, &mut temp);
+    encode_hops(reply_path, &mut temp)?;
     checked_encode_variable_data(TSP_VID, new_vid, &mut temp)?;
     Ok(temp)
 }
@@ -399,18 +377,21 @@ pub fn encode_payload(
             encode_padding(padding, &mut temp)?;
             temp.extend(data.as_ref());
         }
-        Payload::DirectRelationProposal {
-            nonce,
+        Payload::RelationProposal {
             request_digest,
+            nonce,
+            reply_path,
+            referral,
         } => {
             temp.extend(&XRFI);
             encode_sender_identity(sender_identity, &mut temp)?;
             encode_digest(request_digest, &mut temp);
             encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
-            checked_encode_variable_data(TSP_VID, &[], &mut temp)?; // NULL new-VID field
+            encode_hops(reply_path, &mut temp)?;
+            encode_referral(referral.as_ref(), &mut temp)?;
             encode_padding(padding, &mut temp)?;
         }
-        Payload::DirectRelationAffirm {
+        Payload::RelationAffirm {
             request_digest,
             reply_digest,
         } => {
@@ -418,40 +399,6 @@ pub fn encode_payload(
             encode_sender_identity(sender_identity, &mut temp)?;
             encode_digest(request_digest, &mut temp);
             encode_digest(reply_digest, &mut temp);
-            encode_padding(padding, &mut temp)?;
-        }
-        Payload::ParallelRelationProposal {
-            nonce,
-            request_digest,
-            sig_new_vid,
-            new_vid,
-        } => {
-            if new_vid.as_ref().is_empty() {
-                return Err(EncodeError::InvalidVid);
-            }
-            temp.extend(&XRFI);
-            encode_sender_identity(sender_identity, &mut temp)?;
-            encode_digest(request_digest, &mut temp);
-            encode_fixed_data(TSP_NONCE, &nonce.0, &mut temp);
-            checked_encode_variable_data(TSP_VID, new_vid.as_ref(), &mut temp)?;
-            encode_embedded_signature(sig_new_vid, &mut temp)?;
-            encode_padding(padding, &mut temp)?;
-        }
-        Payload::ParallelRelationAffirm {
-            request_digest,
-            reply_digest,
-            sig_new_vid,
-            new_vid,
-        } => {
-            if new_vid.as_ref().is_empty() {
-                return Err(EncodeError::InvalidVid);
-            }
-            temp.extend(&XRFA);
-            encode_sender_identity(sender_identity, &mut temp)?;
-            encode_digest(request_digest, &mut temp);
-            encode_digest(reply_digest, &mut temp);
-            checked_encode_variable_data(TSP_VID, new_vid.as_ref(), &mut temp)?;
-            encode_embedded_signature(sig_new_vid, &mut temp)?;
             encode_padding(padding, &mut temp)?;
         }
         Payload::RelationshipCancel { reply } => {
@@ -466,6 +413,76 @@ pub fn encode_payload(
     output.extend(temp.iter());
 
     Ok(())
+}
+
+/// The new VID a referral introduces, and that VID's own signature
+type Referral<'a, Vid> = (Vid, &'a Signature);
+
+/// Encode the referral field (spec 9.2): a generic list holding the new VID and
+/// that VID's own signature, or the empty list when the message is not a
+/// referral. Grouping the two means they switch on and off together.
+fn encode_referral(
+    referral: Option<&Referral<'_, impl AsRef<[u8]>>>,
+    output: &mut impl for<'a> Extend<&'a u8>,
+) -> Result<(), EncodeError> {
+    let Some((new_vid, signature)) = referral else {
+        encode_count(TSP_HOP_LIST, 0usize, output);
+
+        return Ok(());
+    };
+
+    if new_vid.as_ref().is_empty() {
+        return Err(EncodeError::InvalidVid);
+    }
+
+    let mut temp = Vec::new();
+    checked_encode_variable_data(TSP_VID, new_vid.as_ref(), &mut temp)?;
+    encode_embedded_signature(signature, &mut temp)?;
+
+    encode_count(TSP_HOP_LIST, temp.len() / 3, output);
+    output.extend(temp.iter());
+
+    Ok(())
+}
+
+/// Decode the referral field; the count delimits its byte length
+fn decode_referral<'a, Vid: TryFrom<&'a [u8]>>(
+    stream: &'a mut [u8],
+) -> Result<(Option<Referral<'a, Vid>>, &'a mut [u8]), DecodeError> {
+    let (length, stream) =
+        decode_count_mut(TSP_HOP_LIST, stream).ok_or(DecodeError::UnexpectedData)?;
+
+    let bytes = (length as usize)
+        .checked_mul(3)
+        .ok_or(DecodeError::UnexpectedData)?;
+    if bytes > stream.len() {
+        return Err(DecodeError::UnexpectedData);
+    }
+    let (mut referral, rest) = stream.split_at_mut(bytes);
+
+    if referral.is_empty() {
+        return Ok((None, rest));
+    }
+
+    let new_vid: &[u8];
+    (new_vid, referral) =
+        decode_variable_data_mut(TSP_VID, referral).ok_or(DecodeError::UnexpectedData)?;
+    if new_vid.is_empty() {
+        return Err(DecodeError::UnexpectedData);
+    }
+
+    let (signature, remainder) = decoded_signature_from_stream(referral)?;
+    if !remainder.is_empty() {
+        return Err(DecodeError::TrailingGarbage);
+    }
+
+    Ok((
+        Some((
+            new_vid.try_into().map_err(|_| DecodeError::VidError)?,
+            signature,
+        )),
+        rest,
+    ))
 }
 
 /// Encode a hops list; the count is the length in quadlets/triplets of the
@@ -645,27 +662,19 @@ pub fn decode_payload(stream: &mut [u8]) -> Result<DecodedPayload<'_>, DecodeErr
             (nonce, stream) =
                 decode_fixed_data_mut(TSP_NONCE, stream).ok_or(DecodeError::UnexpectedData)?;
 
-            let new_vid: &[u8];
-            (new_vid, stream) =
-                decode_variable_data_mut(TSP_VID, stream).ok_or(DecodeError::UnexpectedData)?;
+            let reply_path;
+            (reply_path, stream) = decode_hops(stream)?;
 
-            if new_vid.is_empty() {
-                stream = decode_padding(stream)?;
-                Payload::DirectRelationProposal {
-                    nonce: Nonce(*nonce),
-                    request_digest,
-                }
-            } else {
-                let sig_new_vid;
-                (sig_new_vid, stream) = decoded_signature_from_stream(stream)?;
-                stream = decode_padding(stream)?;
+            let referral;
+            (referral, stream) = decode_referral(stream)?;
 
-                Payload::ParallelRelationProposal {
-                    nonce: Nonce(*nonce),
-                    request_digest,
-                    sig_new_vid,
-                    new_vid,
-                }
+            stream = decode_padding(stream)?;
+
+            Payload::RelationProposal {
+                request_digest,
+                nonce: Nonce(*nonce),
+                reply_path,
+                referral,
             }
         }
         XRFA => {
@@ -675,33 +684,11 @@ pub fn decode_payload(stream: &mut [u8]) -> Result<DecodedPayload<'_>, DecodeErr
             let reply_digest;
             (reply_digest, stream) = decode_digest(stream)?;
 
-            // the next field is either the padding (direct form, ending the payload)
-            // or the new VID of the parallel (referral) form, followed by a signature
-            let vid_or_pad_mut;
-            (vid_or_pad_mut, stream) =
-                decode_variable_data_mut(TSP_VID, stream).ok_or(DecodeError::UnexpectedData)?;
-            let vid_or_pad: &[u8] = vid_or_pad_mut;
+            stream = decode_padding(stream)?;
 
-            if stream.is_empty() {
-                Payload::DirectRelationAffirm {
-                    request_digest,
-                    reply_digest,
-                }
-            } else {
-                let new_vid = vid_or_pad;
-                if new_vid.is_empty() {
-                    return Err(DecodeError::UnexpectedData);
-                }
-                let sig_new_vid;
-                (sig_new_vid, stream) = decoded_signature_from_stream(stream)?;
-                stream = decode_padding(stream)?;
-
-                Payload::ParallelRelationAffirm {
-                    request_digest,
-                    reply_digest,
-                    sig_new_vid,
-                    new_vid,
-                }
+            Payload::RelationAffirm {
+                request_digest,
+                reply_digest,
             }
         }
         XRFD => {
@@ -809,36 +796,30 @@ pub fn encode_digest_input(
     output.extend(envelope_prefix);
 
     match payload {
-        Payload::DirectRelationProposal { nonce, .. } => {
-            output.extend(&XRFI);
-            encode_sender_identity(sender_identity, output)?;
-            output.extend(&DIGEST_DUMMY);
-            encode_fixed_data(TSP_NONCE, &nonce.0, output);
-            checked_encode_variable_data(TSP_VID, &[], output)?;
-        }
-        Payload::ParallelRelationProposal { nonce, new_vid, .. } => {
-            output.extend(&XRFI);
-            encode_sender_identity(sender_identity, output)?;
-            output.extend(&DIGEST_DUMMY);
-            encode_fixed_data(TSP_NONCE, &nonce.0, output);
-            checked_encode_variable_data(TSP_VID, new_vid.as_ref(), output)?;
-        }
-        Payload::DirectRelationAffirm { request_digest, .. } => {
-            output.extend(&XRFA);
-            encode_sender_identity(sender_identity, output)?;
-            encode_digest(request_digest, output);
-            output.extend(&DIGEST_DUMMY);
-        }
-        Payload::ParallelRelationAffirm {
-            request_digest,
-            new_vid,
+        Payload::RelationProposal {
+            nonce,
+            reply_path,
+            referral,
             ..
         } => {
+            output.extend(&XRFI);
+            encode_sender_identity(sender_identity, output)?;
+            output.extend(&DIGEST_DUMMY);
+            encode_fixed_data(TSP_NONCE, &nonce.0, output);
+            encode_hops(reply_path, output)?;
+            // the new VID is covered, but its signature is not: it is produced
+            // after the digest and signs it (spec 7.2.1)
+            if let Some((new_vid, _)) = referral {
+                checked_encode_variable_data(TSP_VID, new_vid.as_ref(), output)?;
+            } else {
+                encode_count(TSP_HOP_LIST, 0usize, output);
+            }
+        }
+        Payload::RelationAffirm { request_digest, .. } => {
             output.extend(&XRFA);
             encode_sender_identity(sender_identity, output)?;
             encode_digest(request_digest, output);
             output.extend(&DIGEST_DUMMY);
-            checked_encode_variable_data(TSP_VID, new_vid.as_ref(), output)?;
         }
         _ => return Err(EncodeError::NoDigestSlot),
     }
@@ -1802,22 +1783,36 @@ mod test {
     #[test]
     #[wasm_bindgen_test]
     fn test_par_refer_rel() {
-        test_turn_around(Payload::ParallelRelationProposal {
-            nonce: Nonce([7; 16]),
+        // an invite that introduces a new VID carries the referral field
+        test_turn_around(Payload::RelationProposal {
             request_digest: Digest::Sha2_256(&Default::default()),
-            sig_new_vid: &[5; 64],
-            new_vid: b"Charlie",
+            nonce: Nonce([7; 16]),
+            reply_path: vec![],
+            referral: Some((b"Charlie", &[5; 64])),
         });
     }
 
     #[test]
     #[wasm_bindgen_test]
-    fn test_parallel_relation_accept_round_trip() {
-        test_turn_around(Payload::ParallelRelationAffirm {
-            request_digest: Digest::Sha2_256(&[3; 32]),
-            reply_digest: Digest::Blake2b256(&[4; 32]),
-            sig_new_vid: &[9; 64],
-            new_vid: b"Delta",
+    fn test_routed_relation_proposal_round_trip() {
+        // an invite that asks for a routed reply carries a reply path
+        test_turn_around(Payload::RelationProposal {
+            request_digest: Digest::Blake2b256(&[6; 32]),
+            nonce: Nonce([8; 16]),
+            reply_path: vec![b"did:test:p".as_slice(), b"did:test:a1".as_slice()],
+            referral: None,
+        });
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_routed_referral_proposal_round_trip() {
+        // both fields populated at once
+        test_turn_around(Payload::RelationProposal {
+            request_digest: Digest::Sha2_256(&[2; 32]),
+            nonce: Nonce([9; 16]),
+            reply_path: vec![b"did:test:q".as_slice()],
+            referral: Some((b"did:test:a1", &[4; 64])),
         });
     }
 
@@ -1869,15 +1864,17 @@ mod test {
         let temp = (1u8..33).collect::<Vec<u8>>();
         let digest: &[u8; 32] = temp.as_slice().try_into().unwrap();
         let nonce = [7u8; 16];
-        test_turn_around(Payload::DirectRelationProposal {
-            nonce: Nonce(nonce),
+        test_turn_around(Payload::RelationProposal {
             request_digest: Digest::Sha2_256(digest),
+            nonce: Nonce(nonce),
+            reply_path: vec![],
+            referral: None,
         });
-        test_turn_around(Payload::DirectRelationAffirm {
+        test_turn_around(Payload::RelationAffirm {
             request_digest: Digest::Sha2_256(digest),
             reply_digest: Digest::Sha2_256(digest),
         });
-        test_turn_around(Payload::DirectRelationAffirm {
+        test_turn_around(Payload::RelationAffirm {
             request_digest: Digest::Blake2b256(digest),
             reply_digest: Digest::Blake2b256(digest),
         });

--- a/tsp_sdk/src/cesr/packet/fuzzing.rs
+++ b/tsp_sdk/src/cesr/packet/fuzzing.rs
@@ -86,7 +86,6 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
                 sig_new_vid: &[24; 64],
             },
             Variants::RelationshipCancel => Payload::RelationshipCancel {
-                nonce: Nonce(Arbitrary::arbitrary(u)?),
                 reply: digest(&DIGEST),
             },
         };
@@ -156,15 +155,9 @@ impl<'a> PartialEq<Payload<'a, &'a mut [u8], &'a [u8]>> for Wrapper {
                 },
             ) => l_request == r_request && l_reply == r_reply && l_vid == r_vid,
             (
-                Payload::RelationshipCancel {
-                    nonce: l_nonce,
-                    reply: l_reply,
-                },
-                Payload::RelationshipCancel {
-                    nonce: r_nonce,
-                    reply: r_reply,
-                },
-            ) => l_nonce.0 == r_nonce.0 && l_reply == r_reply,
+                Payload::RelationshipCancel { reply: l_reply },
+                Payload::RelationshipCancel { reply: r_reply },
+            ) => l_reply == r_reply,
             _ => false,
         }
     }

--- a/tsp_sdk/src/cesr/packet/fuzzing.rs
+++ b/tsp_sdk/src/cesr/packet/fuzzing.rs
@@ -23,10 +23,8 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
             Padding,
             NestedMessage,
             RoutedMessage,
-            DirectRelationProposal,
-            DirectRelationAffirm,
-            ParallelRelationProposal,
-            ParallelRelationAffirm,
+            RelationProposal,
+            RelationAffirm,
             RelationshipCancel,
         }
 
@@ -38,10 +36,8 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
                 Payload::Padding { .. } => Variants::Padding,
                 Payload::NestedMessage(_) => Variants::NestedMessage,
                 Payload::RoutedMessage(_, _) => Variants::RoutedMessage,
-                Payload::DirectRelationProposal { .. } => Variants::DirectRelationProposal,
-                Payload::DirectRelationAffirm { .. } => Variants::DirectRelationAffirm,
-                Payload::ParallelRelationProposal { .. } => Variants::ParallelRelationProposal,
-                Payload::ParallelRelationAffirm { .. } => Variants::ParallelRelationAffirm,
+                Payload::RelationProposal { .. } => Variants::RelationProposal,
+                Payload::RelationAffirm { .. } => Variants::RelationAffirm,
                 Payload::RelationshipCancel { .. } => Variants::RelationshipCancel,
             }
         }
@@ -65,25 +61,19 @@ impl<'a> arbitrary::Arbitrary<'a> for Wrapper {
             Variants::RoutedMessage => {
                 Payload::RoutedMessage(Arbitrary::arbitrary(u)?, Arbitrary::arbitrary(u)?)
             }
-            Variants::DirectRelationProposal => Payload::DirectRelationProposal {
-                nonce: Nonce(Arbitrary::arbitrary(u)?),
+            Variants::RelationProposal => Payload::RelationProposal {
                 request_digest: digest(&DIGEST),
+                nonce: Nonce(Arbitrary::arbitrary(u)?),
+                reply_path: Arbitrary::arbitrary(u)?,
+                referral: if Arbitrary::arbitrary(u)? {
+                    Some((Arbitrary::arbitrary(u)?, &[42; 64]))
+                } else {
+                    None
+                },
             },
-            Variants::DirectRelationAffirm => Payload::DirectRelationAffirm {
+            Variants::RelationAffirm => Payload::RelationAffirm {
                 request_digest: digest(&DIGEST),
                 reply_digest: digest(&DIGEST),
-            },
-            Variants::ParallelRelationProposal => Payload::ParallelRelationProposal {
-                nonce: Nonce(Arbitrary::arbitrary(u)?),
-                request_digest: digest(&DIGEST),
-                new_vid: Arbitrary::arbitrary(u)?,
-                sig_new_vid: &[42; 64],
-            },
-            Variants::ParallelRelationAffirm => Payload::ParallelRelationAffirm {
-                request_digest: digest(&DIGEST),
-                reply_digest: digest(&DIGEST),
-                new_vid: Arbitrary::arbitrary(u)?,
-                sig_new_vid: &[24; 64],
             },
             Variants::RelationshipCancel => Payload::RelationshipCancel {
                 reply: digest(&DIGEST),
@@ -107,53 +97,36 @@ impl<'a> PartialEq<Payload<'a, &'a mut [u8], &'a [u8]>> for Wrapper {
                 l0 == r0 && l1 == r1
             }
             (
-                Payload::DirectRelationProposal {
+                Payload::RelationProposal {
+                    request_digest: l_request,
                     nonce: l_nonce,
-                    request_digest: l_request_digest,
+                    reply_path: l_path,
+                    referral: l_referral,
                 },
-                Payload::DirectRelationProposal {
+                Payload::RelationProposal {
+                    request_digest: r_request,
                     nonce: r_nonce,
-                    request_digest: r_request_digest,
+                    reply_path: r_path,
+                    referral: r_referral,
                 },
-            ) => l_nonce.0 == r_nonce.0 && l_request_digest == r_request_digest,
+            ) => {
+                l_request == r_request
+                    && l_nonce.0 == r_nonce.0
+                    && l_path == r_path
+                    // the signature bytes are not carried through the wrapper
+                    && l_referral.as_ref().map(|(vid, _)| vid.as_slice())
+                        == r_referral.as_ref().map(|(vid, _)| *vid)
+            }
             (
-                Payload::DirectRelationAffirm {
+                Payload::RelationAffirm {
                     request_digest: l_request,
                     reply_digest: l_reply,
                 },
-                Payload::DirectRelationAffirm {
+                Payload::RelationAffirm {
                     request_digest: r_request,
                     reply_digest: r_reply,
                 },
             ) => l_request == r_request && l_reply == r_reply,
-            (
-                Payload::ParallelRelationProposal {
-                    new_vid: l_vid,
-                    request_digest: l_request,
-                    sig_new_vid: _l_sig,
-                    nonce: l_nonce,
-                },
-                Payload::ParallelRelationProposal {
-                    new_vid: r_vid,
-                    request_digest: r_request,
-                    sig_new_vid: _r_sig,
-                    nonce: r_nonce,
-                },
-            ) => l_vid == r_vid && l_request == r_request && l_nonce == r_nonce,
-            (
-                Payload::ParallelRelationAffirm {
-                    request_digest: l_request,
-                    reply_digest: l_reply,
-                    new_vid: l_vid,
-                    sig_new_vid: _l_sig,
-                },
-                Payload::ParallelRelationAffirm {
-                    request_digest: r_request,
-                    reply_digest: r_reply,
-                    new_vid: r_vid,
-                    sig_new_vid: _r_sig,
-                },
-            ) => l_request == r_request && l_reply == r_reply && l_vid == r_vid,
             (
                 Payload::RelationshipCancel { reply: l_reply },
                 Payload::RelationshipCancel { reply: r_reply },

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -159,11 +159,11 @@ pub(crate) fn build_parallel_request_signed_data(
 ) -> Result<Vec<u8>, CryptoError> {
     // the digest is derived first (its own slot dummied, the new-VID signature
     // not yet present); the signature is then made over the final digest
-    let payload = crate::cesr::Payload::<&[u8], &[u8]>::ParallelRelationProposal {
-        nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+    let payload = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
         request_digest: digest_algorithm.field(&*request_digest),
-        sig_new_vid: &[0; 64],
-        new_vid,
+        nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+        reply_path: vec![],
+        referral: Some((new_vid, &[0; 64])),
     };
     *request_digest = compute_relationship_digest(
         &payload,
@@ -177,35 +177,7 @@ pub(crate) fn build_parallel_request_signed_data(
         sender_in_payload,
         &nonce,
         digest_algorithm.field(request_digest),
-        new_vid,
-    )?)
-}
-
-pub(crate) fn build_parallel_accept_signed_data(
-    thread_id: &Digest,
-    sender_in_payload: Option<&[u8]>,
-    digest_algorithm: RelationshipDigestAlgorithm,
-    envelope_prefix: &[u8],
-    reply_digest: &mut Digest,
-    new_vid: &[u8],
-) -> Result<Vec<u8>, CryptoError> {
-    let payload = crate::cesr::Payload::<&[u8], &[u8]>::ParallelRelationAffirm {
-        request_digest: digest_algorithm.field(thread_id),
-        reply_digest: digest_algorithm.field(&*reply_digest),
-        sig_new_vid: &[0; 64],
-        new_vid,
-    };
-    *reply_digest = compute_relationship_digest(
-        &payload,
-        sender_in_payload,
-        envelope_prefix,
-        digest_algorithm,
-    )?;
-
-    Ok(crate::cesr::encode_parallel_relation_affirm_challenge(
-        sender_in_payload,
-        digest_algorithm.field(thread_id),
-        digest_algorithm.field(reply_digest),
+        &[] as &[&[u8]],
         new_vid,
     )?)
 }
@@ -216,19 +188,18 @@ fn relationship_request_payload<'a>(
     nonce_bytes: [u8; 16],
     request_digest: &'a Digest,
 ) -> CesrRelationshipPayload<'a> {
-    match form {
-        RelationshipForm::Direct => crate::cesr::Payload::DirectRelationProposal {
-            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
-            request_digest: digest_algorithm.field(request_digest),
-        },
-        RelationshipForm::Parallel {
-            new_vid,
-            sig_new_vid,
-        } => crate::cesr::Payload::ParallelRelationProposal {
-            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
-            request_digest: digest_algorithm.field(request_digest),
-            sig_new_vid,
-            new_vid,
+    crate::cesr::Payload::RelationProposal {
+        request_digest: digest_algorithm.field(request_digest),
+        nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+        // routed relationship forming is not implemented yet; when it is, the
+        // reply path the caller asks for goes here
+        reply_path: vec![],
+        referral: match form {
+            RelationshipForm::Direct => None,
+            RelationshipForm::Parallel {
+                new_vid,
+                sig_new_vid,
+            } => Some((*new_vid, *sig_new_vid)),
         },
     }
 }
@@ -239,20 +210,13 @@ fn relationship_accept_payload<'a>(
     digest_algorithm: RelationshipDigestAlgorithm,
     reply_digest: &'a Digest,
 ) -> CesrRelationshipPayload<'a> {
-    match form {
-        RelationshipForm::Direct => crate::cesr::Payload::DirectRelationAffirm {
-            request_digest: digest_algorithm.field(thread_id),
-            reply_digest: digest_algorithm.field(reply_digest),
-        },
-        RelationshipForm::Parallel {
-            new_vid,
-            sig_new_vid,
-        } => crate::cesr::Payload::ParallelRelationAffirm {
-            request_digest: digest_algorithm.field(thread_id),
-            reply_digest: digest_algorithm.field(reply_digest),
-            sig_new_vid,
-            new_vid,
-        },
+    // an accept has one form: where it accepts a referral, the accepting
+    // endpoint's new VID is the sender of the message, not a payload field
+    let _ = form;
+
+    crate::cesr::Payload::RelationAffirm {
+        request_digest: digest_algorithm.field(thread_id),
+        reply_digest: digest_algorithm.field(reply_digest),
     }
 }
 
@@ -316,10 +280,8 @@ pub(crate) fn verify_relationship_digest(
     envelope_prefix: &[u8],
 ) -> Result<(), CryptoError> {
     let embedded = match payload {
-        crate::cesr::Payload::DirectRelationProposal { request_digest, .. }
-        | crate::cesr::Payload::ParallelRelationProposal { request_digest, .. } => request_digest,
-        crate::cesr::Payload::DirectRelationAffirm { reply_digest, .. }
-        | crate::cesr::Payload::ParallelRelationAffirm { reply_digest, .. } => reply_digest,
+        crate::cesr::Payload::RelationProposal { request_digest, .. } => request_digest,
+        crate::cesr::Payload::RelationAffirm { reply_digest, .. } => reply_digest,
         _ => return Ok(()),
     };
 
@@ -712,26 +674,32 @@ mod tests {
         let algorithm = super::RelationshipDigestAlgorithm::Sha2_256;
         let nonce_bytes = [7_u8; 16];
         let mut digest = [0_u8; 32];
-        let payload = crate::cesr::Payload::<&[u8], &[u8]>::DirectRelationProposal {
-            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+        let payload = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
             request_digest: algorithm.field(&digest),
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            reply_path: vec![],
+            referral: None,
         };
         let mut input = Vec::new();
         crate::cesr::encode_digest_input(&payload, Some(sender), &envelope_prefix, &mut input)
             .unwrap();
         digest = algorithm.hash(&input);
 
-        let good = crate::cesr::Payload::<&[u8], &[u8]>::DirectRelationProposal {
-            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+        let good = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
             request_digest: algorithm.field(&digest),
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            reply_path: vec![],
+            referral: None,
         };
         super::verify_relationship_digest(&good, Some(sender), &envelope_prefix).unwrap();
 
         let mut tampered_digest = digest;
         tampered_digest[0] ^= 0x01;
-        let tampered = crate::cesr::Payload::<&[u8], &[u8]>::DirectRelationProposal {
-            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+        let tampered = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
             request_digest: algorithm.field(&tampered_digest),
+            nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            reply_path: vec![],
+            referral: None,
         };
         assert!(matches!(
             super::verify_relationship_digest(&tampered, Some(sender), &envelope_prefix),

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -265,73 +265,53 @@ fn open_payload<'a>(
 
     let (secret_payload, parallel_signature_info) = match payload {
         crate::cesr::Payload::GenericMessage(data) => (Payload::Content(data as _), None),
-        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => (
-            open_relationship_request(
-                *request_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Direct,
-            ),
-            None,
-        ),
-        crate::cesr::Payload::DirectRelationAffirm {
+        crate::cesr::Payload::RelationProposal {
             request_digest,
-            reply_digest,
-        } => (
-            open_relationship_accept(
-                *request_digest.as_bytes(),
-                *reply_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Direct,
-            ),
-            None,
-        ),
-        crate::cesr::Payload::ParallelRelationProposal {
             nonce,
-            request_digest,
-            sig_new_vid,
-            new_vid,
-            ..
-        } => (
-            open_relationship_request(
-                *request_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Parallel {
-                    new_vid,
-                    sig_new_vid,
-                },
-            ),
-            Some(ParallelSignatureInfo {
-                new_vid,
-                sig_new_vid,
-                signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
-                    sender_identity,
-                    &nonce,
-                    request_digest,
-                    new_vid,
-                )?,
-            }),
-        ),
-        crate::cesr::Payload::ParallelRelationAffirm {
+            reply_path,
+            referral,
+        } => {
+            let _ = reply_path;
+            match referral {
+                None => (
+                    open_relationship_request(
+                        *request_digest.as_bytes(),
+                        crate::definitions::RelationshipForm::Direct,
+                    ),
+                    None,
+                ),
+                Some((new_vid, sig_new_vid)) => (
+                    open_relationship_request(
+                        *request_digest.as_bytes(),
+                        crate::definitions::RelationshipForm::Parallel {
+                            new_vid,
+                            sig_new_vid,
+                        },
+                    ),
+                    Some(ParallelSignatureInfo {
+                        new_vid,
+                        sig_new_vid,
+                        signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
+                            sender_identity,
+                            &nonce,
+                            request_digest,
+                            &reply_path,
+                            new_vid,
+                        )?,
+                    }),
+                ),
+            }
+        }
+        crate::cesr::Payload::RelationAffirm {
             request_digest,
             reply_digest,
-            sig_new_vid,
-            new_vid,
         } => (
             open_relationship_accept(
                 *request_digest.as_bytes(),
                 *reply_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Parallel {
-                    new_vid,
-                    sig_new_vid,
-                },
+                crate::definitions::RelationshipForm::Direct,
             ),
-            Some(ParallelSignatureInfo {
-                new_vid,
-                sig_new_vid,
-                signed_data: crate::cesr::encode_parallel_relation_affirm_challenge(
-                    sender_identity,
-                    request_digest,
-                    reply_digest,
-                    new_vid,
-                )?,
-            }),
+            None,
         ),
         crate::cesr::Payload::ControlMessage(_) | crate::cesr::Payload::Padding { .. } => {
             // recognized on the wire, but not yet surfaced through the API

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -80,7 +80,6 @@ fn payload_for_seal<'a>(
             payload
         }
         Payload::CancelRelationship { thread_id } => crate::cesr::Payload::RelationshipCancel {
-            nonce: crate::cesr::Nonce::generate(|dst| csprng.fill_bytes(dst)),
             reply: digest_algorithm.field(thread_id),
         },
         Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(*data),

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -84,7 +84,6 @@ pub(crate) fn seal(
             payload
         }
         Payload::CancelRelationship { ref thread_id } => crate::cesr::Payload::RelationshipCancel {
-            nonce: crate::cesr::Nonce::generate(|dst| csprng.fill_bytes(dst)),
             reply: digest_algorithm.field(thread_id),
         },
         Payload::NestedMessage(data) => crate::cesr::Payload::NestedMessage(data),

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -152,73 +152,53 @@ pub(crate) fn open<'a>(
 
     let (secret_payload, parallel_signature_info) = match payload {
         crate::cesr::Payload::GenericMessage(data) => (Payload::Content(data as _), None),
-        crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => (
-            open_relationship_request(
-                *request_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Direct,
-            ),
-            None,
-        ),
-        crate::cesr::Payload::DirectRelationAffirm {
+        crate::cesr::Payload::RelationProposal {
             request_digest,
-            reply_digest,
-        } => (
-            open_relationship_accept(
-                *request_digest.as_bytes(),
-                *reply_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Direct,
-            ),
-            None,
-        ),
-        crate::cesr::Payload::ParallelRelationProposal {
             nonce,
-            request_digest,
-            sig_new_vid,
-            new_vid,
-            ..
-        } => (
-            open_relationship_request(
-                *request_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Parallel {
-                    new_vid,
-                    sig_new_vid,
-                },
-            ),
-            Some(ParallelSignatureInfo {
-                new_vid,
-                sig_new_vid,
-                signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
-                    sender_identity,
-                    &nonce,
-                    request_digest,
-                    new_vid,
-                )?,
-            }),
-        ),
-        crate::cesr::Payload::ParallelRelationAffirm {
+            reply_path,
+            referral,
+        } => {
+            let _ = reply_path;
+            match referral {
+                None => (
+                    open_relationship_request(
+                        *request_digest.as_bytes(),
+                        crate::definitions::RelationshipForm::Direct,
+                    ),
+                    None,
+                ),
+                Some((new_vid, sig_new_vid)) => (
+                    open_relationship_request(
+                        *request_digest.as_bytes(),
+                        crate::definitions::RelationshipForm::Parallel {
+                            new_vid,
+                            sig_new_vid,
+                        },
+                    ),
+                    Some(ParallelSignatureInfo {
+                        new_vid,
+                        sig_new_vid,
+                        signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
+                            sender_identity,
+                            &nonce,
+                            request_digest,
+                            &reply_path,
+                            new_vid,
+                        )?,
+                    }),
+                ),
+            }
+        }
+        crate::cesr::Payload::RelationAffirm {
             request_digest,
             reply_digest,
-            sig_new_vid,
-            new_vid,
         } => (
             open_relationship_accept(
                 *request_digest.as_bytes(),
                 *reply_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Parallel {
-                    new_vid,
-                    sig_new_vid,
-                },
+                crate::definitions::RelationshipForm::Direct,
             ),
-            Some(ParallelSignatureInfo {
-                new_vid,
-                sig_new_vid,
-                signed_data: crate::cesr::encode_parallel_relation_affirm_challenge(
-                    sender_identity,
-                    request_digest,
-                    reply_digest,
-                    new_vid,
-                )?,
-            }),
+            None,
         ),
         crate::cesr::Payload::ControlMessage(_) | crate::cesr::Payload::Padding { .. } => {
             // recognized on the wire, but not yet surfaced through the API

--- a/tsp_sdk/src/parallel_relationship_test.rs
+++ b/tsp_sdk/src/parallel_relationship_test.rs
@@ -142,26 +142,23 @@ async fn test_parallel_relationship_accept_bootstraps_unknown_sender_async() {
         .expect("parallel accept stream ended")
         .expect("failed to receive parallel accept");
 
+    // the accept arrives from bob's new VID over the new relationship, which
+    // alice has not verified before, so receiving it bootstraps that VID
     let crate::definitions::ReceivedTspMessage::AcceptRelationship {
         sender,
         receiver,
         thread_id: received_thread_id,
         reply_thread_id: _,
-        form:
-            ReceivedRelationshipForm::Parallel {
-                new_vid,
-                sig_new_vid: _,
-            },
+        form: ReceivedRelationshipForm::Direct,
         delivery: ReceivedRelationshipDelivery::Direct,
     } = accept
     else {
         panic!("alice did not receive a parallel relationship accept");
     };
 
-    assert_eq!(sender, bob.identifier());
+    assert_eq!(sender, bob_parallel.identifier());
     assert_eq!(receiver, alice_parallel.identifier());
     assert_eq!(received_thread_id, thread_id);
-    assert_eq!(new_vid, bob_parallel.identifier());
     assert!(
         alice_db
             .has_verified_vid(bob_parallel.identifier())

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -1902,9 +1902,9 @@ impl SecureStore {
     /// ignored, which the caller sees as a discard. Returns whether a reply is
     /// expected.
     ///
-    /// The digest identifies the relationship being cancelled, but MAY be NULL
-    /// when the canceling endpoint never received one, in which case the VID
-    /// pair identifies it on its own.
+    /// The digest identifies the relationship being cancelled. Every party to a
+    /// relationship holds at least the invite's digest, since a relationship
+    /// cannot be formed without one, so a cancellation always names it.
     fn cancel_relationship(
         &self,
         local_vid: &str,
@@ -1916,8 +1916,6 @@ impl SecureStore {
                 "unrecognized relationship cancellation from {remote_vid}; ignored"
             )))
         };
-        let recognized = |expected: Digest| thread_id == Digest::default() || thread_id == expected;
-
         let reply_expected = match self.relation_status_for_vid_pair(local_vid, remote_vid)? {
             RelationshipStatus::Bidirectional {
                 thread_id: local,
@@ -1925,7 +1923,7 @@ impl SecureStore {
                 ..
             } => {
                 // either direction's digest identifies the relationship
-                if !recognized(local) && !recognized(remote) {
+                if thread_id != local && thread_id != remote {
                     return ignore();
                 }
 
@@ -1933,7 +1931,7 @@ impl SecureStore {
             }
             RelationshipStatus::Unidirectional { thread_id: digest }
             | RelationshipStatus::ReverseUnidirectional { thread_id: digest } => {
-                if !recognized(digest) {
+                if thread_id != digest {
                     return ignore();
                 }
 

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -209,17 +209,13 @@ struct ParallelSignatureMaterial {
     request_nonce: Option<[u8; 16]>,
 }
 
-enum ParallelSignatureContext<'a> {
-    Request {
-        sender_identity: &'a str,
-        receiver_identity: &'a str,
-        nonce: [u8; 16],
-    },
-    Accept {
-        sender_identity: &'a str,
-        receiver_identity: &'a str,
-        thread_id: Digest,
-    },
+/// The fields an invite's `Signature_new` is made over. An accept carries no
+/// such signature: its new VID is the sender of the message, so the message's
+/// own signature proves control of it.
+struct ParallelSignatureContext<'a> {
+    sender_identity: &'a str,
+    receiver_identity: &'a str,
+    nonce: [u8; 16],
 }
 
 fn random_nonce_bytes() -> [u8; 16] {
@@ -897,9 +893,11 @@ impl SecureStore {
         let mut request_digest = [0_u8; 32];
 
         let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
-            crate::cesr::Payload::DirectRelationProposal {
-                nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            crate::cesr::Payload::RelationProposal {
                 request_digest: nested_digest_field(&request_digest, digest_algorithm),
+                nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+                reply_path: vec![],
+                referral: None,
             };
 
         let mut encoded_payload =
@@ -915,9 +913,11 @@ impl SecureStore {
 
         encoded_payload.clear();
         let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
-            crate::cesr::Payload::DirectRelationProposal {
-                nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+            crate::cesr::Payload::RelationProposal {
                 request_digest: nested_digest_field(&request_digest, digest_algorithm),
+                nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
+                reply_path: vec![],
+                referral: None,
             };
         crate::cesr::encode_payload(&payload, sender_identity, None, &mut encoded_payload)?;
 
@@ -937,7 +937,7 @@ impl SecureStore {
         let mut reply_thread_id = [0_u8; 32];
 
         let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
-            crate::cesr::Payload::DirectRelationAffirm {
+            crate::cesr::Payload::RelationAffirm {
                 request_digest: nested_digest_field(&thread_id, digest_algorithm),
                 reply_digest: nested_digest_field(&reply_thread_id, digest_algorithm),
             };
@@ -955,7 +955,7 @@ impl SecureStore {
 
         encoded_payload.clear();
         let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
-            crate::cesr::Payload::DirectRelationAffirm {
+            crate::cesr::Payload::RelationAffirm {
                 request_digest: nested_digest_field(&thread_id, digest_algorithm),
                 reply_digest: nested_digest_field(&reply_thread_id, digest_algorithm),
             };
@@ -1012,7 +1012,7 @@ impl SecureStore {
         }
 
         match payload {
-            crate::cesr::Payload::DirectRelationProposal { request_digest, .. } => {
+            crate::cesr::Payload::RelationProposal { request_digest, .. } => {
                 if inner_receiver.is_some() {
                     return Err(Error::Relationship(
                         "invalid nested relationship request receiver".into(),
@@ -1029,7 +1029,7 @@ impl SecureStore {
                     thread_id: *request_digest.as_bytes(),
                 }))
             }
-            crate::cesr::Payload::DirectRelationAffirm {
+            crate::cesr::Payload::RelationAffirm {
                 request_digest,
                 reply_digest,
             } => {
@@ -1307,33 +1307,26 @@ impl SecureStore {
                         reply_thread_id,
                         form,
                     } => {
-                        let is_direct = matches!(&form, RelationshipForm::Direct);
                         let form = received_relationship_form(form)?;
 
-                        if is_direct {
-                            self.upgrade_relation(
+                        // an accept answering an outstanding parallel invite
+                        // completes it, and arrives from the peer's new VID
+                        // over the new relationship (spec 7.2.5); any other
+                        // accept upgrades the relationship it names
+                        if self.consume_pending_parallel_request(
+                            receiver_pid.identifier(),
+                            thread_id,
+                        )? {
+                            self.establish_bidirectional_relation(
                                 receiver_pid.identifier(),
                                 &sender,
                                 thread_id,
                                 reply_thread_id,
                             )?;
                         } else {
-                            self.consume_pending_parallel_request(
+                            self.upgrade_relation(
                                 receiver_pid.identifier(),
-                                thread_id,
                                 &sender,
-                            )?;
-                            let parallel_sender_vid = parallel_sender_vid.ok_or_else(|| {
-                                Error::Relationship(
-                                    "missing verified parallel VID for accept message".into(),
-                                )
-                            })?;
-                            let parallel_sender_identifier =
-                                parallel_sender_vid.as_verified().identifier().to_string();
-                            parallel_sender_vid.persist(self)?;
-                            self.establish_bidirectional_relation(
-                                receiver_pid.identifier(),
-                                &parallel_sender_identifier,
                                 thread_id,
                                 reply_thread_id,
                             )?;
@@ -1465,56 +1458,29 @@ impl SecureStore {
     ) -> Result<ParallelSignatureMaterial, Error> {
         let mut digest = [0_u8; 32];
 
-        let (signed_data, request_nonce) = match context {
-            ParallelSignatureContext::Request {
-                sender_identity,
-                receiver_identity,
-                nonce,
-            } => {
-                let mut envelope_prefix = Vec::with_capacity(64);
-                crate::cesr::encode_envelope_prefix(
-                    sender_identity.as_bytes(),
-                    Some(receiver_identity.as_bytes()),
-                    &mut envelope_prefix,
-                )
-                .map_err(crate::crypto::CryptoError::from)?;
-                (
-                    crate::crypto::build_parallel_request_signed_data(
-                        Some(sender_identity.as_bytes()),
-                        digest_algorithm,
-                        nonce,
-                        &envelope_prefix,
-                        &mut digest,
-                        sender_new_vid.identifier().as_bytes(),
-                    )?,
-                    Some(nonce),
-                )
-            }
-            ParallelSignatureContext::Accept {
-                sender_identity,
-                receiver_identity,
-                thread_id,
-            } => {
-                let mut envelope_prefix = Vec::with_capacity(64);
-                crate::cesr::encode_envelope_prefix(
-                    sender_identity.as_bytes(),
-                    Some(receiver_identity.as_bytes()),
-                    &mut envelope_prefix,
-                )
-                .map_err(crate::crypto::CryptoError::from)?;
-                (
-                    crate::crypto::build_parallel_accept_signed_data(
-                        &thread_id,
-                        Some(sender_identity.as_bytes()),
-                        digest_algorithm,
-                        &envelope_prefix,
-                        &mut digest,
-                        sender_new_vid.identifier().as_bytes(),
-                    )?,
-                    None,
-                )
-            }
-        };
+        let ParallelSignatureContext {
+            sender_identity,
+            receiver_identity,
+            nonce,
+        } = context;
+
+        let mut envelope_prefix = Vec::with_capacity(64);
+        crate::cesr::encode_envelope_prefix(
+            sender_identity.as_bytes(),
+            Some(receiver_identity.as_bytes()),
+            &mut envelope_prefix,
+        )
+        .map_err(crate::crypto::CryptoError::from)?;
+
+        let signed_data = crate::crypto::build_parallel_request_signed_data(
+            Some(sender_identity.as_bytes()),
+            digest_algorithm,
+            nonce,
+            &envelope_prefix,
+            &mut digest,
+            sender_new_vid.identifier().as_bytes(),
+        )?;
+        let request_nonce = Some(nonce);
 
         let sig_new_vid = crate::crypto::sign_detached(sender_new_vid, &signed_data)?;
 
@@ -1549,7 +1515,7 @@ impl SecureStore {
         let digest_algorithm = digest_algorithm_for_selection(selection)?;
         let signature_material = self.build_parallel_signature_material(
             &*sender_new_vid,
-            ParallelSignatureContext::Request {
+            ParallelSignatureContext {
                 sender_identity: sender.identifier(),
                 receiver_identity: receiver.identifier(),
                 nonce: random_nonce_bytes(),
@@ -1624,32 +1590,21 @@ impl SecureStore {
     ) -> Result<(Url, Vec<u8>), Error> {
         let sender_new_vid = self.get_private_vid(sender_new_vid)?;
         let receiver_new_vid = self.get_verified_vid(receiver_new_vid)?;
-        let pending_incoming_request =
-            self.find_pending_incoming_parallel_request(receiver_new_vid.identifier(), thread_id)?;
-        let outer_sender = self.get_private_vid(&pending_incoming_request.local_outer_vid)?;
-        let selection = selected_outbound_crypto(&*outer_sender, &*receiver_new_vid, None);
-        let digest_algorithm = digest_algorithm_for_selection(selection)?;
-        let signature_material = self.build_parallel_signature_material(
-            &*sender_new_vid,
-            ParallelSignatureContext::Accept {
-                sender_identity: outer_sender.identifier(),
-                receiver_identity: receiver_new_vid.identifier(),
-                thread_id,
-            },
-            digest_algorithm,
-        )?;
-        let mut reply_thread_id = signature_material.digest;
+        // the invite must be outstanding; it recorded which relationship referred it
+        self.find_pending_incoming_parallel_request(receiver_new_vid.identifier(), thread_id)?;
+        let selection = selected_outbound_crypto(&*sender_new_vid, &*receiver_new_vid, None);
 
+        // the accept travels the new relationship, from this endpoint's new VID
+        // to the peer's, so its own signature proves control of that VID and it
+        // carries no referral field (spec 7.2.5)
+        let mut reply_thread_id = Default::default();
         let tsp_message = seal_envelope(
-            &*outer_sender,
+            &*sender_new_vid,
             &*receiver_new_vid,
             Payload::AcceptRelationship {
                 thread_id,
                 reply_thread_id: Default::default(),
-                form: RelationshipForm::Parallel {
-                    new_vid: sender_new_vid.identifier().as_bytes(),
-                    sig_new_vid: signature_material.sig_new_vid.as_slice(),
-                },
+                form: RelationshipForm::Direct,
             },
             Some(&mut reply_thread_id),
             None,
@@ -2108,48 +2063,33 @@ impl SecureStore {
         Ok(())
     }
 
+    /// Complete an outstanding parallel invite, if this accept answers one.
+    /// The accept arrives from the peer's new VID over the new relationship
+    /// (spec 7.2.5), so the thread id is what identifies it.
     fn consume_pending_parallel_request(
         &self,
         local_parallel_vid: &str,
         thread_id: Digest,
-        expected_outer_receiver: &str,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         let mut vids = self.vids.write()?;
 
         let Some(local_context) = vids.get_mut(local_parallel_vid) else {
-            return Err(Error::MissingVid(local_parallel_vid.into()));
+            return Ok(false);
         };
 
-        if let Some(index) = local_context
+        let Some(index) = local_context
             .pending_parallel_requests
             .iter()
             .position(|request| {
-                request.thread_id == thread_id
-                    && request.local_parallel_vid == local_parallel_vid
-                    && request.outer_receiver == expected_outer_receiver
+                request.thread_id == thread_id && request.local_parallel_vid == local_parallel_vid
             })
-        {
-            local_context.pending_parallel_requests.remove(index);
-            return Ok(());
-        }
+        else {
+            return Ok(false);
+        };
 
-        if local_context
-            .pending_parallel_requests
-            .iter()
-            .any(|request| {
-                request.thread_id == thread_id
-                    && request.local_parallel_vid == local_parallel_vid
-                    && !request.outer_receiver.is_empty()
-            })
-        {
-            return Err(Error::Relationship(format!(
-                "parallel relationship accept sender mismatch for {local_parallel_vid}"
-            )));
-        }
+        local_context.pending_parallel_requests.remove(index);
 
-        Err(Error::Relationship(format!(
-            "cannot find pending parallel request for {local_parallel_vid}"
-        )))
+        Ok(true)
     }
 
     fn add_pending_nested_request(
@@ -2883,40 +2823,23 @@ mod test {
 
         let received = a_store.open_message(&mut sealed).unwrap();
 
+        // the accept arrives from bob's new VID over the new relationship, so
+        // the new VID is the sender rather than a payload field (spec 7.2.5)
         let ReceivedTspMessage::AcceptRelationship {
             sender,
             receiver,
             thread_id: request_digest,
             reply_thread_id: received_reply_digest,
-            form:
-                ReceivedRelationshipForm::Parallel {
-                    new_vid,
-                    sig_new_vid,
-                },
+            form: ReceivedRelationshipForm::Direct,
             delivery: ReceivedRelationshipDelivery::Direct,
         } = received
         else {
             panic!("unexpected message type");
         };
-        assert_eq!(sender, bob.identifier());
+        assert_eq!(sender, bob_parallel.identifier());
         assert_eq!(receiver, alice_parallel.identifier());
-        assert_eq!(new_vid, bob_parallel.identifier());
-        assert_eq!(
-            a_store
-                .get_verified_vid(bob_parallel.identifier())
-                .unwrap()
-                .identifier(),
-            bob_parallel.identifier()
-        );
         assert_eq!(request_digest, thread_id);
         assert!(received_reply_digest.iter().any(|byte| *byte != 0));
-        assert_eq!(
-            sig_new_vid.len(),
-            match alice_parallel.signature_key_type() {
-                crate::definitions::VidSignatureKeyType::Ed25519 => 64,
-                crate::definitions::VidSignatureKeyType::MlDsa65 => 3309,
-            }
-        );
 
         let RelationshipStatus::Bidirectional {
             thread_id: receiver_thread_id,
@@ -3066,26 +2989,30 @@ mod test {
 
         let ReceivedTspMessage::AcceptRelationship {
             sender,
-            form: ReceivedRelationshipForm::Parallel { new_vid, .. },
+            form: ReceivedRelationshipForm::Direct,
             ..
         } = a_store.open_message(&mut accept).unwrap()
         else {
             panic!("unexpected message type");
         };
 
-        assert_eq!(sender, bob.identifier());
-        assert_eq!(new_vid, bob_parallel.identifier());
+        // the accept comes from bob's new VID over the new relationship
+        assert_eq!(sender, bob_parallel.identifier());
     }
 
     #[test]
     #[wasm_bindgen_test]
-    fn test_parallel_relationship_accept_rejects_wrong_outer_sender() {
+    fn test_parallel_relationship_accept_requires_the_invite_thread_id() {
+        // The accept now travels the new relationship, from the peer's new VID,
+        // so what ties it to the invite is the thread id -- which is the
+        // invite's digest, carried inside a ciphertext only the invited
+        // endpoint could open. An accept naming any other thread id does not
+        // complete the invite.
         let a_store = create_test_store();
         let b_store = create_test_store();
         let c_store = create_test_store();
         let (alice, bob) = create_test_vid_pair();
         let alice_parallel = create_test_vid();
-        let charlie = create_test_vid();
         let charlie_parallel = create_test_vid();
 
         a_store.add_private_vid(alice.clone(), None).unwrap();
@@ -3104,54 +3031,44 @@ mod test {
                 alice_parallel.identifier(),
             )
             .unwrap();
-        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
-            b_store.open_message(&mut request).unwrap()
-        else {
-            panic!("unexpected message type");
-        };
+        assert!(matches!(
+            b_store.open_message(&mut request).unwrap(),
+            ReceivedTspMessage::RequestRelationship { .. }
+        ));
 
-        c_store.add_private_vid(charlie.clone(), None).unwrap();
         c_store
             .add_private_vid(charlie_parallel.clone(), None)
             .unwrap();
         c_store
             .add_verified_vid(alice_parallel.clone(), None)
             .unwrap();
+        a_store
+            .add_verified_vid(charlie_parallel.clone(), None)
+            .unwrap();
 
+        // an accept for a thread id that is not the outstanding invite's
         let forged_receiver = c_store
             .get_verified_vid(alice_parallel.identifier())
             .unwrap();
-        let mut reply_thread_id = [0_u8; 32];
-        let signed_data = crate::crypto::build_parallel_accept_signed_data(
-            &thread_id,
-            Some(charlie.identifier().as_bytes()),
-            relationship_digest_algorithm(&charlie, &*forged_receiver),
-            &test_envelope_prefix(&charlie, &*forged_receiver),
-            &mut reply_thread_id,
-            charlie_parallel.identifier().as_bytes(),
-        )
-        .unwrap();
-        let sig_new_vid = crate::crypto::sign_detached(&charlie_parallel, &signed_data).unwrap();
-        let forged_sender = c_store.get_private_vid(charlie.identifier()).unwrap();
+        let forged_sender = c_store
+            .get_private_vid(charlie_parallel.identifier())
+            .unwrap();
         let mut forged_accept = crate::crypto::seal_and_hash(
             &*forged_sender,
             &*forged_receiver,
             Payload::AcceptRelationship {
-                thread_id,
+                thread_id: [0xAB; 32],
                 reply_thread_id: Default::default(),
-                form: RelationshipForm::Parallel {
-                    new_vid: charlie_parallel.identifier().as_bytes(),
-                    sig_new_vid: sig_new_vid.as_slice(),
-                },
+                form: RelationshipForm::Direct,
             },
-            Some(&mut reply_thread_id),
+            None,
         )
         .unwrap();
 
-        let Err(Error::Relationship(message)) = a_store.open_message(&mut forged_accept) else {
-            panic!("unexpected message result");
-        };
-        assert!(message.contains("sender mismatch"));
+        assert!(
+            a_store.open_message(&mut forged_accept).is_err(),
+            "an accept that names no outstanding invite must not establish one"
+        );
         assert!(matches!(
             a_store
                 .relation_status_for_vid_pair(
@@ -3162,6 +3079,7 @@ mod test {
             RelationshipStatus::Unrelated
         ));
 
+        // the invite is still outstanding
         let (vids, _, _) = a_store.export().unwrap();
         let Some(alice_parallel_export) = vids
             .iter()


### PR DESCRIPTION
Brings the SDK back in line with the spec after the §9 encoding edits (`rev3-work` @ `deb079c`, "Fix encoding issues and mismatches"). Three commits, all wire-breaking.

## 1. Long-form count codes

CESR's long-form count codes are `--X#####`. The `-0X#####` form this implementation emitted belongs to an earlier draft of the v2 tables and was replaced upstream in May 2025; the master table for genus `-_AAACAA`, which the spec pins, carries only the double-dash form. Two lines, but a round-trip test cannot catch it — encoder and decoder agree either way — so the new test pins the encoded bytes.

## 2. The cancellation message loses its nonce

A cancellation names the relationship it ends by its digest, and the spec now requires that digest to be present: a relationship cannot be formed without an invite, so every party holds at least that invite's digest. The nonce existed only to cover the case where the digest was absent. The store no longer reads an all-zero digest as an absent one — a convention invented here for a case the spec no longer has.

This also repairs `examples/src/bench.rs`, which still called `seal_message` with the non-confidential argument removed in PR #333. It sits behind the `bench` feature, which neither CI nor a default clippy run builds, so it had gone unnoticed.

## 3. One invite layout and one accept layout

`XRFI` now has a single layout covering the direct, routed and referral forms, and `XRFA` a single layout with no referral of its own.

An invite carries a reply path and a referral field, both generic lists that are empty when unused. Grouping the new VID with its signature means the two switch on and off together, so no field is present-or-absent on a discriminator — and the look-ahead the accept previously needed to tell a padding field from a new VID is gone. **The reply path is encoded but not yet populated: routed relationship forming is the next piece of work, and this is the field it was missing.**

An accept travels the new relationship, from this endpoint's new VID to the peer's, so control of that VID is proven by the message's own signature and the accept carries no referral field. What ties it to the invite is the thread id — the invite's digest, which reached the peer inside a ciphertext only it could open. The receiving side completes an outstanding invite by thread id rather than by matching the sender against the referring relationship, and the test that covered the old sender check now covers the thread-id one.

## Verification

- Full matrix green: default, no-default `async,resolve`, `pq`, and `--all-features`; workspace tests; clippy `--deny warnings`; fmt.
- Both bindings built and run locally, not left to CI: the wasm extension with the Node suite (5 passing), and a Python 3.12 environment via maturin (9 passing).
- Live, multi-process against two real `demo-intermediary` servers: direct, nested and routed (a → P → Q → b) all pass on the new wire format.
