### PR TITLE
Form relationships over a routed path

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -213,6 +213,13 @@ enum Commands {
         ask: bool,
         #[arg(long, help = "wait for a response")]
         wait: bool,
+        #[arg(
+            long,
+            value_delimiter = ',',
+            conflicts_with = "parallel",
+            help = "route the peer should use to reply, as a comma-separated VID list ending in this endpoint's VID at its intermediary"
+        )]
+        reply_path: Option<Vec<String>>,
     },
     #[command(arg_required_else_help = true, about = "accept a relationship")]
     Accept {
@@ -1367,6 +1374,7 @@ async fn run() -> Result<(), Error> {
             parent_vid,
             ask,
             wait,
+            reply_path,
         } => {
             ensure_vid_verified(&vid_wallet, &receiver_vid, &args.wallet, ask).await?;
 
@@ -1417,7 +1425,14 @@ async fn run() -> Result<(), Error> {
                     "sent a parallel relationship request from {sender_vid} to {receiver_vid} with new identity '{new_vid}'"
                 );
             } else if let Err(e) = vid_wallet
-                .send_relationship_request(&sender_vid, &receiver_vid, None)
+                .send_relationship_request(
+                    &sender_vid,
+                    &receiver_vid,
+                    reply_path
+                        .as_ref()
+                        .map(|hops| hops.iter().map(String::as_str).collect::<Vec<_>>())
+                        .as_deref(),
+                )
                 .await
             {
                 tracing::error!("error sending message from {sender_vid} to {receiver_vid}: {e}");

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -395,13 +395,11 @@ impl AsyncSecureStore {
         match self.inner.relation_status_for_vid_pair(sender, receiver) {
             Ok(relation) => {
                 if matches!(relation, RelationshipStatus::Unrelated) {
-                    self.warn_on_direct_relationship_forming(receiver)?;
                     self.send_relationship_request(sender, receiver, None)
                         .await?
                 }
             }
             Err(Error::Relationship(_)) => {
-                self.warn_on_direct_relationship_forming(receiver)?;
                 self.send_relationship_request(sender, receiver, None)
                     .await?
             }
@@ -413,24 +411,6 @@ impl AsyncSecureStore {
         tracing::info!("sending message to {endpoint}");
 
         crate::transport::send_message(&endpoint, &message).await?;
-
-        Ok(())
-    }
-
-    /// Warn when a relationship is about to be formed directly with a receiver
-    /// for which a route is configured. The specification requires the
-    /// relationship forming message itself to travel the route in that case
-    /// (spec 7.2.4), carrying a Reply_Path; sending it directly reveals to the
-    /// destination, and to anyone observing, an endpoint the route exists to
-    /// keep out of view. Routed relationship forming is not implemented yet.
-    fn warn_on_direct_relationship_forming(&self, receiver: &str) -> Result<(), Error> {
-        if self.inner.has_route_for_vid(receiver)? {
-            tracing::warn!(
-                "forming a relationship with {receiver} directly although a route is set for it: \
-                 routed relationship forming is not implemented, so this message does not take \
-                 the route"
-            );
-        }
 
         Ok(())
     }
@@ -845,97 +825,12 @@ impl AsyncSecureStore {
 
         let db = self.inner.clone();
         let self_clone = self.clone();
-        // A message that fails any verification or validation step is discarded
-        // silently, which is a rule about the wire: nothing is sent in
-        // response, since a response would disclose information to whoever
-        // sent it (spec 3.7). It says nothing about the local caller, so the
-        // failure is passed on and what to make of it is the caller's to
-        // decide. It does not end the stream.
-        let stream: TSPStream<ReceivedTspMessage, Error> = Box::pin(
-            messages
-                .then(move |message| {
-                    let db_inner = db.clone();
-                    let self_inner = self_clone.clone();
-                    async move {
-                        let mut message = message?;
-
-                        if let Ok(colored) = crate::cesr::color_format(&message) {
-                            tracing::trace!("CESR-encoded message: {}", colored);
-                        }
-
-                        // a peer that has been silent longer than the
-                        // re-verification threshold may have rotated its keys
-                        // unobserved; refresh its key state before acting on this
-                        // message (spec 7.4.2)
-                        if let Ok((sender, _)) = crate::cesr::get_sender_receiver(&message)
-                            && let Ok(sender) = std::str::from_utf8(sender)
-                            && db_inner.has_verified_vid(sender)?
-                            && self_inner.silent_beyond_threshold(sender)?
-                        {
-                            debug!("re-resolving {sender} after silence");
-                            if let Err(e) = self_inner.refresh_key_state(sender).await {
-                                // acting on a message whose key state could not be
-                                // confirmed is exactly what the rule forbids
-                                debug!("could not confirm the key state of {sender}: {e}");
-                                return Ok(None);
-                            }
-                        }
-
-                        let opened = match db_inner.open_message(&mut message) {
-                            // first contact: the sender is not in the wallet yet,
-                            // so it has to be resolved before the message can be
-                            // opened at all
-                            Err(Error::UnverifiedSource(unknown_vid, _)) => {
-                                debug!("Verifying VID: {}", unknown_vid);
-                                match self_inner.refresh_key_state(&unknown_vid).await {
-                                    Ok(true) => db_inner.open_message(&mut message),
-                                    Ok(false) => Err(Error::UnverifiedVid(unknown_vid)),
-                                    Err(e) => Err(e),
-                                }
-                            }
-                            // a signature that does not verify may be the result of
-                            // a rotation we have not observed: within an
-                            // established relationship, re-resolve and retry once
-                            // before discarding (spec 3.7, 7.4.2)
-                            Err(Error::Crypto(CryptoError::Verify(vid, reason))) => {
-                                if db_inner.has_relationship_with(&vid)?
-                                    && self_inner.refresh_key_state(&vid).await.is_ok()
-                                {
-                                    debug!("Re-verifying VID: {}", vid);
-                                    db_inner.open_message(&mut message)
-                                } else {
-                                    Err(Error::Crypto(CryptoError::Verify(vid, reason)))
-                                }
-                            }
-                            maybe_message => maybe_message,
-                        };
-
-                        match opened {
-                            Ok(message) => {
-                                if let Some(sender) = message.sender() {
-                                    self_inner.record_seen(sender)?;
-                                }
-
-                                Ok(Some(message.into_owned()))
-                            }
-                            Err(e) => {
-                                debug!("discarded a message that failed validation: {e}");
-
-                                Ok(None)
-                            }
-                        }
-                    }
-                })
-                .filter_map(|result| async move {
-                    match result {
-                        Ok(Some(message)) => Some(Ok(message)),
-                        // silently discarded
-                        Ok(None) => None,
-                        // a transport failure, which is not a message failure
-                        Err(e) => Some(Err(e)),
-                    }
-                }),
-        );
+        let stream: TSPStream<ReceivedTspMessage, Error> =
+            Box::pin(messages.then(move |message| {
+                let db_inner = db.clone();
+                let self_inner = self_clone.clone();
+                async move { self_inner.open_incoming(&db_inner, message?).await }
+            }));
 
         Ok((stream, cursor))
     }
@@ -973,51 +868,96 @@ impl AsyncSecureStore {
 
         let db = self.inner.clone();
         let self_clone = self.clone();
+
         Ok(Box::pin(messages.then(move |message| {
             let db_inner = db.clone();
             let self_inner = self_clone.clone();
-            async move {
-                let mut message = message?;
-
-                if let Ok(colored) = crate::cesr::color_format(&message) {
-                    tracing::trace!("CESR-encoded message: {}", colored);
-                }
-
-                match db_inner.open_message(&mut message) {
-                    Err(Error::UnverifiedSource(unknown_vid, _)) => {
-                        debug!("Verifying VID: {}", unknown_vid);
-                        let options = VerifyVidOptions {
-                            resolution_context: self_inner.get_resolution_context(&unknown_vid)?,
-                        };
-                        self_inner
-                            .verify_vid_with_options(&unknown_vid, None, options)
-                            .await?;
-                        db_inner.open_message(&mut message)
-                    }
-                    Err(Error::UnverifiedVid(unknown_vid)) => {
-                        debug!("Verifying VID: {}", unknown_vid);
-                        self_inner.verify_vid(&unknown_vid, None).await?;
-                        db_inner.open_message(&mut message)
-                    }
-                    Err(Error::Crypto(CryptoError::Verify(vid, _))) => {
-                        debug!("Re-verifying VID: {}", vid);
-                        let options = VerifyVidOptions {
-                            resolution_context: self_inner.get_resolution_context(&vid)?,
-                        };
-                        self_inner
-                            .verify_vid_with_options(&vid, None, options)
-                            .await?;
-                        db_inner.open_message(&mut message)
-                    }
-                    maybe_message => maybe_message,
-                }
-                .map(|msg| msg.into_owned())
-                .map_err(|e| {
-                    tracing::error!("{}", e);
-                    e
-                })
-            }
+            async move { self_inner.open_incoming(&db_inner, message?).await }
         })))
+    }
+
+    /// Open one received message.
+    ///
+    /// A message that fails any verification or validation step is discarded
+    /// silently, which is a rule about the wire: nothing is sent in response,
+    /// since a response would disclose information to whoever sent it (spec
+    /// 3.7). It says nothing about the local caller, so the failure is returned
+    /// and what to make of it is the caller's to decide; it does not end the
+    /// stream, which `Error::ends_stream` lets the caller tell apart.
+    async fn open_incoming(
+        &self,
+        db: &SecureStore,
+        message: BytesMut,
+    ) -> Result<ReceivedTspMessage, Error> {
+        if let Ok(colored) = crate::cesr::color_format(&message) {
+            tracing::trace!("CESR-encoded message: {}", colored);
+        }
+
+        // a peer that has been silent longer than the re-verification threshold
+        // may have rotated its keys unobserved; refresh its key state before
+        // acting on this message (spec 7.4.2)
+        if let Ok((sender, _)) = crate::cesr::get_sender_receiver(&message)
+            && let Ok(sender) = std::str::from_utf8(sender)
+            && db.has_verified_vid(sender)?
+            && self.silent_beyond_threshold(sender)?
+        {
+            debug!("re-resolving {sender} after silence");
+            if let Err(e) = self.refresh_key_state(sender).await {
+                // acting on a message whose key state could not be confirmed is
+                // exactly what the rule forbids
+                debug!("could not confirm the key state of {sender}: {e}");
+
+                return Err(e);
+            }
+        }
+
+        // opening decrypts in place, so every attempt needs the message as it
+        // arrived rather than the buffer a previous attempt left behind
+        let mut attempt = message.clone();
+        let opened = match db.open_message(&mut attempt) {
+            // first contact: the sender is not in the wallet yet, so it has to
+            // be resolved before the message can be opened at all
+            Err(Error::UnverifiedSource(unknown_vid, _))
+            | Err(Error::UnverifiedVid(unknown_vid)) => {
+                debug!("verifying {unknown_vid}");
+                match self.refresh_key_state(&unknown_vid).await {
+                    Ok(true) => {
+                        attempt = message.clone();
+                        db.open_message(&mut attempt)
+                    }
+                    Ok(false) => Err(Error::UnverifiedVid(unknown_vid)),
+                    Err(e) => Err(e),
+                }
+            }
+            // a signature that does not verify may be the result of a rotation
+            // we have not observed: within an established relationship,
+            // re-resolve and retry once before discarding (spec 3.7, 7.4.2)
+            Err(Error::Crypto(CryptoError::Verify(vid, reason))) => {
+                if db.has_relationship_with(&vid)? && self.refresh_key_state(&vid).await.is_ok() {
+                    debug!("re-verifying {vid}");
+                    attempt = message.clone();
+                    db.open_message(&mut attempt)
+                } else {
+                    Err(Error::Crypto(CryptoError::Verify(vid, reason)))
+                }
+            }
+            maybe_message => maybe_message,
+        };
+
+        match opened {
+            Ok(message) => {
+                if let Some(sender) = message.sender() {
+                    self.record_seen(sender)?;
+                }
+
+                Ok(message.into_owned())
+            }
+            Err(e) => {
+                debug!("discarded a message that failed validation: {e}");
+
+                Err(e)
+            }
+        }
     }
 
     /// Send a TSP broadcast message to the specified VIDs

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -149,10 +149,12 @@ fn compute_relationship_digest(
     Ok(algorithm.hash(&input))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_parallel_request_signed_data(
     sender_in_payload: Option<&[u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
     nonce_bytes: [u8; 16],
+    reply_path: &[&[u8]],
     envelope_prefix: &[u8],
     request_digest: &mut Digest,
     new_vid: &[u8],
@@ -162,7 +164,7 @@ pub(crate) fn build_parallel_request_signed_data(
     let payload = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
         request_digest: digest_algorithm.field(&*request_digest),
         nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
-        reply_path: vec![],
+        reply_path: reply_path.to_vec(),
         referral: Some((new_vid, &[0; 64])),
     };
     *request_digest = compute_relationship_digest(
@@ -177,7 +179,7 @@ pub(crate) fn build_parallel_request_signed_data(
         sender_in_payload,
         &nonce,
         digest_algorithm.field(request_digest),
-        &[] as &[&[u8]],
+        reply_path,
         new_vid,
     )?)
 }
@@ -186,14 +188,13 @@ fn relationship_request_payload<'a>(
     form: &RelationshipForm<'a, &'a [u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
     nonce_bytes: [u8; 16],
+    reply_path: &[&'a [u8]],
     request_digest: &'a Digest,
 ) -> CesrRelationshipPayload<'a> {
     crate::cesr::Payload::RelationProposal {
         request_digest: digest_algorithm.field(request_digest),
         nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
-        // routed relationship forming is not implemented yet; when it is, the
-        // reply path the caller asks for goes here
-        reply_path: vec![],
+        reply_path: reply_path.to_vec(),
         referral: match form {
             RelationshipForm::Direct => None,
             RelationshipForm::Parallel {
@@ -220,16 +221,23 @@ fn relationship_accept_payload<'a>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_relationship_request_payload<'a>(
     form: &RelationshipForm<'a, &'a [u8]>,
     sender_in_payload: Option<&[u8]>,
     digest_algorithm: RelationshipDigestAlgorithm,
     nonce_bytes: [u8; 16],
+    reply_path: &[&'a [u8]],
     envelope_prefix: &[u8],
     request_digest: &'a mut Digest,
 ) -> Result<(CesrRelationshipPayload<'a>, Digest), CryptoError> {
-    let placeholder =
-        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest);
+    let placeholder = relationship_request_payload(
+        form,
+        digest_algorithm,
+        nonce_bytes,
+        reply_path,
+        &*request_digest,
+    );
     *request_digest = compute_relationship_digest(
         &placeholder,
         sender_in_payload,
@@ -240,7 +248,13 @@ pub(crate) fn build_relationship_request_payload<'a>(
     let digest = *request_digest;
 
     Ok((
-        relationship_request_payload(form, digest_algorithm, nonce_bytes, &*request_digest),
+        relationship_request_payload(
+            form,
+            digest_algorithm,
+            nonce_bytes,
+            reply_path,
+            &*request_digest,
+        ),
         digest,
     ))
 }
@@ -299,8 +313,13 @@ pub(crate) fn verify_relationship_digest(
 pub(crate) fn open_relationship_request<'a>(
     thread_id: Digest,
     form: RelationshipForm<'a, &'a [u8]>,
+    reply_path: Vec<&'a [u8]>,
 ) -> Payload<'a, &'a [u8], &'a mut [u8]> {
-    Payload::RequestRelationship { thread_id, form }
+    Payload::RequestRelationship {
+        thread_id,
+        form,
+        reply_path,
+    }
 }
 
 pub(crate) fn open_relationship_accept<'a>(

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -45,6 +45,7 @@ fn payload_for_seal<'a>(
         Payload::RequestRelationship {
             thread_id: _ignored,
             form,
+            reply_path,
         } => {
             let nonce_bytes = request_nonce_override.unwrap_or_else(|| {
                 let mut nonce_bytes = [0_u8; 16];
@@ -57,6 +58,7 @@ fn payload_for_seal<'a>(
                 sender_in_payload,
                 digest_algorithm,
                 nonce_bytes,
+                reply_path,
                 envelope_prefix,
                 request_digest_storage,
             )?;
@@ -277,6 +279,7 @@ fn open_payload<'a>(
                     open_relationship_request(
                         *request_digest.as_bytes(),
                         crate::definitions::RelationshipForm::Direct,
+                        reply_path,
                     ),
                     None,
                 ),
@@ -287,6 +290,7 @@ fn open_payload<'a>(
                             new_vid,
                             sig_new_vid,
                         },
+                        reply_path.clone(),
                     ),
                     Some(ParallelSignatureInfo {
                         new_vid,

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -49,6 +49,7 @@ pub(crate) fn seal(
         Payload::RequestRelationship {
             thread_id: _ignored,
             form,
+            reply_path,
         } => {
             let nonce_bytes = request_nonce_override.unwrap_or_else(|| {
                 let mut nonce_bytes = [0_u8; 16];
@@ -61,6 +62,7 @@ pub(crate) fn seal(
                 sender_in_payload,
                 digest_algorithm,
                 nonce_bytes,
+                &reply_path,
                 &data,
                 &mut request_digest_storage,
             )?;
@@ -164,6 +166,7 @@ pub(crate) fn open<'a>(
                     open_relationship_request(
                         *request_digest.as_bytes(),
                         crate::definitions::RelationshipForm::Direct,
+                        reply_path,
                     ),
                     None,
                 ),
@@ -174,6 +177,7 @@ pub(crate) fn open<'a>(
                             new_vid,
                             sig_new_vid,
                         },
+                        reply_path.clone(),
                     ),
                     Some(ParallelSignatureInfo {
                         new_vid,

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -216,6 +216,9 @@ pub enum Payload<'a, Bytes: AsRef<[u8]>, MaybeMutBytes: AsRef<[u8]> = Bytes> {
     RequestRelationship {
         thread_id: Digest,
         form: RelationshipForm<'a, Bytes>,
+        /// The route the replying endpoint is to use to reach this sender
+        /// (spec 7.2.4). Empty when the reply is to come back directly.
+        reply_path: Vec<VidData<'a>>,
     },
     AcceptRelationship {
         thread_id: Digest,

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -2601,7 +2601,8 @@ mod test {
             .unwrap();
 
         let mut first = nested.clone();
-        let Err(Error::UnverifiedSource(unknown, _)) = b_store.open_message(&mut first) else {
+        // the variant carries the payload only when the async feature is on
+        let Err(Error::UnverifiedSource(unknown, ..)) = b_store.open_message(&mut first) else {
             panic!("an unknown inner sender should be reported");
         };
         assert_eq!(unknown, alice.identifier());

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -618,6 +618,17 @@ impl SecureStore {
     }
 
     /// Whether a route is configured for this VID
+    /// The route configured for this VID, if any
+    pub fn get_route_for_vid(&self, vid: &str) -> Result<Option<Vec<String>>, Error> {
+        let vid = self.try_resolve_alias(vid)?;
+
+        Ok(self
+            .vids
+            .read()?
+            .get(&vid)
+            .and_then(|context| context.get_route().map(<[String]>::to_vec)))
+    }
+
     pub fn has_route_for_vid(&self, vid: &str) -> Result<bool, Error> {
         let vid = self.try_resolve_alias(vid)?;
 
@@ -1260,8 +1271,23 @@ impl SecureStore {
                             opaque_payload: BytesMut::from_iter(message.iter()),
                         })
                     }
-                    Payload::RequestRelationship { thread_id, form } => {
+                    Payload::RequestRelationship {
+                        thread_id,
+                        form,
+                        reply_path,
+                    } => {
                         let form = received_relationship_form(form)?;
+
+                        // the sender told us how to reach it (spec 7.2.4), so
+                        // record that as the route for its VID; the accept and
+                        // everything after it then travel that path
+                        if !reply_path.is_empty() {
+                            let hops = reply_path
+                                .iter()
+                                .map(|hop| std::str::from_utf8(hop))
+                                .collect::<Result<Vec<_>, _>>()?;
+                            self.set_route_for_vid(&sender, &hops)?;
+                        }
 
                         if matches!(form, ReceivedRelationshipForm::Direct) {
                             self.record_incoming_relationship_request(
@@ -1417,37 +1443,50 @@ impl SecureStore {
         &self,
         sender: &str,
         receiver: &str,
-        route: Option<&[&str]>,
+        reply_path: Option<&[&str]>,
         selection: Option<OutboundCryptoSelection>,
     ) -> Result<(Url, Vec<u8>), Error> {
-        if route.is_some() {
-            return Err(Error::Relationship(
-                "routed relationship-forming requires Reply_Path; not implemented".into(),
-            ));
-        }
+        let sender_vid = self.get_private_vid(sender)?;
+        let receiver_vid = self.get_verified_vid(receiver)?;
 
-        let sender = self.get_private_vid(sender)?;
-        let receiver = self.get_verified_vid(receiver)?;
+        let reply_path = self.resolve_reply_path(reply_path)?;
+        let reply_path_bytes = reply_path
+            .iter()
+            .map(|hop| hop.as_bytes())
+            .collect::<Vec<_>>();
+
         let mut thread_id = Default::default();
-        let tsp_message = seal_envelope(
-            &*sender,
-            &*receiver,
+        // the invite itself travels whatever route is set for the receiver,
+        // so relationship forming over a routed path uses the same machinery
+        // as any other message (spec 7.2.4)
+        let (endpoint, tsp_message) = self.seal_message_payload_and_hash_with_selection(
+            sender_vid.identifier(),
+            receiver_vid.identifier(),
             Payload::RequestRelationship {
                 thread_id: Default::default(),
                 form: RelationshipForm::Direct,
+                reply_path: reply_path_bytes,
             },
             Some(&mut thread_id),
-            None,
             selection,
         )?;
 
         self.set_relation_and_status_for_vid(
-            receiver.identifier(),
+            receiver_vid.identifier(),
             RelationshipStatus::Unidirectional { thread_id },
-            sender.identifier(),
+            sender_vid.identifier(),
         )?;
 
-        Ok((receiver.endpoint().clone(), tsp_message.to_owned()))
+        Ok((endpoint, tsp_message))
+    }
+
+    /// Resolve the aliases of a caller-supplied reply path
+    fn resolve_reply_path(&self, reply_path: Option<&[&str]>) -> Result<Vec<String>, Error> {
+        reply_path
+            .unwrap_or_default()
+            .iter()
+            .map(|hop| self.try_resolve_alias(hop))
+            .collect()
     }
 
     fn build_parallel_signature_material(
@@ -1476,6 +1515,7 @@ impl SecureStore {
             Some(sender_identity.as_bytes()),
             digest_algorithm,
             nonce,
+            &[],
             &envelope_prefix,
             &mut digest,
             sender_new_vid.identifier().as_bytes(),
@@ -1529,6 +1569,7 @@ impl SecureStore {
             &*receiver,
             Payload::RequestRelationship {
                 thread_id: Default::default(),
+                reply_path: vec![],
                 form: RelationshipForm::Parallel {
                     new_vid: sender_new_vid.identifier().as_bytes(),
                     sig_new_vid: signature_material.sig_new_vid.as_slice(),
@@ -1558,10 +1599,15 @@ impl SecureStore {
         thread_id: Digest,
         route: Option<&[&str]>,
     ) -> Result<(Url, Vec<u8>), Error> {
-        if route.is_some() {
-            return Err(Error::Relationship(
-                "routed relationship-forming requires Reply_Path; not implemented".into(),
-            ));
+        // the accept travels the reply path the invite carried, which was
+        // recorded as the route for the inviting VID when the invite arrived.
+        // A caller may add hops of its own in front of it (spec 7.2.4).
+        if let Some(route) = route {
+            let route = self.resolve_reply_path(Some(route))?;
+            self.set_route_for_vid(
+                receiver,
+                &route.iter().map(String::as_str).collect::<Vec<_>>(),
+            )?;
         }
 
         let mut reply_thread_id = Default::default();
@@ -2512,6 +2558,68 @@ mod test {
 
     #[test]
     #[wasm_bindgen_test]
+    fn test_nested_message_from_unknown_inner_sender_opens_after_verification() {
+        // A nested message whose inner sender is unknown is reported as
+        // UnverifiedSource so the caller can resolve that VID and try again.
+        // The retry must succeed on a fresh copy of the same bytes -- this is
+        // the shape of a routed invite arriving from an endpoint the receiver
+        // has never seen.
+        let a_store = create_test_store();
+        let q_store = create_test_store();
+        let b_store = create_test_store();
+
+        let alice = create_test_vid();
+        let bob = create_test_vid();
+        let intermediary = create_test_vid();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        q_store.add_private_vid(intermediary.clone(), None).unwrap();
+        q_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store
+            .add_verified_vid(intermediary.clone(), None)
+            .unwrap();
+        // bob knows the intermediary, but has never seen alice
+        b_store
+            .set_relation_and_status_for_vid(
+                intermediary.identifier(),
+                RelationshipStatus::Unidirectional { thread_id: [7; 32] },
+                bob.identifier(),
+            )
+            .unwrap();
+
+        let (_url, inner) = a_store
+            .make_relationship_request(alice.identifier(), bob.identifier(), None)
+            .unwrap();
+        let (_url, nested) = q_store
+            .seal_message_payload(
+                intermediary.identifier(),
+                bob.identifier(),
+                Payload::NestedMessage(&inner),
+            )
+            .unwrap();
+
+        let mut first = nested.clone();
+        let Err(Error::UnverifiedSource(unknown, _)) = b_store.open_message(&mut first) else {
+            panic!("an unknown inner sender should be reported");
+        };
+        assert_eq!(unknown, alice.identifier());
+
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        let mut retry = nested.clone();
+        let received = b_store
+            .open_message(&mut retry)
+            .expect("the retry must open the message");
+        assert!(matches!(
+            received,
+            ReceivedTspMessage::RequestRelationship { .. }
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
     fn test_open_seal() {
         let store = create_test_store();
         let (alice, bob) = create_test_vid_pair();
@@ -3170,6 +3278,7 @@ mod test {
             Some(alice.identifier().as_bytes()),
             relationship_digest_algorithm(&alice, &bob),
             nonce_bytes,
+            &[],
             &test_envelope_prefix(&alice, &bob),
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),
@@ -3186,6 +3295,7 @@ mod test {
             &*receiver_vid,
             Payload::RequestRelationship {
                 thread_id: Default::default(),
+                reply_path: vec![],
                 form: RelationshipForm::Parallel {
                     new_vid: alice_parallel.identifier().as_ref(),
                     sig_new_vid: sig_new_vid.as_slice(),
@@ -3231,6 +3341,7 @@ mod test {
             Some(alice.identifier().as_bytes()),
             relationship_digest_algorithm(&alice, &bob),
             nonce_bytes,
+            &[],
             &test_envelope_prefix(&alice, &bob),
             &mut thread_id,
             alice_parallel.identifier().as_bytes(),
@@ -3246,6 +3357,7 @@ mod test {
             &*receiver_vid,
             Payload::RequestRelationship {
                 thread_id: Default::default(),
+                reply_path: vec![],
                 form: RelationshipForm::Parallel {
                     new_vid: alice_parallel.identifier().as_ref(),
                     sig_new_vid: sig_new_vid.as_slice(),
@@ -3414,39 +3526,98 @@ mod test {
 
     #[test]
     #[wasm_bindgen_test]
-    fn test_relationship_forming_requires_reply_path_for_routes() {
-        let store = create_test_store();
-        let (alice, bob) = create_test_vid_pair();
-        let hop = create_test_vid();
+    fn test_relationship_forming_carries_a_reply_path() {
+        // A invites B over a route, telling B how to reach it; B records that
+        // as the route for A, so its accept travels back the same way
+        // (spec 7.2.4).
+        let a_store = create_test_store();
+        let b_store = create_test_store();
 
-        store.add_private_vid(alice.clone(), None).unwrap();
-        store.add_verified_vid(bob.clone(), None).unwrap();
-        store.add_verified_vid(hop.clone(), None).unwrap();
+        let alice = create_test_vid();
+        let bob = create_test_vid();
+        let alice_intermediary = create_test_vid();
+        let bob_intermediary = create_test_vid();
 
-        let err = store
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        a_store
+            .add_verified_vid(bob_intermediary.clone(), None)
+            .unwrap();
+        a_store
+            .add_verified_vid(alice_intermediary.clone(), None)
+            .unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        b_store
+            .add_verified_vid(alice_intermediary.clone(), None)
+            .unwrap();
+        // bob reaches alice's intermediary over his own relationship with it
+        b_store
+            .set_relation_and_status_for_vid(
+                alice_intermediary.identifier(),
+                RelationshipStatus::Unidirectional { thread_id: [6; 32] },
+                bob.identifier(),
+            )
+            .unwrap();
+
+        // alice reaches bob through his intermediary, and asks for the reply
+        // to come back through hers
+        a_store
+            .set_relation_and_status_for_vid(
+                bob_intermediary.identifier(),
+                RelationshipStatus::Unidirectional { thread_id: [5; 32] },
+                alice.identifier(),
+            )
+            .unwrap();
+        a_store
+            .set_route_for_vid(
+                bob.identifier(),
+                &[bob_intermediary.identifier(), bob.identifier()],
+            )
+            .unwrap();
+
+        let (_url, mut request) = a_store
             .make_relationship_request(
                 alice.identifier(),
                 bob.identifier(),
-                Some(&[hop.identifier()]),
+                Some(&[alice_intermediary.identifier(), alice.identifier()]),
             )
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            crate::Error::Relationship(message) if message.contains("Reply_Path")
-        ));
+            .unwrap();
 
-        let err = store
-            .make_relationship_accept(
-                alice.identifier(),
-                bob.identifier(),
-                [3; 32],
-                Some(&[hop.identifier()]),
-            )
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            crate::Error::Relationship(message) if message.contains("Reply_Path")
-        ));
+        // the invite reached bob's intermediary as a routed message; it hands
+        // the inner message to bob
+        let i_store = create_test_store();
+        i_store
+            .add_private_vid(bob_intermediary.clone(), None)
+            .unwrap();
+        i_store.add_verified_vid(alice.clone(), None).unwrap();
+        let forwarded = i_store.open_message(&mut request).unwrap().into_owned();
+
+        let ReceivedTspMessage::ForwardRequest { opaque_payload, .. } = forwarded else {
+            panic!("the invite did not travel the route");
+        };
+
+        let mut inner = opaque_payload.to_vec();
+        let ReceivedTspMessage::RequestRelationship { thread_id, .. } =
+            b_store.open_message(&mut inner).unwrap()
+        else {
+            panic!("bob did not receive a relationship request");
+        };
+
+        // bob now knows how to reach alice
+        assert_eq!(
+            b_store.get_route_for_vid(alice.identifier()).unwrap(),
+            Some(vec![
+                alice_intermediary.identifier().to_string(),
+                alice.identifier().to_string(),
+            ]),
+        );
+
+        // so his accept goes to alice's intermediary rather than to alice
+        let (url, _accept) = b_store
+            .make_relationship_accept(bob.identifier(), alice.identifier(), thread_id, None)
+            .unwrap();
+        assert_url_matches(&url, &alice_intermediary);
     }
 
     #[test]


### PR DESCRIPTION
Relationship forming over a routed path — the one thing routed mode could not do. Two commits.

## 1. One implementation for opening a received message

There were two receive loops doing the same job, and they had drifted apart. Only the tracked one had PR #335's key-state rules. Only the untracked one — the one `receive()` actually uses — reported a failed message to the caller. And both retried a failed open on the buffer the previous attempt had already decrypted **in place**, so the retry verified a signature over plaintext and failed.

That last one is a real delivery bug, not just untidiness: a message from a sender the receiver has never seen is reported as `UnverifiedSource` so the caller can resolve that VID and try again, and the retry then failed — reported, confusingly, as a signature failure attributed to the intermediary that relayed it. A routed invite is exactly that shape, which is how it surfaced.

Both loops now call one method that refreshes stale key state, retries each kind of failure once from an untouched copy of the message, and returns the failure to the caller.

## 2. The invite carries a reply path

An invite now carries the route the replying endpoint should use to reach the inviting one (spec §7.2.4), and travels whatever route is configured for its receiver rather than going directly. Receiving an invite records that reply path as the route for the sender's VID, so the accept — and everything after it — travel back the same way, reusing the routing the SDK already had rather than adding a second mechanism.

This closes the gap PR #335 could only warn about: `send()` formed relationships **directly** even when a route was set, disclosing to the destination, and to anyone watching, the very endpoint the route existed to keep out of view. That warning is gone because the behaviour it described is.

An accept may add hops of its own in front of the reply path, which is the caller's to supply; the CLI takes one with `--reply-path`.

## Verification

- Full matrix green: default, no-default `async,resolve`, `pq`, `--all-features`; workspace tests; clippy `--deny warnings`; fmt.
- New tests: a routed invite through an intermediary, asserting the receiver records the reply path and its accept is addressed to the inviter's intermediary rather than the inviter; and a nested message from an unknown inner sender, asserting the retry opens it.
- Live, multi-process against two real `demo-intermediary` servers: direct, nested, and routed all pass. The routed run is the meaningful one — the invite now travels a → P → Q → b like every other message, where before this branch it went straight to b.
