### PR TITLE
Nested relationship forming

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -1099,7 +1099,7 @@ async fn run() -> Result<(), Error> {
                 VerifyAndOpen(String, BytesMut),
                 Forward(String, Vec<BytesMut>, BytesMut),
                 AssignDefaultRelation(String, Digest),
-                ReplyCancel(String),
+                ReplyCancel(String, Digest),
             }
 
             while let Some(message) = messages.next().await {
@@ -1250,6 +1250,7 @@ async fn run() -> Result<(), Error> {
                         ReceivedTspMessage::CancelRelationship {
                             sender,
                             receiver: _,
+                            thread_id,
                             reply_expected,
                         } => {
                             info!("received cancel relationship from {sender}");
@@ -1258,7 +1259,7 @@ async fn run() -> Result<(), Error> {
                             // directions, and the specification expects the
                             // cancellation to be echoed back (spec 7.3)
                             if reply_expected {
-                                return Action::ReplyCancel(sender);
+                                return Action::ReplyCancel(sender, thread_id);
                             }
                         }
                         ReceivedTspMessage::ForwardRequest {
@@ -1319,8 +1320,10 @@ async fn run() -> Result<(), Error> {
                             .await?;
                         info!("forwarding to next hop: {next_hop}");
                     }
-                    Action::ReplyCancel(remote_vid) => {
-                        if let Err(e) = vid_wallet.send_relationship_cancel(&vid, &remote_vid).await
+                    Action::ReplyCancel(remote_vid, thread_id) => {
+                        if let Err(e) = vid_wallet
+                            .send_relationship_cancel_reply(&vid, &remote_vid, thread_id)
+                            .await
                         {
                             info!("could not reply to the cancellation from {remote_vid}: {e}");
                         } else {

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -210,6 +210,26 @@ impl Store {
     }
 
     #[wasm_bindgen]
+    pub fn make_relationship_cancel_reply(
+        &self,
+        sender: String,
+        receiver: String,
+        thread_id: Vec<u8>,
+    ) -> Result<SealedMessage, Error> {
+        let thread_id = thread_id
+            .try_into()
+            .map_err(|_| Error(tsp_sdk::Error::Relationship("invalid thread id".into())))?;
+        let (url, sealed) = self
+            .0
+            .make_relationship_cancel_reply(&sender, &receiver, thread_id)
+            .map_err(Error)?;
+
+        Ok(SealedMessage {
+            url: url.to_string(),
+            sealed,
+        })
+    }
+
     pub fn make_nested_relationship_request(
         &self,
         parent_sender: String,
@@ -692,10 +712,12 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             tsp_sdk::ReceivedTspMessage::CancelRelationship {
                 sender,
                 receiver,
+                thread_id,
                 reply_expected,
             } => {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
+                this.thread_id = Some(thread_id.to_vec());
                 this.reply_expected = Some(reply_expected);
             }
             tsp_sdk::ReceivedTspMessage::ForwardRequest {

--- a/tsp_node/test.js
+++ b/tsp_node/test.js
@@ -219,8 +219,13 @@ describe('tsp node tests', function() {
         received = store.open_message(sealed);
 
         if (received instanceof CancelRelationship ) {
-            const { sender } = received;
+            const { sender, thread_id } = received;
             assert.strictEqual(sender, bob.identifier());
+
+            // the cancellation can be replied to, echoing its digest
+            ({ url, sealed } = store.make_relationship_cancel_reply(
+                alice.identifier(), bob.identifier(), thread_id));
+            assert.strictEqual(url, "tcp://127.0.0.1:1337");
         } else {
             assert.fail(`Unexpected message type: ${received}`);
         }

--- a/tsp_node/tsp.js
+++ b/tsp_node/tsp.js
@@ -73,6 +73,10 @@ class Store {
         return this.inner.make_relationship_cancel(...args);
     }
 
+    make_relationship_cancel_reply(...args) {
+        return this.inner.make_relationship_cancel_reply(...args);
+    }
+
     make_nested_relationship_accept(...args) {
         return this.inner.make_nested_relationship_accept(...args);
     }
@@ -130,6 +134,7 @@ class ReceivedTspMessage {
                 return new CancelRelationship(
                     msg.sender,
                     msg.receiver,
+                    msg.thread_id,
                 );
 
             case 4: 
@@ -189,10 +194,11 @@ class AcceptRelationship extends ReceivedTspMessage {
 }
 
 class CancelRelationship extends ReceivedTspMessage {
-    constructor(sender, receiver) {
+    constructor(sender, receiver, thread_id) {
         super();
         this.sender = sender;
         this.receiver = receiver;
+        this.thread_id = thread_id;
     }
 }
 

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -295,6 +295,20 @@ impl Store {
         Ok((url.to_string(), bytes))
     }
 
+    fn make_relationship_cancel_reply(
+        &self,
+        sender: String,
+        receiver: String,
+        thread_id: [u8; 32],
+    ) -> PyResult<(String, Vec<u8>)> {
+        let (url, bytes) = self
+            .inner
+            .make_relationship_cancel_reply(&sender, &receiver, thread_id)
+            .map_err(py_exception)?;
+
+        Ok((url.to_string(), bytes))
+    }
+
     fn make_nested_relationship_request(
         &self,
         parent_sender: String,
@@ -573,10 +587,12 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
             tsp_sdk::ReceivedTspMessage::CancelRelationship {
                 sender,
                 receiver,
+                thread_id,
                 reply_expected,
             } => {
                 this.sender = Some(sender);
                 this.receiver = Some(receiver);
+                this.thread_id = Some(thread_id);
                 this.reply_expected = Some(reply_expected);
             }
             tsp_sdk::ReceivedTspMessage::ForwardRequest {

--- a/tsp_python/test.py
+++ b/tsp_python/test.py
@@ -231,9 +231,15 @@ class AliceBob(unittest.TestCase):
 
         received = self.store.open_message(sealed)
         match received:
-            case tsp.CancelRelationship(sender, receiver):
+            case tsp.CancelRelationship(sender, receiver, thread_id):
                 self.assertEqual(sender, self.bob.identifier())
                 self.assertEqual(receiver, self.alice.identifier())
+
+                # the cancellation can be replied to, echoing its digest
+                url, sealed = self.store.make_relationship_cancel_reply(
+                    self.alice.identifier(), self.bob.identifier(), thread_id
+                )
+                self.assertEqual(url, "tcp://127.0.0.1:1337")
 
             case other:
                 self.fail(f"unexpected message type {other}")

--- a/tsp_python/tsp_python/tsp.py
+++ b/tsp_python/tsp_python/tsp.py
@@ -177,6 +177,12 @@ class SecureStore:
         with Wallet(self):
             return self.inner.make_relationship_cancel(sender, receiver)
 
+    def make_relationship_cancel_reply(
+        self, sender: str, receiver: str, thread_id: bytes
+    ) -> tuple[str, bytes]:
+        with Wallet(self):
+            return self.inner.make_relationship_cancel_reply(sender, receiver, thread_id)
+
     def make_nested_relationship_request(
             self, parent_sender: str, receiver: str
     ) -> tuple[tuple[str, bytes], tsp_python.OwnedVid]:
@@ -235,7 +241,9 @@ class ReceivedTspMessage:
                 )
 
             case ReceivedTspMessageVariant.CancelRelationship:
-                return CancelRelationship(msg.sender, msg.receiver)
+                return CancelRelationship(
+                    msg.sender, msg.receiver, bytes(msg.thread_id)
+                )
 
             case ReceivedTspMessageVariant.ForwardRequest:
                 return ForwardRequest(
@@ -278,6 +286,7 @@ class AcceptRelationship(ReceivedTspMessage):
 class CancelRelationship(ReceivedTspMessage):
     sender: str
     receiver: str
+    thread_id: bytes
 
 
 @dataclass

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -672,6 +672,41 @@ impl AsyncSecureStore {
         Ok(())
     }
 
+    /// Build the reply to a cancellation without transmitting it.
+    ///
+    /// Returns `(endpoint, message)`. Use this instead of
+    /// [`AsyncSecureStore::send_relationship_cancel_reply`] when you need to
+    /// transmit over a custom transport.
+    pub fn make_relationship_cancel_reply(
+        &self,
+        sender: &str,
+        receiver: &str,
+        thread_id: Digest,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.inner
+            .make_relationship_cancel_reply(sender, receiver, thread_id)
+    }
+
+    /// Reply to a cancellation of a bidirectional relationship with a `TSP_RFD`
+    /// of our own, echoing the digest the incoming one named (spec 7.3).
+    /// See [`SecureStore::make_relationship_cancel_reply`].
+    pub async fn send_relationship_cancel_reply(
+        &self,
+        sender: &str,
+        receiver: &str,
+        thread_id: Digest,
+    ) -> Result<(), Error> {
+        let (endpoint, message) = self
+            .inner
+            .make_relationship_cancel_reply(sender, receiver, thread_id)?;
+
+        tracing::info!("sending message to {endpoint}");
+
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
     /// Build a nested relationship request message without transmitting it.
     ///
     /// Creates a new nested VID under `parent_sender` for private communication

--- a/tsp_sdk/src/definitions/conversions.rs
+++ b/tsp_sdk/src/definitions/conversions.rs
@@ -90,10 +90,12 @@ impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
             CancelRelationship {
                 sender,
                 receiver,
+                thread_id,
                 reply_expected,
             } => CancelRelationship {
                 sender,
                 receiver,
+                thread_id,
                 reply_expected,
             },
             ForwardRequest {

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -138,10 +138,14 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
     CancelRelationship {
         sender: String,
         receiver: String,
+        /// The digest the cancellation named, which is one of the two the
+        /// relationship was formed with. A reply echoes it (spec 7.3).
+        thread_id: Digest,
         /// Whether the specification expects a `TSP_RFD` in reply: it does when
         /// the cancelled relationship was bidirectional, and does not when it
         /// was one-way (spec 7.3). The relationship has already been removed
-        /// either way; sending the reply is the application's to do.
+        /// either way, so the reply goes out with
+        /// [`crate::SecureStore::make_relationship_cancel_reply`].
         reply_expected: bool,
     },
     ForwardRequest {

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -84,10 +84,6 @@ impl VidContext {
     }
 }
 
-fn nested_digest(bytes: &[u8], algorithm: RelationshipDigestAlgorithm) -> Digest {
-    algorithm.hash(bytes)
-}
-
 fn nested_digest_field<'a>(
     digest: &'a Digest,
     algorithm: RelationshipDigestAlgorithm,
@@ -903,34 +899,42 @@ impl SecureStore {
         let sender_identity = Some(sender.identifier().as_bytes());
         let mut request_digest = [0_u8; 32];
 
-        let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
-            crate::cesr::Payload::RelationProposal {
-                request_digest: nested_digest_field(&request_digest, digest_algorithm),
-                nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
-                reply_path: vec![],
-                referral: None,
-            };
-
-        let mut encoded_payload =
-            Vec::with_capacity(placeholder_payload.calculate_size(sender_identity));
-        crate::cesr::encode_payload(
-            &placeholder_payload,
-            sender_identity,
+        // the inner message is an ordinary TSP message whose sender is the new
+        // VID and whose receiver is NULL, and the digest is that message's own
+        // SAID (spec 7.2.1: the innermost message that carries it)
+        let mut envelope_prefix = Vec::with_capacity(64);
+        crate::cesr::encode_envelope_prefix(
+            sender.identifier().as_bytes(),
             None,
-            &mut encoded_payload,
-        )?;
+            &mut envelope_prefix,
+        )
+        .map_err(crate::crypto::CryptoError::from)?;
 
-        request_digest = nested_digest(&encoded_payload, digest_algorithm);
-
-        encoded_payload.clear();
-        let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
+        fn proposal<'a>(
+            request_digest: &'a Digest,
+            nonce_bytes: [u8; 16],
+            digest_algorithm: RelationshipDigestAlgorithm,
+        ) -> crate::cesr::Payload<'a, &'a [u8], &'a [u8]> {
             crate::cesr::Payload::RelationProposal {
-                request_digest: nested_digest_field(&request_digest, digest_algorithm),
+                request_digest: nested_digest_field(request_digest, digest_algorithm),
                 nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
                 reply_path: vec![],
                 referral: None,
-            };
-        crate::cesr::encode_payload(&payload, sender_identity, None, &mut encoded_payload)?;
+            }
+        }
+
+        let mut digest_input = Vec::with_capacity(128);
+        crate::cesr::encode_digest_input(
+            &proposal(&request_digest, nonce_bytes, digest_algorithm),
+            sender_identity,
+            &envelope_prefix,
+            &mut digest_input,
+        )?;
+        request_digest = digest_algorithm.hash(&digest_input);
+
+        let final_payload = proposal(&request_digest, nonce_bytes, digest_algorithm);
+        let mut encoded_payload = Vec::with_capacity(final_payload.calculate_size(sender_identity));
+        crate::cesr::encode_payload(&final_payload, sender_identity, None, &mut encoded_payload)?;
 
         let message = crate::crypto::sign(sender, None, &encoded_payload)?;
 
@@ -947,30 +951,37 @@ impl SecureStore {
         let sender_identity = Some(sender.identifier().as_bytes());
         let mut reply_thread_id = [0_u8; 32];
 
-        let placeholder_payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
-            crate::cesr::Payload::RelationAffirm {
-                request_digest: nested_digest_field(&thread_id, digest_algorithm),
-                reply_digest: nested_digest_field(&reply_thread_id, digest_algorithm),
-            };
+        let mut envelope_prefix = Vec::with_capacity(64);
+        crate::cesr::encode_envelope_prefix(
+            sender.identifier().as_bytes(),
+            Some(receiver.identifier().as_bytes()),
+            &mut envelope_prefix,
+        )
+        .map_err(crate::crypto::CryptoError::from)?;
 
-        let mut encoded_payload =
-            Vec::with_capacity(placeholder_payload.calculate_size(sender_identity));
-        crate::cesr::encode_payload(
-            &placeholder_payload,
+        fn affirm<'a>(
+            thread_id: &'a Digest,
+            reply_thread_id: &'a Digest,
+            digest_algorithm: RelationshipDigestAlgorithm,
+        ) -> crate::cesr::Payload<'a, &'a [u8], &'a [u8]> {
+            crate::cesr::Payload::RelationAffirm {
+                request_digest: nested_digest_field(thread_id, digest_algorithm),
+                reply_digest: nested_digest_field(reply_thread_id, digest_algorithm),
+            }
+        }
+
+        let mut digest_input = Vec::with_capacity(128);
+        crate::cesr::encode_digest_input(
+            &affirm(&thread_id, &reply_thread_id, digest_algorithm),
             sender_identity,
-            None,
-            &mut encoded_payload,
+            &envelope_prefix,
+            &mut digest_input,
         )?;
+        reply_thread_id = digest_algorithm.hash(&digest_input);
 
-        reply_thread_id = nested_digest(&encoded_payload, digest_algorithm);
-
-        encoded_payload.clear();
-        let payload: crate::cesr::Payload<'_, &[u8], &[u8]> =
-            crate::cesr::Payload::RelationAffirm {
-                request_digest: nested_digest_field(&thread_id, digest_algorithm),
-                reply_digest: nested_digest_field(&reply_thread_id, digest_algorithm),
-            };
-        crate::cesr::encode_payload(&payload, sender_identity, None, &mut encoded_payload)?;
+        let final_payload = affirm(&thread_id, &reply_thread_id, digest_algorithm);
+        let mut encoded_payload = Vec::with_capacity(final_payload.calculate_size(sender_identity));
+        crate::cesr::encode_payload(&final_payload, sender_identity, None, &mut encoded_payload)?;
 
         let message = crate::crypto::sign(sender, Some(receiver), &encoded_payload)?;
 
@@ -980,6 +991,7 @@ impl SecureStore {
     fn try_open_nested_relationship_message(
         &self,
         outer_sender: &str,
+        outer_receiver: &str,
         inner: &mut [u8],
     ) -> Result<Option<NestedRelationshipEvent>, Error> {
         let EnvelopeType::SignedMessage {
@@ -1022,8 +1034,23 @@ impl SecureStore {
             ));
         }
 
+        // the digest is the inner message's own SAID (spec 7.2.1), so recompute
+        // it over that message and reject a mismatch
+        let mut envelope_prefix = Vec::with_capacity(64);
+        crate::cesr::encode_envelope_prefix(
+            inner_sender.as_bytes(),
+            inner_receiver.as_deref().map(str::as_bytes),
+            &mut envelope_prefix,
+        )
+        .map_err(crate::crypto::CryptoError::from)?;
+        crate::crypto::verify_relationship_digest(&payload, sender_identity, &envelope_prefix)?;
+
         match payload {
             crate::cesr::Payload::RelationProposal { request_digest, .. } => {
+                // a nested relationship is formed on the referral of the outer
+                // one, so there has to be an outer one (spec 7.2.5)
+                self.check_relationship_gate(outer_receiver, outer_sender)?;
+
                 if inner_receiver.is_some() {
                     return Err(Error::Relationship(
                         "invalid nested relationship request receiver".into(),
@@ -1044,6 +1071,8 @@ impl SecureStore {
                 request_digest,
                 reply_digest,
             } => {
+                self.check_relationship_gate(outer_receiver, outer_sender)?;
+
                 let Some(connect_to_vid) = inner_receiver else {
                     return Err(Error::Relationship(
                         "invalid nested relationship accept receiver".into(),
@@ -1195,9 +1224,11 @@ impl SecureStore {
                         })
                     }
                     Payload::NestedMessage(inner) => {
-                        if let Some(received_message) =
-                            self.try_open_nested_relationship_message(&sender, inner)?
-                        {
+                        if let Some(received_message) = self.try_open_nested_relationship_message(
+                            &sender,
+                            &intended_receiver,
+                            inner,
+                        )? {
                             return Ok(match received_message {
                                 NestedRelationshipEvent::Request {
                                     nested_vid,
@@ -1719,6 +1750,10 @@ impl SecureStore {
     ) -> Result<((Url, Vec<u8>), OwnedVid), Error> {
         let sender = self.get_private_vid(parent_sender)?;
         let receiver = self.get_verified_vid(receiver)?;
+        // the new relationship is nested inside an existing one, which refers
+        // it; without that outer relationship there is nothing to nest in and
+        // the peer would drop the invite (spec 7.2.5)
+        self.check_relationship_gate(sender.identifier(), receiver.identifier())?;
 
         let nested_vid = self.make_propositioning_vid(sender.identifier())?;
         let selection = selected_outbound_crypto(&*sender, &*receiver, None);
@@ -3817,6 +3852,195 @@ mod test {
         assert_ne!(
             message_type.signature_type,
             crate::cesr::SignatureType::NoSignature
+        );
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_nested_relationship_cancel_travels_the_outer_relationship() {
+        // A nested relationship is cancelled with the same TSP_RFD as any
+        // other, carried as an inner message of the outer relationship, and it
+        // references the digest that formed it (spec 9.4).
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let ((_url, mut invite), nested_a) = a_store
+            .make_nested_relationship_request(alice.identifier(), bob.identifier())
+            .unwrap();
+        let ReceivedTspMessage::RequestRelationship {
+            thread_id,
+            delivery: ReceivedRelationshipDelivery::Nested { nested_vid },
+            ..
+        } = b_store.open_message(&mut invite).unwrap()
+        else {
+            panic!("bob did not receive a nested relationship request");
+        };
+
+        let ((_url, mut accept), nested_b) = b_store
+            .make_nested_relationship_accept(bob.identifier(), &nested_vid, thread_id)
+            .unwrap();
+        let ReceivedTspMessage::AcceptRelationship { .. } =
+            a_store.open_message(&mut accept).unwrap()
+        else {
+            panic!("alice did not receive a nested relationship accept");
+        };
+
+        // alice ends the nested relationship
+        let (_url, mut cancel) = a_store
+            .make_relationship_cancel(nested_a.identifier(), nested_b.identifier())
+            .unwrap();
+
+        let ReceivedTspMessage::CancelRelationship {
+            sender,
+            receiver,
+            thread_id: cancelled,
+            reply_expected,
+        } = b_store.open_message(&mut cancel).unwrap()
+        else {
+            panic!("bob did not receive a cancellation");
+        };
+        assert_eq!(sender, nested_a.identifier());
+        assert_eq!(receiver, nested_b.identifier());
+        // the relationship was bidirectional, so bob replies in kind, echoing
+        // the digest even though he has already dropped the relationship
+        assert!(reply_expected);
+        let (_url, mut reply) = b_store
+            .make_relationship_cancel_reply(nested_b.identifier(), nested_a.identifier(), cancelled)
+            .unwrap();
+        // alice dropped it when she sent hers, so she ignores the reply
+        assert!(matches!(
+            a_store.open_message(&mut reply),
+            Err(Error::Relationship(_))
+        ));
+
+        // bob accepted it, which means it named one of the two digests that
+        // formed the relationship, and both sides have now dropped it
+        assert!(matches!(
+            a_store
+                .relation_status_for_vid_pair(nested_a.identifier(), nested_b.identifier())
+                .unwrap(),
+            RelationshipStatus::Unrelated
+        ));
+        assert!(matches!(
+            b_store
+                .relation_status_for_vid_pair(nested_b.identifier(), nested_a.identifier())
+                .unwrap(),
+            RelationshipStatus::Unrelated
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_nested_relationship_needs_an_outer_relationship() {
+        // A nested relationship is referred by the outer one it sits inside, so
+        // neither endpoint takes part without that outer relationship (spec
+        // 7.2.5).
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+
+        // alice knows bob's VID but has formed no relationship with him
+        assert!(matches!(
+            a_store.make_nested_relationship_request(alice.identifier(), bob.identifier()),
+            Err(Error::UnestablishedRelationship(..))
+        ));
+
+        // and if alice believes there is one but bob has no record of it, bob
+        // does not act on the invite either
+        a_store
+            .set_relation_and_status_for_vid(
+                bob.identifier(),
+                RelationshipStatus::Bidirectional {
+                    thread_id: [1; 32],
+                    remote_thread_id: [2; 32],
+                    outstanding_nested_requests: vec![],
+                },
+                alice.identifier(),
+            )
+            .unwrap();
+        let ((_url, mut invite), _nested_a) = a_store
+            .make_nested_relationship_request(alice.identifier(), bob.identifier())
+            .unwrap();
+        assert!(matches!(
+            b_store.open_message(&mut invite),
+            Err(Error::UnestablishedRelationship(..))
+        ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_nested_relationship_digest_is_self_referencing() {
+        // The digests of a nested exchange are the inner messages' own SAIDs
+        // (spec 7.2.1). The receiver recomputes each one, so a legitimate
+        // exchange only completes if both sides derive it identically, and an
+        // altered message stops matching.
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let ((_url, mut invite), _nested_a) = a_store
+            .make_nested_relationship_request(alice.identifier(), bob.identifier())
+            .unwrap();
+        let pristine = invite.clone();
+
+        let ReceivedTspMessage::RequestRelationship {
+            thread_id,
+            delivery: ReceivedRelationshipDelivery::Nested { nested_vid },
+            ..
+        } = b_store.open_message(&mut invite).unwrap()
+        else {
+            panic!("bob did not receive a nested relationship request");
+        };
+        // deriving it from the message means it cannot be a fixed value
+        assert!(thread_id.iter().any(|byte| *byte != 0));
+
+        // the accept echoes that digest and derives its own
+        let ((_url, mut accept), _nested_b) = b_store
+            .make_nested_relationship_accept(bob.identifier(), &nested_vid, thread_id)
+            .unwrap();
+
+        let ReceivedTspMessage::AcceptRelationship {
+            thread_id: echoed,
+            reply_thread_id,
+            ..
+        } = a_store.open_message(&mut accept).unwrap()
+        else {
+            panic!("alice did not receive a nested relationship accept");
+        };
+        assert_eq!(echoed, thread_id, "the invite's digest is echoed verbatim");
+        assert!(reply_thread_id.iter().any(|byte| *byte != 0));
+        assert_ne!(reply_thread_id, thread_id);
+
+        // an invite whose bytes were altered no longer matches its own digest
+        let b_store = create_test_store();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let mut tampered = pristine.clone();
+        let position = tampered.len() / 2;
+        tampered[position] ^= 0x01;
+        assert!(
+            b_store.open_message(&mut tampered).is_err(),
+            "a nested invite whose bytes were altered must not be accepted"
         );
     }
 

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -1374,6 +1374,7 @@ impl SecureStore {
                         Ok(ReceivedTspMessage::CancelRelationship {
                             sender,
                             receiver: intended_receiver,
+                            thread_id,
                             reply_expected,
                         })
                     }
@@ -1693,6 +1694,23 @@ impl SecureStore {
         Ok((transport, message))
     }
 
+    /// Reply to a `TSP_RFD` that cancelled a bidirectional relationship, with a
+    /// `TSP_RFD` of our own (spec 7.3).
+    ///
+    /// `thread_id` is the digest the incoming cancellation named, carried on
+    /// [`ReceivedTspMessage::CancelRelationship`]. Receiving the cancellation
+    /// already removed the relationship, which is why this does not look one
+    /// up: the reply closes the other direction for the peer, and echoing the
+    /// digest is what identifies the relationship being closed.
+    pub fn make_relationship_cancel_reply(
+        &self,
+        sender: &str,
+        receiver: &str,
+        thread_id: Digest,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.seal_message_payload(sender, receiver, Payload::CancelRelationship { thread_id })
+    }
+
     /// Send a nested relationship request to `receiver`, creating a new nested vid with `outer_sender` as a parent.
     pub fn make_nested_relationship_request(
         &self,
@@ -1941,10 +1959,11 @@ impl SecureStore {
             RelationshipStatus::Unrelated => return ignore(),
         };
 
-        if let Some(context) = self.vids.write()?.get_mut(remote_vid) {
-            context.relation_status = RelationshipStatus::Unrelated;
-            context.relation_vid = None;
-        }
+        // only the status goes: the relation VID says which of our VIDs
+        // corresponds to this peer, which is what addresses the reply the
+        // specification asks for (spec 7.3), and cancelling from this side
+        // leaves it in place too
+        self.replace_relation_status_for_vid(remote_vid, RelationshipStatus::Unrelated)?;
 
         Ok(reply_expected)
     }
@@ -2480,8 +2499,11 @@ mod test {
         let (_url, mut cancel) = a_store
             .make_relationship_cancel(alice.identifier(), bob.identifier())
             .unwrap();
-        let ReceivedTspMessage::CancelRelationship { reply_expected, .. } =
-            b_store.open_message(&mut cancel).unwrap()
+        let ReceivedTspMessage::CancelRelationship {
+            thread_id,
+            reply_expected,
+            ..
+        } = b_store.open_message(&mut cancel).unwrap()
         else {
             panic!("unexpected message type");
         };
@@ -2495,6 +2517,11 @@ mod test {
                 .unwrap(),
             RelationshipStatus::Unrelated
         ));
+        // and bob can still build that reply, though he has already dropped
+        // the relationship it names (spec 7.3)
+        b_store
+            .make_relationship_cancel_reply(bob.identifier(), alice.identifier(), thread_id)
+            .unwrap();
 
         // one-way: the relationship is removed, but no reply is expected
         let a_store = create_test_store();


### PR DESCRIPTION
Brings nested relationship forming in line with Rev 3, and fixes a cancellation bug that a live nested exchange uncovered.

## Nested relationship digests are the spec's self-referencing digest

Forming a nested relationship used a plain hash of the encoded payload as the thread id. Spec 7.2.1 defines it as the inner message's own SAID: computed over the version, both envelope VIDs and the payload fields, with the digest's own slot filled with the `0x23` dummy. Both endpoints now derive it that way, and the receiver recomputes it and rejects a mismatch — so the digest is bound to the message that carries it rather than being a number the sender is free to choose.

The invite's inner envelope is `[VID_a1, NULL]` and the accept's is `[VID_b1, VID_a1]`, matching 7.2.5, and both are covered by the digest.

A nested relationship is also referred by the outer one it sits inside (7.2.5), so neither endpoint takes part without that outer relationship: the invite is refused at the sender, and ignored at the receiver.

## Replying to a cancellation

Spec 7.3 has the receiver of a `TSP_RFD` reply with one of its own and *then* remove the relationship. The SDK removed it first, so the reply had no digest left to name and no relation VID left to address it with — building it failed outright. Cancelling a nested relationship over the live intermediary showed this as a cancellation that could be sent but never answered:

```
INFO tsp: received cancel relationship from did:peer:2.Vz6Mux...
INFO tsp: could not reply to the cancellation from did:peer:2.Vz6Mux...: Relationship Error: no relationship to cancel
```

`ReceivedTspMessage::CancelRelationship` now carries the digest the cancellation named, which is the one a reply echoes, and `make_relationship_cancel_reply` sends that reply without needing a relationship it has already dropped. Receiving a cancellation no longer clears the relation VID either — that is what addresses the reply, and cancelling from this side has always left it in place.

The endpoint that initiated the cancellation ignores the reply, since it dropped the relationship when it sent its own, so the exchange terminates.

## Verification

Feature matrix (default, `nacl`, `pq`, `--no-default-features --features async,resolve`, `--all-features`), clippy, fmt, `wasm32-unknown-unknown` check and `wasm-pack test --node`, and both binding suites built fresh from source.

End to end over `p.teaspoon.world` with two `did:web` identities: outer relationship formed, nested relationship formed, a message sent over the nested relationship, then the nested relationship cancelled and the cancellation answered.