### PR TITLE
did:peer numalgo 4

### DIFF
--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -672,7 +672,13 @@ async fn run() -> Result<(), Error> {
                 .resolve_alias(&alias)?
                 .ok_or(Error::MissingVid("Cannot find this alias".to_string()))?;
 
-            print!("{vid}");
+            // this hands the VID to someone out of band, so it prints the form
+            // they can verify: a did:peer's short form means nothing to an
+            // endpoint that has not seen its document
+            match vid_wallet.as_store().get_verified_vid(&vid) {
+                Ok(verified) => print!("{}", tsp_sdk::vid::introduction_identifier(&*verified)),
+                Err(_) => print!("{vid}"),
+            }
         }
         Commands::Create {
             r#type,
@@ -835,9 +841,12 @@ async fn run() -> Result<(), Error> {
             let metadata = match metadata {
                 Some(metadata) => Some(metadata),
                 None => {
-                    let (_, metadata) = verify_vid(private_vid.identifier())
-                        .await
-                        .map_err(|err| Error::Vid(VidError::InvalidVid(err.to_string())))?;
+                    // resolve what a peer would be given, which for a did:peer
+                    // is its long form: the short form carries no document
+                    let (_, metadata) =
+                        verify_vid(&tsp_sdk::vid::introduction_identifier(private_vid.vid()))
+                            .await
+                            .map_err(|err| Error::Vid(VidError::InvalidVid(err.to_string())))?;
                     metadata
                 }
             };
@@ -1095,7 +1104,6 @@ async fn run() -> Result<(), Error> {
             // closures cannot be async, and async fn's don't easily do recursion
             enum Action {
                 Nothing,
-                Verify(String),
                 VerifyAndOpen(String, BytesMut),
                 Forward(String, Vec<BytesMut>, BytesMut),
                 AssignDefaultRelation(String, Digest),
@@ -1182,7 +1190,10 @@ async fn run() -> Result<(), Error> {
                                         "received parallel relationship request for '{new_vid}' from {sender}"
                                     );
                                     println!("{new_vid}\t{thread_id_string}");
-                                    return Action::Verify(new_vid);
+                                    // the referral carried the new VID's own
+                                    // verification material, which the SDK has
+                                    // already checked and stored; there is
+                                    // nothing left to resolve
                                 }
                                 (
                                     ReceivedRelationshipDelivery::Nested { nested_vid },
@@ -1192,7 +1203,6 @@ async fn run() -> Result<(), Error> {
                                         "received nested parallel relationship request from '{nested_vid}' for '{new_vid}' from {sender}"
                                     );
                                     println!("{new_vid}\t{thread_id_string}");
-                                    return Action::Verify(new_vid);
                                 }
                                 (ReceivedRelationshipDelivery::Routed, _) => {
                                     error!(
@@ -1308,11 +1318,6 @@ async fn run() -> Result<(), Error> {
                         info!("{vid} is verified and added to the wallet {}", &args.wallet);
 
                         let _ = handle_message(message);
-                    }
-                    Action::Verify(vid) => {
-                        vid_wallet.verify_vid(&vid, None).await?;
-
-                        info!("{vid} is verified and added to the wallet {}", &args.wallet);
                     }
                     Action::Forward(next_hop, route, payload) => {
                         vid_wallet

--- a/examples/tests/cli_tests.rs
+++ b/examples/tests/cli_tests.rs
@@ -43,6 +43,16 @@ fn create_wallet(alias: &str, did_type: &str) -> String {
     random_name
 }
 
+/// The short form of a `did:peer:4`, which is how a VID is known once its
+/// document has been seen. `print` emits the long form, since that is what
+/// introduces a VID to someone who has never seen it.
+fn short_form(did: &str) -> String {
+    match did.split(':').collect::<Vec<_>>()[..] {
+        ["did", "peer", hash, _document] => format!("did:peer:{hash}"),
+        _ => did.to_string(),
+    }
+}
+
 fn create_peer_wallet(alias: &str, tcp_addr: &str) -> String {
     let mut cmd: Command = Command::new(cargo_bin!("tsp"));
     let wallet_name = format!("test_wallet_{}", random_string(8));
@@ -530,7 +540,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
         String::from_utf8_lossy(&outer_receive.stderr)
     );
     let (outer_sender, outer_thread_id) = parse_relationship_stdout(&outer_receive.stdout);
-    assert_eq!(outer_sender, alice_did);
+    assert_eq!(outer_sender, short_form(&alice_did));
 
     let outer_accept_receive = {
         let tsp_bin = tsp_bin.to_path_buf();
@@ -628,7 +638,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
     );
     let (received_new_vid, parallel_thread_id) =
         parse_relationship_stdout(&parallel_receive.stdout);
-    assert_eq!(received_new_vid, alice_alt_did);
+    assert_eq!(received_new_vid, short_form(&alice_alt_did));
 
     let parallel_accept = StdCommand::new(tsp_bin)
         .args([
@@ -660,7 +670,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
         String::from_utf8_lossy(&parallel_request.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&parallel_request.stdout).contains(&bob_alt_did),
+        String::from_utf8_lossy(&parallel_request.stdout).contains(&short_form(&bob_alt_did)),
         "parallel request output did not include bob-alt did: stdout={}, stderr={}",
         String::from_utf8_lossy(&parallel_request.stdout),
         String::from_utf8_lossy(&parallel_request.stderr)
@@ -669,7 +679,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
     let alice_store = load_wallet(&alice_wallet);
     assert!(matches!(
         alice_store
-            .get_relation_status_for_vid_pair("alice-alt", &bob_alt_did)
+            .get_relation_status_for_vid_pair("alice-alt", &short_form(&bob_alt_did))
             .unwrap(),
         RelationshipStatus::Bidirectional { .. }
     ));
@@ -677,7 +687,7 @@ fn test_parallel_request_and_accept_roundtrip_over_cli() {
     let bob_store = load_wallet(&bob_wallet);
     assert!(matches!(
         bob_store
-            .get_relation_status_for_vid_pair("bob-alt", &alice_alt_did)
+            .get_relation_status_for_vid_pair("bob-alt", &short_form(&alice_alt_did))
             .unwrap(),
         RelationshipStatus::Bidirectional { .. }
     ));

--- a/tsp_sdk/benches/common/bench.rs
+++ b/tsp_sdk/benches/common/bench.rs
@@ -149,8 +149,11 @@ pub enum VidVerifyInput {
 }
 
 fn setup_did_peer() -> VidVerifyInput {
+    // the long form of a did:peer:4, which is what an endpoint resolves: the
+    // short form carries no document. Fixed rather than generated so the
+    // measured work is the same run to run.
     VidVerifyInput::Peer(
-        "did:peer:2.Vz6MurhTjqX5uhQ5bJbAaoEwSDFcKDwVJTvoii51JBtSPpKzX.Ez6LbvBvy92yWENk8xKYmaX9X9nzMtQCQ2EqgdLKv2YkcpHo7.SeyJzIjp7InVyaSI6InRzcDovLyJ9LCJ0IjoidHNwIn0"
+        "did:peer:4zQmRAVYmJfBEJQmwGrLSHBuhGPzfrrc3Stpy4PJ7A4prRqv:z2kCqs4oURbyPVxWvLGsQbAdjk8rSFaHh3WrHx3BhMyxctozJVLhk8RTXhxMySbJbzBktUG1A5NFknC4vtqSuS2XsU7uvAcHCqu8RpQ5xcQNHieTHAj6rN745QAfnjjzY4YTPBBiPJ8M2HDdPV8AWFuuYXXrAFvymCLkWgoVujXuqk3cccEfM7p7cWmpVetistjz76jmy5VMrGYtCPVkWabWc7bb9baLEASCmDyM2rwfmPQP6simivu5KXoaNjFK3id5Fg1cGk8NKquFDF6nE4k6FqnXRtcXGzKxn8zkLG8QxG3zHRYjfCuFjEou7y8MhBfmB1UTuGZ2Qh7wwp6hNXgewpw8PfZkLfxia4QaamwDEAGgZ44nq1ioGUCrA3KwSQCNycxbggBmGsacER2ki5iZKKmBLcW2pZTpThmQyigApG26uW7xB1EH9Mn2XHqZRS8ie7Uyh5iyBJ8gdzUyxEuVLpFAvaJf4Kmknr8G2Tyb5LtwHkjR9nW56QYXpUThqVjyZ4APL428pJxCRR5MrTepp5ahHbY7YjTGu5eUCS8kMfpEBtvzkxeAqsaN8a2C3e"
             .to_string(),
     )
 }

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -559,8 +559,8 @@ pub(crate) fn open_with_signature_info<'a>(
     }
 
     let result = match envelope.crypto_type {
-        CryptoType::HpkeBase => tsp_hpke::open(receiver, sender, raw_header, envelope, ciphertext),
-        CryptoType::SealedBox => tsp_nacl::open(receiver, sender, raw_header, envelope, ciphertext),
+        CryptoType::HpkeBase => tsp_hpke::open(receiver, raw_header, envelope, ciphertext),
+        CryptoType::SealedBox => tsp_nacl::open(receiver, raw_header, envelope, ciphertext),
         CryptoType::Plaintext => Err(CryptoError::MissingCiphertext),
     };
     #[cfg(feature = "bench-network-timings")]
@@ -579,14 +579,16 @@ pub fn sign(
 }
 
 /// Construct and sign a non-confidential TSP message whose payload is encoded
-/// in the payload position as it stands; see [`nonconfidential::sign_payload`]
-pub(crate) fn sign_payload(
+/// in the payload position as it stands, under `sender_id`; see
+/// [`nonconfidential::sign_payload_as`]
+pub(crate) fn sign_payload_as(
     sender: &dyn PrivateVid,
+    sender_id: &str,
     receiver: Option<&dyn VerifiedVid>,
     payload: &crate::cesr::Payload<impl AsRef<[u8]>, impl AsRef<[u8]>>,
     sender_identity: Option<&[u8]>,
 ) -> Result<TSPMessage, CryptoError> {
-    nonconfidential::sign_payload(sender, receiver, payload, sender_identity)
+    nonconfidential::sign_payload_as(sender, sender_id, receiver, payload, sender_identity)
 }
 
 /// Decode a CESR Authentic Non-Confidential Message, verify the signature and return its contents

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -578,12 +578,32 @@ pub fn sign(
     nonconfidential::sign(sender, receiver, payload)
 }
 
+/// Construct and sign a non-confidential TSP message whose payload is encoded
+/// in the payload position as it stands; see [`nonconfidential::sign_payload`]
+pub(crate) fn sign_payload(
+    sender: &dyn PrivateVid,
+    receiver: Option<&dyn VerifiedVid>,
+    payload: &crate::cesr::Payload<impl AsRef<[u8]>, impl AsRef<[u8]>>,
+    sender_identity: Option<&[u8]>,
+) -> Result<TSPMessage, CryptoError> {
+    nonconfidential::sign_payload(sender, receiver, payload, sender_identity)
+}
+
 /// Decode a CESR Authentic Non-Confidential Message, verify the signature and return its contents
 pub fn verify<'a>(
     sender: &dyn VerifiedVid,
     tsp_message: &'a mut [u8],
 ) -> Result<(&'a [u8], MessageType), CryptoError> {
     nonconfidential::verify(sender, tsp_message)
+}
+
+/// Decode a CESR Authentic Non-Confidential Message, verify the signature and
+/// return its payload decoded, whatever its type
+pub(crate) fn verify_payload<'a>(
+    sender: &dyn VerifiedVid,
+    tsp_message: &'a mut [u8],
+) -> Result<(crate::cesr::DecodedPayload<'a>, MessageType), CryptoError> {
+    nonconfidential::verify_payload(sender, tsp_message)
 }
 
 pub fn default_encryption_key_type() -> VidEncryptionKeyType {

--- a/tsp_sdk/src/crypto/nonconfidential.rs
+++ b/tsp_sdk/src/crypto/nonconfidential.rs
@@ -4,12 +4,36 @@ use crate::{
     definitions::{MessageType, PrivateVid, TSPMessage, VerifiedVid},
 };
 
-/// Construct and sign a non-confidential TSP message; the payload is carried
-/// as a cleartext -Z## payload in the payload position
+/// Construct and sign a non-confidential TSP message carrying an application
+/// payload; it is carried as a cleartext `XSCS` payload in the payload position.
+///
+/// A message whose payload is a control message is built with
+/// [`sign_payload`] instead — wrapping one in `XSCS` would put a payload
+/// inside a payload.
 pub fn sign(
     sender: &dyn PrivateVid,
     receiver: Option<&dyn VerifiedVid>,
     payload: &[u8],
+) -> Result<TSPMessage, CryptoError> {
+    sign_payload(
+        sender,
+        receiver,
+        &crate::cesr::Payload::<_, &[u8]>::GenericMessage(payload),
+        None,
+    )
+}
+
+/// Construct and sign a non-confidential TSP message whose payload is
+/// `payload`, encoded in the payload position as it stands.
+///
+/// This is what a signed-only control message needs: spec 9.4.13 and 9.4.14
+/// require the inner message of a nested `TSP_RFI`/`TSP_RFA` to carry that
+/// control payload itself, not an `XSCS` payload wrapping one.
+pub fn sign_payload(
+    sender: &dyn PrivateVid,
+    receiver: Option<&dyn VerifiedVid>,
+    payload: &crate::cesr::Payload<impl AsRef<[u8]>, impl AsRef<[u8]>>,
+    sender_identity: Option<&[u8]>,
 ) -> Result<TSPMessage, CryptoError> {
     let mut data = Vec::with_capacity(64);
 
@@ -23,12 +47,7 @@ pub fn sign(
         &mut data,
     )?;
 
-    crate::cesr::encode_payload(
-        &crate::cesr::Payload::<_, &[u8]>::GenericMessage(payload),
-        None,
-        None,
-        &mut data,
-    )?;
+    crate::cesr::encode_payload(payload, sender_identity, None, &mut data)?;
     crate::cesr::finalize_envelope_frame(&mut data);
 
     append_signature(sender, &mut data)?;
@@ -36,11 +55,28 @@ pub fn sign(
     Ok(data)
 }
 
-/// Decode a CESR Authentic Non-Confidential Message, verify the signature and return its contents
+/// Decode a CESR Authentic Non-Confidential Message, verify the signature and
+/// return its application payload. A message carrying anything other than an
+/// application payload is read with [`verify_payload`].
 pub fn verify<'a>(
     sender: &dyn VerifiedVid,
     tsp_message: &'a mut [u8],
 ) -> Result<(&'a [u8], MessageType), CryptoError> {
+    let (DecodedPayload { payload, .. }, message_type) = verify_payload(sender, tsp_message)?;
+
+    let crate::cesr::Payload::GenericMessage(message) = payload else {
+        return Err(CryptoError::UnsupportedPayload);
+    };
+
+    Ok((message, message_type))
+}
+
+/// Decode a CESR Authentic Non-Confidential Message, verify the signature and
+/// return its payload decoded, whatever its type.
+pub fn verify_payload<'a>(
+    sender: &dyn VerifiedVid,
+    tsp_message: &'a mut [u8],
+) -> Result<(DecodedPayload<'a>, MessageType), CryptoError> {
     let view = crate::cesr::decode_envelope(tsp_message)?;
 
     // verify outer signature
@@ -73,16 +109,8 @@ pub fn verify<'a>(
         return Err(CryptoError::MissingCiphertext);
     }
 
-    let DecodedPayload {
-        payload: decoded, ..
-    } = crate::cesr::decode_payload(payload)?;
-    let crate::cesr::Payload::GenericMessage(message) = decoded else {
-        // other payload types in signed-only messages are not yet surfaced
-        return Err(CryptoError::UnsupportedPayload);
-    };
-
     Ok((
-        message,
+        crate::cesr::decode_payload(payload)?,
         MessageType {
             crypto_type,
             signature_type,

--- a/tsp_sdk/src/crypto/nonconfidential.rs
+++ b/tsp_sdk/src/crypto/nonconfidential.rs
@@ -35,13 +35,37 @@ pub fn sign_payload(
     payload: &crate::cesr::Payload<impl AsRef<[u8]>, impl AsRef<[u8]>>,
     sender_identity: Option<&[u8]>,
 ) -> Result<TSPMessage, CryptoError> {
+    sign_payload_as(
+        sender,
+        sender.identifier(),
+        receiver,
+        payload,
+        sender_identity,
+    )
+}
+
+/// As [`sign_payload`], but writing `sender_id` into the envelope rather than
+/// the sender's own identifier.
+///
+/// This exists for a VID that is being introduced: a `did:peer:4` is used by
+/// its short form, which a peer cannot resolve until it has seen the document,
+/// so the message that introduces it carries the long form instead. The keys
+/// are the same either way, and the peer resolves the long form back to the
+/// short form it will use thereafter.
+pub fn sign_payload_as(
+    sender: &dyn PrivateVid,
+    sender_id: &str,
+    receiver: Option<&dyn VerifiedVid>,
+    payload: &crate::cesr::Payload<impl AsRef<[u8]>, impl AsRef<[u8]>>,
+    sender_identity: Option<&[u8]>,
+) -> Result<TSPMessage, CryptoError> {
     let mut data = Vec::with_capacity(64);
 
     crate::cesr::encode_envelope(
         Envelope {
             crypto_type: CryptoType::Plaintext,
             signature_type: signature_type(sender),
-            sender: sender.identifier(),
+            sender: sender_id,
             receiver: receiver.map(|r| r.identifier()),
         },
         &mut data,

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -193,24 +193,22 @@ fn seal_with_kem<Kem: KemTrait>(
 /// Open an HPKE-Base message; the KEM is selected by the receiving VID's key type
 pub(crate) fn open<'a>(
     receiver: &dyn PrivateVid,
-    sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
 ) -> Result<(MessageContents<'a>, Option<ParallelSignatureInfo<'a>>), CryptoError> {
     match receiver.encryption_key_type() {
         VidEncryptionKeyType::X25519 => {
-            open_with_kem::<X25519Kem>(receiver, sender, raw_header, envelope, ciphertext)
+            open_with_kem::<X25519Kem>(receiver, raw_header, envelope, ciphertext)
         }
         VidEncryptionKeyType::X25519MlKem768 => {
-            open_with_kem::<PqKem>(receiver, sender, raw_header, envelope, ciphertext)
+            open_with_kem::<PqKem>(receiver, raw_header, envelope, ciphertext)
         }
     }
 }
 
 fn open_with_kem<'a, Kem: KemTrait>(
     receiver: &dyn PrivateVid,
-    sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
@@ -239,11 +237,10 @@ fn open_with_kem<'a, Kem: KemTrait>(
         &tag,
     )?;
 
-    open_payload(sender, raw_header, envelope, ciphertext)
+    open_payload(raw_header, envelope, ciphertext)
 }
 
 fn open_payload<'a>(
-    sender: &dyn VerifiedVid,
     raw_header: &[u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
@@ -259,8 +256,12 @@ fn open_payload<'a>(
 
     // In HPKE-Base the sender-VID confidential field is optional (the aad binds
     // the sender identity); when present it MUST match the envelope (spec 8.2.2)
+    // it is compared against the envelope rather than the resolved VID's own
+    // identifier: a VID being introduced is named in the envelope by the form
+    // that carries its verification material, which is not the identifier it
+    // resolves to
     if let Some(id) = sender_identity
-        && id != sender.identifier().as_bytes()
+        && id != envelope.sender
     {
         return Err(CryptoError::UnexpectedSender);
     }

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -120,7 +120,6 @@ pub(crate) fn seal(
 
 pub(crate) fn open<'a>(
     receiver: &dyn PrivateVid,
-    sender: &dyn VerifiedVid,
     raw_header: &'a [u8],
     envelope: Envelope<&[u8]>,
     ciphertext: &'a mut [u8],
@@ -143,9 +142,11 @@ pub(crate) fn open<'a>(
 
     // the sealed box is anonymous: the ESSR sender-VID confidential field is
     // required and MUST match the envelope (spec 8.3.2)
+    // as in HPKE-Base, the comparison is against the envelope rather than the
+    // resolved VID's identifier, which differ for a VID being introduced
     match sender_identity {
         Some(id) => {
-            if id != sender.identifier().as_bytes() {
+            if id != envelope.sender {
                 return Err(CryptoError::UnexpectedSender);
             }
         }

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -107,6 +107,64 @@ fn digest_algorithm_for_selection(
     )?)
 }
 
+/// A private VID presented under the identifier it is being introduced by.
+///
+/// A `did:peer` is used by its short form, which a peer cannot resolve until it
+/// has seen the document, so the message that introduces it carries the long
+/// form instead. Everything else about the VID — its keys, its endpoint — is
+/// unchanged, so wrapping it here puts the right identifier in the envelope,
+/// in the AAD derived from it, and in the ESSR sender field, without the
+/// sealing code needing to know that any of this is going on.
+struct IntroducedVid<'a> {
+    inner: &'a dyn PrivateVid,
+    identifier: String,
+}
+
+impl<'a> IntroducedVid<'a> {
+    fn new(inner: &'a dyn PrivateVid) -> Self {
+        Self {
+            identifier: crate::vid::did::peer::introduction_identifier(inner),
+            inner,
+        }
+    }
+}
+
+impl VerifiedVid for IntroducedVid<'_> {
+    fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    fn endpoint(&self) -> &Url {
+        self.inner.endpoint()
+    }
+
+    fn verifying_key(&self) -> &crate::definitions::PublicVerificationKeyData {
+        self.inner.verifying_key()
+    }
+
+    fn encryption_key(&self) -> &crate::definitions::PublicKeyData {
+        self.inner.encryption_key()
+    }
+
+    fn encryption_key_type(&self) -> crate::definitions::VidEncryptionKeyType {
+        self.inner.encryption_key_type()
+    }
+
+    fn signature_key_type(&self) -> crate::definitions::VidSignatureKeyType {
+        self.inner.signature_key_type()
+    }
+}
+
+impl PrivateVid for IntroducedVid<'_> {
+    fn decryption_key(&self) -> &crate::definitions::PrivateKeyData {
+        self.inner.decryption_key()
+    }
+
+    fn signing_key(&self) -> &crate::definitions::PrivateSigningKeyData {
+        self.inner.signing_key()
+    }
+}
+
 fn seal_envelope(
     sender: &dyn PrivateVid,
     receiver: &dyn VerifiedVid,
@@ -680,10 +738,22 @@ impl SecureStore {
 
     /// Resolve alias to its corresponding DID, or leave it as is
     pub fn try_resolve_alias(&self, alias: &str) -> Result<String, Error> {
-        Ok(self
+        let resolved = self
             .resolve_alias(alias)?
             .unwrap_or(alias.to_owned())
-            .to_string())
+            .to_string();
+
+        // a did:peer is introduced by its long form and known by its short
+        // form, so a caller naming it by the form it was handed still means
+        // the VID the wallet holds
+        if !self.vids.read()?.contains_key(&resolved)
+            && let Some(short_form) = crate::vid::did::peer::short_form(&resolved)
+            && self.vids.read()?.contains_key(&short_form)
+        {
+            return Ok(short_form);
+        }
+
+        Ok(resolved)
     }
 
     /// Set alias for a DID
@@ -896,19 +966,19 @@ impl SecureStore {
         let mut nonce_bytes = [0_u8; 16];
         csprng.fill_bytes(&mut nonce_bytes);
 
-        let sender_identity = Some(sender.identifier().as_bytes());
+        // the invite introduces the new VID, so it carries the form the peer
+        // can verify without having seen it before (spec 2.1, did:peer:4 long
+        // form); the peer resolves it to the short form used thereafter
+        let wire_sender = crate::vid::did::peer::introduction_identifier(sender);
+        let sender_identity = Some(wire_sender.as_bytes());
         let mut request_digest = [0_u8; 32];
 
         // the inner message is an ordinary TSP message whose sender is the new
         // VID and whose receiver is NULL, and the digest is that message's own
         // SAID (spec 7.2.1: the innermost message that carries it)
         let mut envelope_prefix = Vec::with_capacity(64);
-        crate::cesr::encode_envelope_prefix(
-            sender.identifier().as_bytes(),
-            None,
-            &mut envelope_prefix,
-        )
-        .map_err(crate::crypto::CryptoError::from)?;
+        crate::cesr::encode_envelope_prefix(wire_sender.as_bytes(), None, &mut envelope_prefix)
+            .map_err(crate::crypto::CryptoError::from)?;
 
         fn proposal<'a>(
             request_digest: &'a Digest,
@@ -936,7 +1006,13 @@ impl SecureStore {
 
         // the inner message's payload IS the TSP_RFI (spec 9.4.13), so it is
         // signed as it stands rather than wrapped in an application payload
-        let message = crate::crypto::sign_payload(sender, None, &final_payload, sender_identity)?;
+        let message = crate::crypto::sign_payload_as(
+            sender,
+            &wire_sender,
+            None,
+            &final_payload,
+            sender_identity,
+        )?;
 
         Ok((message, request_digest))
     }
@@ -948,12 +1024,14 @@ impl SecureStore {
         thread_id: Digest,
         digest_algorithm: RelationshipDigestAlgorithm,
     ) -> Result<(Vec<u8>, Digest), Error> {
-        let sender_identity = Some(sender.identifier().as_bytes());
+        // as with the invite, the accept introduces this endpoint's new VID
+        let wire_sender = crate::vid::did::peer::introduction_identifier(sender);
+        let sender_identity = Some(wire_sender.as_bytes());
         let mut reply_thread_id = [0_u8; 32];
 
         let mut envelope_prefix = Vec::with_capacity(64);
         crate::cesr::encode_envelope_prefix(
-            sender.identifier().as_bytes(),
+            wire_sender.as_bytes(),
             Some(receiver.identifier().as_bytes()),
             &mut envelope_prefix,
         )
@@ -982,8 +1060,13 @@ impl SecureStore {
         let final_payload = affirm(&thread_id, &reply_thread_id, digest_algorithm);
 
         // likewise the TSP_RFA is the inner message's payload (spec 9.4.14)
-        let message =
-            crate::crypto::sign_payload(sender, Some(receiver), &final_payload, sender_identity)?;
+        let message = crate::crypto::sign_payload_as(
+            sender,
+            &wire_sender,
+            Some(receiver),
+            &final_payload,
+            sender_identity,
+        )?;
 
         Ok((message, reply_thread_id))
     }
@@ -1009,21 +1092,26 @@ impl SecureStore {
             .transpose()?
             .map(str::to_owned);
 
+        // a VID being introduced arrives in a form that carries its own
+        // verification material; resolving it yields the identifier the two
+        // endpoints use from here on, which is what the wallet is keyed by
+        let sender_vid: std::sync::Arc<dyn VerifiedVid> = match self.get_verified_vid(&inner_sender)
+        {
+            Ok(sender_vid) => sender_vid,
+            Err(_) => match verify_vid_offline(&inner_sender) {
+                Ok(sender_vid) => std::sync::Arc::new(sender_vid),
+                Err(_) => return Ok(None),
+            },
+        };
+        let nested_vid = sender_vid.identifier().to_string();
+
         let (
             crate::cesr::DecodedPayload {
                 payload,
                 sender_identity,
             },
             _,
-        ) = match self.get_verified_vid(&inner_sender) {
-            Ok(sender_vid) => crate::crypto::verify_payload(&*sender_vid, inner)?,
-            Err(_) => {
-                let Ok(sender_vid) = verify_vid_offline(&inner_sender) else {
-                    return Ok(None);
-                };
-                crate::crypto::verify_payload(&sender_vid, inner)?
-            }
-        };
+        ) = crate::crypto::verify_payload(&*sender_vid, inner)?;
 
         // anything that is not a relationship control message belongs to the
         // caller of this function, which opens it as an ordinary message
@@ -1064,13 +1152,13 @@ impl SecureStore {
                     ));
                 }
 
-                if self.get_verified_vid(&inner_sender).is_err() {
+                if self.get_verified_vid(&nested_vid).is_err() {
                     self.add_nested_vid(&inner_sender)?;
                 }
-                self.set_parent_for_vid(&inner_sender, Some(outer_sender))?;
+                self.set_parent_for_vid(&nested_vid, Some(outer_sender))?;
 
                 Ok(Some(NestedRelationshipEvent::Request {
-                    nested_vid: inner_sender,
+                    nested_vid,
                     thread_id: *request_digest.as_bytes(),
                 }))
             }
@@ -1086,10 +1174,10 @@ impl SecureStore {
                     ));
                 };
 
-                if self.get_verified_vid(&inner_sender).is_err() {
+                if self.get_verified_vid(&nested_vid).is_err() {
                     self.add_nested_vid(&inner_sender)?;
                 }
-                self.set_parent_for_vid(&inner_sender, Some(outer_sender))?;
+                self.set_parent_for_vid(&nested_vid, Some(outer_sender))?;
                 self.consume_pending_nested_request(
                     outer_sender,
                     *request_digest.as_bytes(),
@@ -1101,16 +1189,16 @@ impl SecureStore {
                 self.set_relation_and_status_for_vid(
                     &connect_to_vid,
                     relation_status.clone(),
-                    &inner_sender,
+                    &nested_vid,
                 )?;
                 self.set_relation_and_status_for_vid(
-                    &inner_sender,
+                    &nested_vid,
                     relation_status,
                     &connect_to_vid,
                 )?;
 
                 Ok(Some(NestedRelationshipEvent::Accept {
-                    nested_vid: inner_sender,
+                    nested_vid,
                     thread_id: *request_digest.as_bytes(),
                     reply_thread_id: *reply_digest.as_bytes(),
                 }))
@@ -1206,6 +1294,11 @@ impl SecureStore {
                         sender_vid.as_verified(),
                         message,
                     )?;
+
+                // a VID being introduced names itself in the envelope by the
+                // form that carries its verification material; from here on it
+                // is the identifier that resolves to
+                let sender = sender_vid.as_verified().identifier().to_string();
 
                 let parallel_sender_vid = parallel_signature_info
                     .map(|parallel_signature_info| {
@@ -1335,7 +1428,8 @@ impl SecureStore {
                             )?;
                         }
 
-                        if let ReceivedRelationshipForm::Parallel { new_vid, .. } = &form {
+                        let mut form = form;
+                        if let ReceivedRelationshipForm::Parallel { new_vid, .. } = &mut form {
                             match self.relation_status_for_vid_pair(&intended_receiver, &sender)? {
                                 RelationshipStatus::Bidirectional { .. } => {}
                                 RelationshipStatus::Unidirectional { .. }
@@ -1350,9 +1444,14 @@ impl SecureStore {
                                     "missing verified parallel VID for request message".into(),
                                 )
                             })?;
+                            // the referral introduced the VID in the form that
+                            // carries its verification material; from here it is
+                            // known by the identifier that resolves to
+                            *new_vid = parallel_sender_vid.as_verified().identifier().to_string();
+                            let new_vid = new_vid.clone();
                             parallel_sender_vid.persist(self)?;
                             self.add_pending_incoming_parallel_request(
-                                new_vid,
+                                &new_vid,
                                 thread_id,
                                 &intended_receiver,
                             )?;
@@ -1557,7 +1656,7 @@ impl SecureStore {
             &[],
             &envelope_prefix,
             &mut digest,
-            sender_new_vid.identifier().as_bytes(),
+            crate::vid::did::peer::introduction_identifier(sender_new_vid).as_bytes(),
         )?;
         let request_nonce = Some(nonce);
 
@@ -1592,6 +1691,9 @@ impl SecureStore {
 
         let selection = selected_outbound_crypto(&*sender, &*receiver, None);
         let digest_algorithm = digest_algorithm_for_selection(selection)?;
+        // the referral introduces the new VID, so it names the form the peer
+        // can verify without having seen it (did:peer:4 long form)
+        let new_vid_long_form = crate::vid::did::peer::introduction_identifier(&*sender_new_vid);
         let signature_material = self.build_parallel_signature_material(
             &*sender_new_vid,
             ParallelSignatureContext {
@@ -1610,7 +1712,7 @@ impl SecureStore {
                 thread_id: Default::default(),
                 reply_path: vec![],
                 form: RelationshipForm::Parallel {
-                    new_vid: sender_new_vid.identifier().as_bytes(),
+                    new_vid: new_vid_long_form.as_bytes(),
                     sig_new_vid: signature_material.sig_new_vid.as_slice(),
                 },
             },
@@ -1684,7 +1786,7 @@ impl SecureStore {
         // carries no referral field (spec 7.2.5)
         let mut reply_thread_id = Default::default();
         let tsp_message = seal_envelope(
-            &*sender_new_vid,
+            &IntroducedVid::new(&*sender_new_vid),
             &*receiver_new_vid,
             Payload::AcceptRelationship {
                 thread_id,
@@ -3351,7 +3453,7 @@ mod test {
             &[],
             &test_envelope_prefix(&alice, &bob),
             &mut thread_id,
-            alice_parallel.identifier().as_bytes(),
+            crate::vid::did::peer::introduction_identifier(&alice_parallel).as_bytes(),
         )
         .unwrap();
         let mut sig_new_vid = crate::crypto::sign_detached(&alice_parallel, &signed_data).unwrap();
@@ -3367,7 +3469,8 @@ mod test {
                 thread_id: Default::default(),
                 reply_path: vec![],
                 form: RelationshipForm::Parallel {
-                    new_vid: alice_parallel.identifier().as_ref(),
+                    new_vid: crate::vid::did::peer::introduction_identifier(&alice_parallel)
+                        .as_ref(),
                     sig_new_vid: sig_new_vid.as_slice(),
                 },
             },
@@ -3414,7 +3517,7 @@ mod test {
             &[],
             &test_envelope_prefix(&alice, &bob),
             &mut thread_id,
-            alice_parallel.identifier().as_bytes(),
+            crate::vid::did::peer::introduction_identifier(&alice_parallel).as_bytes(),
         )
         .unwrap();
         let sig_new_vid = crate::crypto::sign_detached(&alice_parallel, &signed_data).unwrap();
@@ -3429,7 +3532,8 @@ mod test {
                 thread_id: Default::default(),
                 reply_path: vec![],
                 form: RelationshipForm::Parallel {
-                    new_vid: alice_parallel.identifier().as_ref(),
+                    new_vid: crate::vid::did::peer::introduction_identifier(&alice_parallel)
+                        .as_ref(),
                     sig_new_vid: sig_new_vid.as_slice(),
                 },
             },
@@ -3476,9 +3580,10 @@ mod test {
             .expect("sealed message should not be empty");
         *last ^= 0x01;
 
-        let Err(Error::Crypto(CryptoError::Verify(vid, _))) =
-            receiver_store.open_message(&mut sealed)
-        else {
+        // the sender is a did:peer, whose short form the receiver cannot
+        // resolve without having been introduced to it, so an unknown sender
+        // is rejected before its signature is ever considered
+        let Err(Error::UnverifiedSource(vid, ..)) = receiver_store.open_message(&mut sealed) else {
             panic!("unexpected message result");
         };
 

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -933,10 +933,10 @@ impl SecureStore {
         request_digest = digest_algorithm.hash(&digest_input);
 
         let final_payload = proposal(&request_digest, nonce_bytes, digest_algorithm);
-        let mut encoded_payload = Vec::with_capacity(final_payload.calculate_size(sender_identity));
-        crate::cesr::encode_payload(&final_payload, sender_identity, None, &mut encoded_payload)?;
 
-        let message = crate::crypto::sign(sender, None, &encoded_payload)?;
+        // the inner message's payload IS the TSP_RFI (spec 9.4.13), so it is
+        // signed as it stands rather than wrapped in an application payload
+        let message = crate::crypto::sign_payload(sender, None, &final_payload, sender_identity)?;
 
         Ok((message, request_digest))
     }
@@ -980,10 +980,10 @@ impl SecureStore {
         reply_thread_id = digest_algorithm.hash(&digest_input);
 
         let final_payload = affirm(&thread_id, &reply_thread_id, digest_algorithm);
-        let mut encoded_payload = Vec::with_capacity(final_payload.calculate_size(sender_identity));
-        crate::cesr::encode_payload(&final_payload, sender_identity, None, &mut encoded_payload)?;
 
-        let message = crate::crypto::sign(sender, Some(receiver), &encoded_payload)?;
+        // likewise the TSP_RFA is the inner message's payload (spec 9.4.14)
+        let message =
+            crate::crypto::sign_payload(sender, Some(receiver), &final_payload, sender_identity)?;
 
         Ok((message, reply_thread_id))
     }
@@ -1009,24 +1009,31 @@ impl SecureStore {
             .transpose()?
             .map(str::to_owned);
 
-        let (inner_message, _) = match self.get_verified_vid(&inner_sender) {
-            Ok(sender_vid) => crate::crypto::verify(&*sender_vid, inner)?,
+        let (
+            crate::cesr::DecodedPayload {
+                payload,
+                sender_identity,
+            },
+            _,
+        ) = match self.get_verified_vid(&inner_sender) {
+            Ok(sender_vid) => crate::crypto::verify_payload(&*sender_vid, inner)?,
             Err(_) => {
                 let Ok(sender_vid) = verify_vid_offline(&inner_sender) else {
                     return Ok(None);
                 };
-                crate::crypto::verify(&sender_vid, inner)?
+                crate::crypto::verify_payload(&sender_vid, inner)?
             }
         };
 
-        let mut payload_bytes = inner_message.to_vec();
-        let crate::cesr::DecodedPayload {
+        // anything that is not a relationship control message belongs to the
+        // caller of this function, which opens it as an ordinary message
+        if !matches!(
             payload,
-            sender_identity,
-        } = match crate::cesr::decode_payload(&mut payload_bytes) {
-            Ok(decoded) => decoded,
-            Err(_) => return Ok(None),
-        };
+            crate::cesr::Payload::RelationProposal { .. }
+                | crate::cesr::Payload::RelationAffirm { .. }
+        ) {
+            return Ok(None);
+        }
 
         if sender_identity != Some(inner_sender.as_bytes()) {
             return Err(Error::Relationship(
@@ -3977,6 +3984,77 @@ mod test {
             b_store.open_message(&mut invite),
             Err(Error::UnestablishedRelationship(..))
         ));
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_nested_control_message_payload_is_the_control_payload() {
+        // The inner message of a nested TSP_RFI/TSP_RFA carries that control
+        // payload itself (spec 9.4.13/9.4.14), not an XSCS application payload
+        // wrapping one. A round trip cannot catch the difference, because the
+        // receiver peels whatever the sender wrapped, so decode the payload of
+        // the inner message directly and look at its type.
+        fn payload_type_of(message: &[u8]) -> &'static str {
+            let mut buf = message.to_vec();
+            let crate::cesr::DecodedEnvelope {
+                payload_position: Some(payload),
+                ..
+            } = crate::cesr::decode_envelope(&mut buf)
+                .unwrap()
+                .into_opened::<&[u8]>()
+                .unwrap()
+            else {
+                panic!("the inner message carries a payload");
+            };
+            match crate::cesr::decode_payload(payload).unwrap().payload {
+                crate::cesr::Payload::RelationProposal { .. } => "XRFI",
+                crate::cesr::Payload::RelationAffirm { .. } => "XRFA",
+                crate::cesr::Payload::GenericMessage(_) => "XSCS",
+                _ => "other",
+            }
+        }
+
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let (alice, bob) = create_test_vid_pair();
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.clone(), None).unwrap();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.clone(), None).unwrap();
+        establish_existing_relationship(&a_store, &alice, &b_store, &bob);
+
+        let ((_url, mut invite), nested_a) = a_store
+            .make_nested_relationship_request(alice.identifier(), bob.identifier())
+            .unwrap();
+        let ReceivedTspMessage::RequestRelationship {
+            thread_id,
+            delivery: ReceivedRelationshipDelivery::Nested { nested_vid },
+            ..
+        } = b_store.open_message(&mut invite).unwrap()
+        else {
+            panic!("bob did not receive a nested relationship request");
+        };
+
+        let (rfi, _) = a_store
+            .make_signed_nested_request_message(
+                &*a_store.get_private_vid(nested_a.identifier()).unwrap(),
+                crate::crypto::RelationshipDigestAlgorithm::Sha2_256,
+            )
+            .unwrap();
+        assert_eq!(payload_type_of(&rfi), "XRFI");
+
+        let (_accept, nested_b) = b_store
+            .make_nested_relationship_accept(bob.identifier(), &nested_vid, thread_id)
+            .unwrap();
+        let (rfa, _) = b_store
+            .make_signed_nested_accept_message(
+                &*b_store.get_private_vid(nested_b.identifier()).unwrap(),
+                &*b_store.get_verified_vid(&nested_vid).unwrap(),
+                thread_id,
+                crate::crypto::RelationshipDigestAlgorithm::Sha2_256,
+            )
+            .unwrap();
+        assert_eq!(payload_type_of(&rfa), "XRFA");
     }
 
     #[test]

--- a/tsp_sdk/src/test.rs
+++ b/tsp_sdk/src/test.rs
@@ -228,8 +228,10 @@ async fn test_nested_mode() {
     alice_db
         .set_parent_for_vid(nested_alice_vid.identifier(), Some(alice_vid.identifier()))
         .unwrap();
+    // a nested VID is introduced by the form that carries its verification
+    // material; its short form is what both sides use once it is known
     alice_db
-        .verify_vid(nested_bob_vid.identifier(), None)
+        .verify_vid(&crate::vid::introduction_identifier(&nested_bob_vid), None)
         .await
         .unwrap();
     alice_db
@@ -244,7 +246,10 @@ async fn test_nested_mode() {
         .unwrap();
 
     bob_db
-        .verify_vid(nested_alice_vid.identifier(), None)
+        .verify_vid(
+            &crate::vid::introduction_identifier(&nested_alice_vid),
+            None,
+        )
         .await
         .unwrap();
     bob_db

--- a/tsp_sdk/src/vid/did/peer.rs
+++ b/tsp_sdk/src/vid/did/peer.rs
@@ -1,208 +1,343 @@
 use crate::definitions::{VidEncryptionKeyType, VidSignatureKeyType};
 use crate::{Vid, definitions::VerifiedVid, vid::error::VidError};
-use base64ct::{Base64UrlUnpadded, Encoding};
-use serde_json::json;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 #[cfg(feature = "async")]
 use tracing::log::trace;
 use url::Url;
 
 pub(crate) const SCHEME: &str = "peer";
 
-/// Encode VID as did:peer,include verification end encryption key
-/// The service definition has type `tsp`
-/// See <https://identity.foundation/peer-did-method-spec/>
-pub fn encode_did_peer(vid: &Vid) -> String {
-    let mut v = Vec::with_capacity(34);
+/// The service type TSP publishes its transport under
+const TSP_SERVICE_TYPE: &str = "tsp";
 
-    match vid.sig_key_type {
-        VidSignatureKeyType::Ed25519 => {
-            // multicodec for ed25519-pub
-            v.push(0xed);
-            // key bytes length
-            v.push(0x20);
-        }
-        VidSignatureKeyType::MlDsa65 => {
-            // private use area (0x300001) => encoded as unsigned varint, see: https://github.com/multiformats/unsigned-varint
-            v.extend_from_slice(&0x8180c001u32.to_be_bytes());
-            // key bytes length (1952 bytes) => encoded as unsigned varint, see: https://github.com/multiformats/unsigned-varint
-            v.extend_from_slice(&0xa00fu16.to_be_bytes());
-        }
-    };
+/// Multicodec identifier for JSON, as an unsigned varint of the value 0x0200
+const MULTICODEC_JSON: [u8; 2] = [0x80, 0x04];
 
-    v.extend_from_slice(vid.verifying_key().as_ref());
+/// Multihash prefix for SHA2-256 (0x12) at 32 bytes (0x20)
+const MULTIHASH_SHA2_256: [u8; 2] = [0x12, 0x20];
 
-    let verification_key = bs58::encode(&v)
-        .with_alphabet(bs58::Alphabet::BITCOIN)
-        .into_string();
-
-    v.clear();
-    match vid.enc_key_type {
-        VidEncryptionKeyType::X25519 => {
-            #[cfg(feature = "async")]
-            trace!("serializing x25519 encryption key");
-            // multicodec for x25519-pub
-            v.push(0xec);
-            // key bytes length
-            v.push(0x20);
-        }
-        VidEncryptionKeyType::X25519MlKem768 => {
-            #[cfg(feature = "async")]
-            trace!("serializing X25519MlKem768 encryption key");
-            // private use area (0x300000) => encoded as unsigned varint, see: https://github.com/multiformats/unsigned-varint
-            v.extend_from_slice(&0x8080c001u32.to_be_bytes());
-            // key bytes length (1216 bytes) => encoded as unsigned varint, see: https://github.com/multiformats/unsigned-varint
-            v.extend_from_slice(&0xc009u16.to_be_bytes());
-        }
-    }
-
-    v.extend_from_slice(vid.encryption_key().as_ref());
-
-    let encryption_key = bs58::encode(&v)
-        .with_alphabet(bs58::Alphabet::BITCOIN)
-        .into_string();
-
-    let service = Base64UrlUnpadded::encode_string(
-        json!({
-            "t": "tsp",
-            "s": {
-                "uri": vid.endpoint()
-            }
-        })
-        .to_string()
-        .as_bytes(),
-    );
-
-    format!("did:peer:2.Vz{verification_key}.Ez{encryption_key}.S{service}")
+/// The "Input Document" of a `did:peer:4` (did:peer method spec, Method 4): a
+/// DID document with no `id` at the root and only relative references, from
+/// which both forms of the identifier are derived.
+///
+/// The field order here is the serialized order, and the serialized bytes are
+/// what the identifier hashes over, so this declaration fixes the identifier a
+/// given key pair produces. Do not reorder it.
+#[derive(Serialize, Deserialize)]
+struct InputDocument {
+    #[serde(rename = "@context")]
+    context: String,
+    #[serde(rename = "verificationMethod")]
+    verification_method: Vec<VerificationMethod>,
+    authentication: Vec<String>,
+    #[serde(rename = "keyAgreement")]
+    key_agreement: Vec<String>,
+    service: Vec<Service>,
 }
 
-pub fn verify_did_peer(parts: &[&str]) -> Result<Vid, VidError> {
-    let mut peer_parts = parts[2].split('.');
+#[derive(Serialize, Deserialize)]
+struct VerificationMethod {
+    id: String,
+    #[serde(rename = "type")]
+    key_type: String,
+    #[serde(rename = "publicKeyMultibase")]
+    public_key_multibase: String,
+}
 
-    // only numalgo 2 is supported
-    if peer_parts.next() != Some("2") {
+#[derive(Serialize, Deserialize)]
+struct Service {
+    id: String,
+    #[serde(rename = "type")]
+    service_type: String,
+    #[serde(rename = "serviceEndpoint")]
+    service_endpoint: ServiceEndpoint,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ServiceEndpoint {
+    uri: String,
+}
+
+const SIGNING_KEY_REF: &str = "#key-1";
+const ENCRYPTION_KEY_REF: &str = "#key-2";
+
+fn base58btc(bytes: &[u8]) -> String {
+    format!(
+        "z{}",
+        bs58::encode(bytes)
+            .with_alphabet(bs58::Alphabet::BITCOIN)
+            .into_string()
+    )
+}
+
+fn decode_base58btc(value: &str) -> Result<Vec<u8>, VidError> {
+    let Some(body) = value.strip_prefix('z') else {
+        return Err(VidError::ResolveVid("did:peer value is not base58btc"));
+    };
+
+    bs58::decode(body)
+        .with_alphabet(bs58::Alphabet::BITCOIN)
+        .into_vec()
+        .map_err(|_| VidError::ResolveVid("invalid base58btc value in did:peer"))
+}
+
+fn signature_key_multicodec(key_type: VidSignatureKeyType) -> &'static [u8] {
+    match key_type {
+        // ed25519-pub
+        VidSignatureKeyType::Ed25519 => &[0xed, 0x01],
+        // private use area (0x300001), as an unsigned varint
+        VidSignatureKeyType::MlDsa65 => &[0x81, 0x80, 0xc0, 0x01],
+    }
+}
+
+fn encryption_key_multicodec(key_type: VidEncryptionKeyType) -> &'static [u8] {
+    match key_type {
+        // x25519-pub
+        VidEncryptionKeyType::X25519 => &[0xec, 0x01],
+        // private use area (0x300000), as an unsigned varint
+        VidEncryptionKeyType::X25519MlKem768 => &[0x80, 0x80, 0xc0, 0x01],
+    }
+}
+
+fn multikey(multicodec: &[u8], key: &[u8]) -> String {
+    let mut buf = Vec::with_capacity(multicodec.len() + key.len());
+    buf.extend_from_slice(multicodec);
+    buf.extend_from_slice(key);
+
+    base58btc(&buf)
+}
+
+fn split_multikey<'a>(
+    decoded: &'a [u8],
+    multicodec: &[u8],
+    expected_len: usize,
+) -> Option<&'a [u8]> {
+    decoded
+        .strip_prefix(multicodec)
+        .filter(|key| key.len() == expected_len)
+}
+
+fn input_document(vid: &dyn VerifiedVid) -> InputDocument {
+    InputDocument {
+        context: "https://www.w3.org/ns/did/v1".to_string(),
+        verification_method: vec![
+            VerificationMethod {
+                id: SIGNING_KEY_REF.to_string(),
+                key_type: "Multikey".to_string(),
+                public_key_multibase: multikey(
+                    signature_key_multicodec(vid.signature_key_type()),
+                    vid.verifying_key().as_ref(),
+                ),
+            },
+            VerificationMethod {
+                id: ENCRYPTION_KEY_REF.to_string(),
+                key_type: "Multikey".to_string(),
+                public_key_multibase: multikey(
+                    encryption_key_multicodec(vid.encryption_key_type()),
+                    vid.encryption_key().as_ref(),
+                ),
+            },
+        ],
+        authentication: vec![SIGNING_KEY_REF.to_string()],
+        key_agreement: vec![ENCRYPTION_KEY_REF.to_string()],
+        service: vec![Service {
+            id: "#tsp".to_string(),
+            service_type: TSP_SERVICE_TYPE.to_string(),
+            service_endpoint: ServiceEndpoint {
+                uri: vid.endpoint().to_string(),
+            },
+        }],
+    }
+}
+
+/// The `encoded document` of a `did:peer:4`: the Input Document as JSON with no
+/// whitespace, prefixed with the multicodec identifier for JSON and encoded as
+/// base58btc.
+fn encode_document(document: &InputDocument) -> Result<String, VidError> {
+    let json = serde_json::to_vec(document)
+        .map_err(|_| VidError::ResolveVid("could not encode a did:peer document"))?;
+
+    let mut buf = Vec::with_capacity(MULTICODEC_JSON.len() + json.len());
+    buf.extend_from_slice(&MULTICODEC_JSON);
+    buf.extend_from_slice(&json);
+
+    Ok(base58btc(&buf))
+}
+
+/// The `hash` of a `did:peer:4`: SHA2-256 over the encoded document as it
+/// stands, as a base58btc multihash.
+fn hash_document(encoded_document: &str) -> String {
+    let digest = Sha256::digest(encoded_document.as_bytes());
+
+    let mut buf = Vec::with_capacity(MULTIHASH_SHA2_256.len() + digest.len());
+    buf.extend_from_slice(&MULTIHASH_SHA2_256);
+    buf.extend_from_slice(&digest);
+
+    base58btc(&buf)
+}
+
+/// Encode a VID as the long form of a `did:peer:4`, which embeds the whole
+/// document and so can be verified by a receiver that has never seen it.
+///
+/// A VID is introduced in this form once; thereafter it is referred to by
+/// [`encode_did_peer`], its short form. See <https://identity.foundation/peer-did-method-spec/>
+pub fn encode_did_peer_long_form(vid: &dyn VerifiedVid) -> String {
+    let Ok(encoded_document) = encode_document(&input_document(vid)) else {
+        return String::new();
+    };
+    let hash = hash_document(&encoded_document);
+
+    format!("did:peer:4{hash}:{encoded_document}")
+}
+
+/// Encode a VID as the short form of a `did:peer:4`: the hash of its document,
+/// without the document. This is a VID's identity; it is resolvable only by an
+/// endpoint that has already seen the long form.
+pub fn encode_did_peer(vid: &dyn VerifiedVid) -> String {
+    let Ok(encoded_document) = encode_document(&input_document(vid)) else {
+        return String::new();
+    };
+
+    format!("did:peer:4{}", hash_document(&encoded_document))
+}
+
+/// The short form of a `did:peer:4` long form, or `None` if this is not one.
+pub fn short_form(identifier: &str) -> Option<String> {
+    match identifier.split(':').collect::<Vec<_>>()[..] {
+        ["did", SCHEME, hash, _document] if hash.starts_with('4') => {
+            Some(format!("did:peer:{hash}"))
+        }
+        _ => None,
+    }
+}
+
+/// The form of a VID's identifier to put on the wire when introducing it: a
+/// `did:peer` is introduced in long form, since its short form cannot be
+/// resolved by an endpoint that has not seen it. Every other VID type is
+/// resolvable by its identifier, so that is what it uses.
+pub fn introduction_identifier(vid: &dyn VerifiedVid) -> String {
+    if vid.identifier().starts_with("did:peer:") {
+        encode_did_peer_long_form(vid)
+    } else {
+        vid.identifier().to_string()
+    }
+}
+
+/// Resolve a `did:peer:4`. Only the long form carries the document, so only the
+/// long form can be resolved on its own; the returned VID is identified by its
+/// short form, which is what the two endpoints use thereafter.
+pub fn verify_did_peer(parts: &[&str]) -> Result<Vid, VidError> {
+    let Some(hash) = parts[2].strip_prefix('4') else {
         return Err(VidError::ResolveVid(
-            "only numalgo 2 is supported for did:peer",
+            "only numalgo 4 is supported for did:peer",
+        ));
+    };
+
+    let Some(encoded_document) = parts.get(3) else {
+        return Err(VidError::ResolveVid(
+            "a short form did:peer:4 cannot be resolved on its own; the long form must be known",
+        ));
+    };
+
+    if parts.len() > 4 {
+        return Err(VidError::ResolveVid("trailing data in did:peer"));
+    }
+
+    // the identifier commits to its own document (did:peer method spec,
+    // Method 4, "Resolving a DID"), so recomputing the hash both verifies the
+    // document and is what makes the short form usable in its place
+    if hash_document(encoded_document) != hash {
+        return Err(VidError::ResolveVid(
+            "did:peer:4 document does not match its hash",
         ));
     }
 
+    let decoded = decode_base58btc(encoded_document)?;
+    let Some(json) = decoded.strip_prefix(&MULTICODEC_JSON) else {
+        return Err(VidError::ResolveVid("did:peer:4 document is not JSON"));
+    };
+
+    let document: InputDocument = serde_json::from_slice(json)
+        .map_err(|_| VidError::ResolveVid("invalid did:peer:4 document"))?;
+
     let mut public_sigkey = None;
+    let mut sig_key_type = None;
     let mut public_enckey = None;
     let mut enc_key_type = None;
-    let mut sig_key_type = None;
-    let mut transport = None;
 
-    let mut buf = [0; 3309 + 6];
+    for method in &document.verification_method {
+        let decoded = decode_base58btc(&method.public_key_multibase)?;
 
-    for part in peer_parts {
-        match &part[0..2] {
-            // Key Agreement (Encryption) + base58 multibase prefix
-            "Ez" => {
-                bs58::decode(&part[2..])
-                    .with_alphabet(bs58::Alphabet::BITCOIN)
-                    .onto(&mut buf)
-                    .map_err(|_| {
-                        VidError::ResolveVid("invalid encoded encryption key in did:peer")
-                    })?;
-
-                match buf {
-                    // multicodec for x25519-pub + length 32 bytes
-                    [0xec, 0x20, rest @ ..] => {
-                        #[cfg(feature = "async")]
-                        trace!("found x25519 encryption key");
-                        public_enckey = Some(rest[..0x20].to_vec());
-                        enc_key_type = Some(VidEncryptionKeyType::X25519)
-                    }
-                    // multicodec reserved range (0x300000), followed by length (1216)
-                    [
-                        0b10000000,
-                        0b10000000,
-                        0b11000000,
-                        0b00000001,
-                        0b11000000,
-                        0b00001001,
-                        rest @ ..,
-                    ] => {
-                        #[cfg(feature = "async")]
-                        trace!("found X25519MlKem768 encryption key");
-                        public_enckey = rest[..1216].to_vec().into();
-                        enc_key_type = Some(VidEncryptionKeyType::X25519MlKem768)
-                    }
-                    _ => {
-                        return Err(VidError::ResolveVid(
-                            "invalid encryption key type in did:peer",
-                        ));
-                    }
-                }
+        if document.authentication.contains(&method.id) {
+            if let Some(key) = split_multikey(
+                &decoded,
+                signature_key_multicodec(VidSignatureKeyType::Ed25519),
+                32,
+            ) {
+                #[cfg(feature = "async")]
+                trace!("found Ed25519 signature key");
+                public_sigkey = Some(key.to_vec());
+                sig_key_type = Some(VidSignatureKeyType::Ed25519);
+            } else if let Some(key) = split_multikey(
+                &decoded,
+                signature_key_multicodec(VidSignatureKeyType::MlDsa65),
+                1952,
+            ) {
+                #[cfg(feature = "async")]
+                trace!("found ML-DSA-65 signature key");
+                public_sigkey = Some(key.to_vec());
+                sig_key_type = Some(VidSignatureKeyType::MlDsa65);
+            } else {
+                return Err(VidError::ResolveVid(
+                    "invalid signature key type in did:peer",
+                ));
             }
-            // Authentication (Verification) + base58 multibase prefix
-            "Vz" => {
-                bs58::decode(&part[2..])
-                    .with_alphabet(bs58::Alphabet::BITCOIN)
-                    .onto(&mut buf)
-                    .map_err(|_| {
-                        VidError::ResolveVid("invalid encoded verification key in did:peer")
-                    })?;
+        }
 
-                match buf {
-                    // multicodec for ed25519-pub + length 32 bytes
-                    [0xed, 0x20, rest @ ..] => {
-                        #[cfg(feature = "async")]
-                        trace!("found Ed25519 signature key");
-                        public_sigkey = Some(rest[..0x20].to_vec());
-                        sig_key_type = Some(VidSignatureKeyType::Ed25519)
-                    }
-                    // multicodec reserved range (0x300001), followed by length (1952) (https://go.dev/play/p/KskwkAiBV7D)
-                    [
-                        0b10000001,
-                        0b10000000,
-                        0b11000000,
-                        0b00000001,
-                        0b10100000,
-                        0b00001111,
-                        rest @ ..,
-                    ] => {
-                        #[cfg(feature = "async")]
-                        trace!("found ML-DSA-65 signature key");
-                        public_sigkey = rest[..1952].to_vec().into();
-                        sig_key_type = Some(VidSignatureKeyType::MlDsa65)
-                    }
-                    _ => {
-                        return Err(VidError::ResolveVid(
-                            "invalid signature key type in did:peer",
-                        ));
-                    }
-                }
-            }
-            // start of base64url encoded service definition
-            "Se" => {
-                let transport_bytes = Base64UrlUnpadded::decode_vec(&part[1..])
-                    .map_err(|_| VidError::ResolveVid("invalid encoded transport in did:peer"))?;
-
-                let transport_json: serde_json::Value = serde_json::from_slice(&transport_bytes)
-                    .map_err(|_| VidError::ResolveVid("invalid encoded transport in did:peer"))?;
-
-                if transport_json["t"] != "tsp" {
-                    return Err(VidError::ResolveVid("invalid transport type in did:peer"));
-                }
-
-                if let Some(transport_bytes) = &transport_json["s"]["uri"].as_str() {
-                    transport = Url::parse(transport_bytes).ok();
-                }
-            }
-            _ => {
-                return Err(VidError::ResolveVid("invalid part in did:peer"));
+        if document.key_agreement.contains(&method.id) {
+            if let Some(key) = split_multikey(
+                &decoded,
+                encryption_key_multicodec(VidEncryptionKeyType::X25519),
+                32,
+            ) {
+                #[cfg(feature = "async")]
+                trace!("found x25519 encryption key");
+                public_enckey = Some(key.to_vec());
+                enc_key_type = Some(VidEncryptionKeyType::X25519);
+            } else if let Some(key) = split_multikey(
+                &decoded,
+                encryption_key_multicodec(VidEncryptionKeyType::X25519MlKem768),
+                1216,
+            ) {
+                #[cfg(feature = "async")]
+                trace!("found X25519MlKem768 encryption key");
+                public_enckey = Some(key.to_vec());
+                enc_key_type = Some(VidEncryptionKeyType::X25519MlKem768);
+            } else {
+                return Err(VidError::ResolveVid(
+                    "invalid encryption key type in did:peer",
+                ));
             }
         }
     }
 
+    let transport = document
+        .service
+        .iter()
+        .find(|service| service.service_type == TSP_SERVICE_TYPE)
+        .and_then(|service| Url::parse(&service.service_endpoint.uri).ok());
+
+    // the VID is known by its short form once its document has been seen
+    let id = format!("did:peer:4{hash}");
+
     match (public_sigkey, public_enckey, transport) {
         (Some(public_sigkey), Some(public_enckey), Some(mut transport)) => {
-            let path = transport
-                .path()
-                .replace("[vid_placeholder]", &parts.join(":"));
+            let path = transport.path().replace("[vid_placeholder]", &id);
             transport.set_path(&path);
+
             Ok(Vid {
-                id: parts.join(":"),
+                id,
                 transport,
                 sig_key_type: sig_key_type.unwrap_or(VidSignatureKeyType::Ed25519),
                 public_sigkey: public_sigkey.into(),
@@ -216,20 +351,36 @@ pub fn verify_did_peer(parts: &[&str]) -> Result<Vid, VidError> {
     }
 }
 
-#[cfg(not(feature = "pq"))]
 #[cfg(test)]
 mod test {
-    use crate::definitions::{VerifiedVid, VidEncryptionKeyType, VidSignatureKeyType};
-    use url::Url;
+    use super::*;
+
+    #[cfg(not(feature = "pq"))]
+    use crate::definitions::VerifiedVid;
     use wasm_bindgen_test::wasm_bindgen_test;
-
-    use crate::Vid;
-
-    use super::{encode_did_peer, verify_did_peer};
 
     #[test]
     #[wasm_bindgen_test]
-    fn encode_decode() {
+    fn matches_the_method_specs_own_example() {
+        // The worked example from the did:peer method spec, Method 4. Its
+        // document is not a TSP one, so this pins the derivation itself: the
+        // JSON multicodec prefix, the hash over the encoded document as it
+        // stands, and both forms.
+        let encoded_document = "z2M1k7h4psgp4CmJcnQn2Ljp7Pz7ktsd7oBhMU3dWY5s4fhFNj17qcRTQ427C7QHNT6cQ7T3XfRh35Q2GhaNFZmWHVFq4vL7F8nm36PA9Y96DvdrUiRUaiCuXnBFrn1o7mxFZAx14JL4t8vUWpuDPwQuddVo1T8myRiVH7wdxuoYbsva5x6idEpCQydJdFjiHGCpNc2UtjzPQ8awSXkctGCnBmgkhrj5gto3D4i3EREXYq4Z8r2cWGBr2UzbSmnxW2BuYddFo9Yfm6mKjtJyLpF74ytqrF5xtf84MnGFg1hMBmh1xVx1JwjZ2BeMJs7mNS8DTZhKC7KH38EgqDtUZzfjhpjmmUfkXg2KFEA3EGbbVm1DPqQXayPYKAsYPS9AyKkcQ3fzWafLPP93UfNhtUPL8JW5pMcSV3P8v6j3vPXqnnGknNyBprD6YGUVtgLiAqDBDUF3LSxFQJCVYYtghMTv8WuSw9h1a1SRFrDQLGHE4UrkgoRvwaGWr64aM87T1eVGkP5Dt4L1AbboeK2ceLArPScrdYGTpi3BpTkLwZCdjdiFSfTy9okL1YNRARqUf2wm8DvkVGUU7u5nQA3ZMaXWJAewk6k1YUxKd7LvofGUK4YEDtoxN5vb6r1Q2godrGqaPkjfL3RoYPpDYymf9XhcgG8Kx3DZaA6cyTs24t45KxYAfeCw4wqUpCH9HbpD78TbEUr9PPAsJgXBvBj2VVsxnr7FKbK4KykGcg1W8M1JPz21Z4Y72LWgGQCmixovrkHktcTX1uNHjAvKBqVD5C7XmVfHgXCHj7djCh3vzLNuVLtEED8J1hhqsB1oCBGiuh3xXr7fZ9wUjJCQ1HYHqxLJKdYKtoCiPmgKM7etVftXkmTFETZmpM19aRyih3bao76LdpQtbw636r7a3qt8v4WfxsXJetSL8c7t24SqQBcAY89FBsbEnFNrQCMK3JEseKHVaU388ctvRD45uQfe5GndFxthj4iSDomk4uRFd1uRbywoP1tRuabHTDX42UxPjz";
+
+        assert_eq!(
+            hash_document(encoded_document),
+            "zQmd8CpeFPci817KDsbSAKWcXAE2mjvCQSasRewvbSF54Bd"
+        );
+
+        let decoded = decode_base58btc(encoded_document).unwrap();
+        let json = decoded.strip_prefix(&MULTICODEC_JSON).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(json).unwrap();
+        assert_eq!(value["verificationMethod"][0]["id"], "#6LSqPZfn");
+    }
+
+    #[cfg(not(feature = "pq"))]
+    fn test_vid() -> Vid {
         let (_sigkey, public_sigkey) = crate::crypto::gen_sign_keypair();
         let (_enckey, public_enckey) = crate::crypto::gen_encrypt_keypair();
 
@@ -241,15 +392,70 @@ mod test {
             enc_key_type: VidEncryptionKeyType::X25519,
             public_enckey,
         };
-
         vid.id = encode_did_peer(&vid);
 
+        vid
+    }
+
+    #[cfg(not(feature = "pq"))]
+    #[test]
+    #[wasm_bindgen_test]
+    fn long_form_resolves_to_the_short_form() {
+        let vid = test_vid();
+        let long_form = encode_did_peer_long_form(&vid);
+
+        assert!(long_form.starts_with(&vid.id));
+
+        let parts = long_form.split(':').collect::<Vec<&str>>();
+        let resolved = verify_did_peer(&parts).unwrap();
+
+        // resolving the long form yields a VID identified by its short form
+        assert_eq!(resolved.identifier(), vid.id);
+        assert_eq!(vid.verifying_key(), resolved.verifying_key());
+        assert_eq!(vid.encryption_key(), resolved.encryption_key());
+        assert_eq!(vid.endpoint(), resolved.endpoint());
+    }
+
+    #[cfg(not(feature = "pq"))]
+    #[test]
+    #[wasm_bindgen_test]
+    fn short_form_alone_does_not_resolve() {
+        let vid = test_vid();
         let parts = vid.id.split(':').collect::<Vec<&str>>();
 
-        let resolved_vid = verify_did_peer(&parts).unwrap();
+        assert!(verify_did_peer(&parts).is_err());
+    }
 
-        assert_eq!(vid.verifying_key(), resolved_vid.verifying_key());
-        assert_eq!(vid.encryption_key(), resolved_vid.encryption_key());
-        assert_eq!(vid.endpoint(), resolved_vid.endpoint());
+    #[cfg(not(feature = "pq"))]
+    #[test]
+    #[wasm_bindgen_test]
+    fn a_tampered_document_is_rejected() {
+        let vid = test_vid();
+        let long_form = encode_did_peer_long_form(&vid);
+
+        // a document that no longer hashes to the identifier's hash is not the
+        // document that identifier names
+        let (head, tail) = long_form.split_at(long_form.len() - 4);
+        let tampered = format!(
+            "{head}{}",
+            if tail.starts_with('A') {
+                "BBBB"
+            } else {
+                "AAAA"
+            }
+        );
+
+        let parts = tampered.split(':').collect::<Vec<&str>>();
+        assert!(verify_did_peer(&parts).is_err());
+    }
+
+    #[cfg(not(feature = "pq"))]
+    #[test]
+    #[wasm_bindgen_test]
+    fn numalgo_2_is_not_accepted() {
+        let legacy = "did:peer:2.Vz6Muyi75snjJxpBzSheqWX7kD2W23kDxZqh5PKMNVEBV4M79.Ez6LbvHWzhVvS39kwtKnBqcEaEtJy6MSMJfEr5kv26S8n9rXi.SeyJzIjp7InVyaSI6InRzcDovLyJ9LCJ0IjoidHNwIn0";
+        let parts = legacy.split(':').collect::<Vec<&str>>();
+
+        assert!(verify_did_peer(&parts).is_err());
     }
 }

--- a/tsp_sdk/src/vid/mod.rs
+++ b/tsp_sdk/src/vid/mod.rs
@@ -22,7 +22,10 @@ pub mod resolve;
 pub use did::web::{create_did_web, vid_to_did_document};
 
 #[cfg(feature = "resolve")]
-pub use did::peer::{encode_did_peer, verify_did_peer};
+pub use did::peer::{
+    encode_did_peer, encode_did_peer_long_form, introduction_identifier, short_form,
+    verify_did_peer,
+};
 
 pub use error::VidError;
 use url::Url;


### PR DESCRIPTION
Moves nested and parallel VIDs to `did:peer` numalgo 4, and fixes a nested payload framing bug found on the way in.

## Numalgo 4, with the short form as identity

Numalgo 2 writes the keys straight into the identifier, so every message carried them in full — about 155 characters classically, 4.4 KB with post-quantum keys. Numalgo 4 splits the two jobs: the long form embeds the document so a peer who has never seen the VID can verify it, and the short form is a hash of that document, 57 characters whatever the keys are.

| | classical | PQ |
|---|---|---|
| numalgo 2 (before) | ~155 | ~4.4 KB |
| numalgo 4 long form | ~580 | ~4.5 KB |
| numalgo 4 short form | **57** | **57** |

The short form is the identity. The long form appears only where a VID is introduced — spec line 212, "exchanged once in long form and referenced thereafter" — which is the sender of a nested invite or accept, and the new VID inside a parallel referral. Which form applies is a property of the VID type, so a parallel VID that is a `did:webvh` is named by its identifier as before.

The derivation is checked against the method spec's own worked example rather than by round trip, since a round trip cannot catch a wrong multicodec or hash input.

Numalgo 2 is dropped rather than kept for transition — nothing persistent survives this branch's clean break.

## The nested control payload (first commit)

`crypto::sign` wraps its input in an `XSCS` application payload, and the nested paths handed it already-encoded `XRFI`/`XRFA` bytes. So the wire carried a payload inside a payload, where spec 9.4.13/9.4.14 require the control payload itself:

```
before:  -Z## XSCS 4BAA 4BAA -A## [ -Z## XRFI … ]
after:   -Z## XRFI …
```

Inherited from `5e7f036` (2026-03-30), which replaced the `XRNI`/`XRNA` nested types with plain RFI/RFA and reused the application-payload signer. It round-tripped because the receiver peeled whatever the sender wrapped, so the test decodes the payload and asserts its type.

## Consequences

- The ESSR sender field is checked against the **envelope** rather than the resolved VID's identifier — what the check's comment always claimed, and the only reading that works once the two differ. That left `sender` unused in both backends' open paths (HPKE-Base and the sealed box are both anonymous), so it is removed.
- The parallel accept introduces its VID as the sender of an *encrypted* envelope. The VID is wrapped rather than threading an override through both backends, which puts the right identifier in the envelope, the aad derived from it, and the ESSR field at once.
- **An unknown `did:peer` sender is now unresolvable by design** — a short form carries no document — so such a message is refused as an unverified source before its signature is considered. One existing test asserted the old behaviour and now asserts this.
- Naming a VID by either form finds it, since an operator is handed the long form while the wallet holds the short one. `tsp print` emits the introduction form; the CLI no longer re-verifies a parallel VID the SDK has already resolved and stored.

## Verification

Feature matrix (default, `nacl`, `pq`, no-default `async,resolve`), clippy `--all-features`, fmt, `wasm-pack test --node`, both binding suites built fresh, and the full `examples` suite including the parallel request/accept round trip over the CLI.