### PR TITLE
Key-state confirmation

### DIFF
--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -79,6 +79,37 @@ impl Default for KeyStatePolicy {
 struct KeyStateTracker {
     last_seen: HashMap<String, Instant>,
     last_resolved: HashMap<String, Instant>,
+    /// Peers whose key state this endpoint is not currently relying on, and
+    /// why. Spec 3.7: an endpoint suspends reliance when it cannot confirm a
+    /// peer's key state, or when what it obtains conflicts with what it holds
+    /// rather than extending it, and accepts no message under that key state —
+    /// including one that would otherwise verify — until it is confirmed.
+    unconfirmed: HashMap<String, KeyStateDoubt>,
+}
+
+/// Why an endpoint is not relying on a peer's key state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KeyStateDoubt {
+    /// The VID could not be resolved, so its current key state is unknown.
+    /// Spec 11.2 calls this common and usually transient.
+    Unconfirmed,
+    /// Resolution returned key state that replaces what was held rather than
+    /// continuing it. Spec 11.2 treats this as evidence of compromise.
+    Conflicting,
+}
+
+impl std::fmt::Display for KeyStateDoubt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeyStateDoubt::Unconfirmed => write!(f, "its key state could not be confirmed"),
+            KeyStateDoubt::Conflicting => {
+                write!(
+                    f,
+                    "the key state obtained conflicts with the key state held"
+                )
+            }
+        }
+    }
 }
 
 #[derive(Default, Clone)]
@@ -142,6 +173,30 @@ impl AsyncSecureStore {
         })
     }
 
+    /// Stop relying on this peer's key state until it can be confirmed
+    /// (spec 3.7). Returns the doubt, for reporting.
+    fn suspend_key_state(&self, vid: &str, doubt: KeyStateDoubt) -> Result<KeyStateDoubt, Error> {
+        debug!("suspending reliance on the key state of {vid}: {doubt}");
+        self.key_state
+            .write()?
+            .unconfirmed
+            .insert(vid.to_string(), doubt);
+
+        Ok(doubt)
+    }
+
+    /// Whether this endpoint is currently declining to rely on a peer's key
+    /// state; see [KeyStateDoubt]
+    pub fn key_state_doubt(&self, vid: &str) -> Result<Option<KeyStateDoubt>, Error> {
+        Ok(self.key_state.read()?.unconfirmed.get(vid).copied())
+    }
+
+    fn confirm_key_state(&self, vid: &str) -> Result<(), Error> {
+        self.key_state.write()?.unconfirmed.remove(vid);
+
+        Ok(())
+    }
+
     fn record_seen(&self, vid: &str) -> Result<(), Error> {
         self.key_state
             .write()?
@@ -149,6 +204,17 @@ impl AsyncSecureStore {
             .insert(vid.to_string(), Instant::now());
 
         Ok(())
+    }
+
+    /// Try to lift a suspension by resolving the peer again. Returns whether
+    /// the key state is now confirmed; a conflicting one leaves the suspension
+    /// in place, so this can only clear a suspension the peer has resolved.
+    async fn reconfirm_key_state(&self, vid: &str) -> Result<bool, Error> {
+        match self.refresh_key_state(vid).await {
+            Ok(true) => Ok(self.key_state_doubt(vid)?.is_none()),
+            // rate limited, or still unreachable
+            Ok(false) | Err(_) => Ok(false),
+        }
     }
 
     /// Re-resolve a peer's VID to refresh its key state, subject to the rate
@@ -283,7 +349,26 @@ impl AsyncSecureStore {
         let (verified_vid, metadata) = crate::vid::verify_vid_with_options(vid, options).await?;
 
         let verified_vid_id = verified_vid.identifier().to_string();
+
+        // key state that replaces what is held rather than continuing it is
+        // evidence of compromise, not a rotation to adopt (spec 3.7, 11.2);
+        // the held state is kept and reliance on it suspended
+        if let Ok(held) = self.inner.get_verified_vid(&verified_vid_id) {
+            let held_metadata = self.inner.metadata_for_vid(&verified_vid_id)?;
+            if !crate::vid::extends_held_key_state(
+                &*held,
+                held_metadata.as_ref(),
+                &verified_vid,
+                metadata.as_ref(),
+            ) {
+                self.suspend_key_state(&verified_vid_id, KeyStateDoubt::Conflicting)?;
+
+                return Err(Error::ConflictingKeyState(verified_vid_id));
+            }
+        }
+
         self.inner.add_verified_vid(verified_vid, metadata)?;
+        self.confirm_key_state(&verified_vid_id)?;
 
         // resolving is how key state is confirmed: this peer's state is fresh
         // as of now, for both of the policy's thresholds
@@ -928,21 +1013,41 @@ impl AsyncSecureStore {
             tracing::trace!("CESR-encoded message: {}", colored);
         }
 
-        // a peer that has been silent longer than the re-verification threshold
-        // may have rotated its keys unobserved; refresh its key state before
-        // acting on this message (spec 7.4.2)
         if let Ok((sender, _)) = crate::cesr::get_sender_receiver(&message)
             && let Ok(sender) = std::str::from_utf8(sender)
             && db.has_verified_vid(sender)?
-            && self.silent_beyond_threshold(sender)?
         {
-            debug!("re-resolving {sender} after silence");
-            if let Err(e) = self.refresh_key_state(sender).await {
-                // acting on a message whose key state could not be confirmed is
-                // exactly what the rule forbids
-                debug!("could not confirm the key state of {sender}: {e}");
+            // reliance on this peer's key state is suspended until it can be
+            // confirmed, and no message is accepted under it in the meantime —
+            // including one that would otherwise verify (spec 3.7)
+            if let Some(doubt) = self.key_state_doubt(sender)?
+                && !self.reconfirm_key_state(sender).await?
+            {
+                return Err(Error::UnconfirmedKeyState(
+                    sender.to_string(),
+                    doubt.to_string(),
+                ));
+            }
 
-                return Err(e);
+            // a peer that has been silent longer than the re-verification
+            // threshold may have rotated its keys unobserved; refresh its key
+            // state before acting on this message (spec 7.4.2)
+            if self.silent_beyond_threshold(sender)? {
+                debug!("re-resolving {sender} after silence");
+                match self.refresh_key_state(sender).await {
+                    // acting on a message whose key state could not be
+                    // confirmed is exactly what the rule forbids, and a
+                    // resolution the rate limit declined is not a confirmation
+                    Ok(false) | Err(_) => {
+                        let doubt = self.suspend_key_state(sender, KeyStateDoubt::Unconfirmed)?;
+
+                        return Err(Error::UnconfirmedKeyState(
+                            sender.to_string(),
+                            doubt.to_string(),
+                        ));
+                    }
+                    Ok(true) => {}
+                }
             }
         }
 
@@ -1097,6 +1202,65 @@ mod tests {
             })
             .unwrap();
         assert!(!store.silent_beyond_threshold("did:test:alice").unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_message_is_not_acted_on_while_key_state_is_suspended() {
+        // Spec 3.7: while an endpoint cannot confirm a peer's key state it
+        // accepts no message under that key state, including one that would
+        // otherwise verify.
+        let alice = crate::OwnedVid::new_did_peer("tcp://127.0.0.1:1337".parse().unwrap());
+        let bob = crate::OwnedVid::new_did_peer("tcp://127.0.0.1:1338".parse().unwrap());
+
+        let a_store = AsyncSecureStore::new();
+        a_store.add_private_vid(alice.clone(), None).unwrap();
+        a_store.add_verified_vid(bob.vid().clone(), None).unwrap();
+
+        let b_store = AsyncSecureStore::new();
+        b_store.add_private_vid(bob.clone(), None).unwrap();
+        b_store.add_verified_vid(alice.vid().clone(), None).unwrap();
+        for store in [&a_store, &b_store] {
+            store
+                .as_store()
+                .set_relationship_policy(crate::store::RelationshipPolicy::Ungated)
+                .unwrap();
+        }
+
+        let (_url, sealed) = a_store
+            .as_store()
+            .seal_message(alice.identifier(), bob.identifier(), b"hello")
+            .unwrap();
+
+        // it opens while the key state is not in doubt
+        let opened = b_store
+            .open_incoming(b_store.as_store(), BytesMut::from(&sealed[..]))
+            .await;
+        assert!(opened.is_ok(), "a message opens normally: {opened:?}");
+
+        // suspend, and the same message is no longer acted on
+        b_store
+            .suspend_key_state(alice.identifier(), KeyStateDoubt::Conflicting)
+            .unwrap();
+        assert_eq!(
+            b_store.key_state_doubt(alice.identifier()).unwrap(),
+            Some(KeyStateDoubt::Conflicting)
+        );
+        let refused = b_store
+            .open_incoming(b_store.as_store(), BytesMut::from(&sealed[..]))
+            .await;
+        assert!(
+            matches!(refused, Err(Error::UnconfirmedKeyState(..))),
+            "a suspended key state refuses a message that would verify: {refused:?}"
+        );
+
+        // and once confirmed it opens again
+        b_store.confirm_key_state(alice.identifier()).unwrap();
+        assert!(
+            b_store
+                .open_incoming(b_store.as_store(), BytesMut::from(&sealed[..]))
+                .await
+                .is_ok()
+        );
     }
 
     #[test]

--- a/tsp_sdk/src/error.rs
+++ b/tsp_sdk/src/error.rs
@@ -45,6 +45,12 @@ pub enum Error {
     MissingDropOff(String),
     #[error("Error: no relationship from {0} to {1}; the message is dropped")]
     UnestablishedRelationship(String, String),
+    #[error(
+        "Error: the key state obtained for {0} conflicts with the key state held; reliance on it is suspended"
+    )]
+    ConflictingKeyState(String),
+    #[error("Error: not acting on a message from {0}: {1}")]
+    UnconfirmedKeyState(String, String),
     #[error("Internal error")]
     Internal,
 }

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -554,6 +554,18 @@ impl SecureStore {
         }
     }
 
+    /// The metadata stored alongside a VID when it was last resolved, which is
+    /// what a later resolution is compared against (spec 3.7)
+    pub fn metadata_for_vid(&self, vid: &str) -> Result<Option<serde_json::Value>, Error> {
+        let vid = self.try_resolve_alias(vid)?;
+
+        Ok(self
+            .vids
+            .read()?
+            .get(&vid)
+            .and_then(|context| context.metadata.clone()))
+    }
+
     /// List all VIDs in the wallet
     pub fn list_vids(&self) -> Result<Vec<String>, Error> {
         Ok(self.vids.read()?.keys().cloned().collect())

--- a/tsp_sdk/src/vid/did/web.rs
+++ b/tsp_sdk/src/vid/did/web.rs
@@ -1,3 +1,18 @@
+//! `did:web`, retained for testing and demonstration.
+//!
+//! **This is not a VID type the specification considers suitable.** Spec 2.2
+//! lists KERI AIDs, `did:webs`, `did:webvh`, `did:peer` and `urn:said`, and
+//! spec 2 requires a VID's key state to be verifiable. A `did:web` publishes a
+//! document with no history, so a verifier has no way to tell a rotation from a
+//! substitution — it is classified [`Unprovenanced`] for exactly that reason,
+//! and an endpoint will not confirm a change to one.
+//!
+//! It stays because it is the simplest illustration of what resolving a VID
+//! means, one request for one document, and because the demo servers use it.
+//! New deployments should use `did:webvh`.
+//!
+//! [`Unprovenanced`]: crate::vid::KeyStateProvenance::Unprovenanced
+
 use crate::definitions::{VerifiedVid, VidEncryptionKeyType, VidSignatureKeyType};
 use base64ct::{Base64UrlUnpadded, Encoding};
 use serde::{Deserialize, Serialize};

--- a/tsp_sdk/src/vid/key_state.rs
+++ b/tsp_sdk/src/vid/key_state.rs
@@ -1,0 +1,216 @@
+//! Telling a key-state change from a substitution.
+//!
+//! Spec 3.7 requires an endpoint not to act on a message when it cannot
+//! confirm the sending VID's key state, or when the state it obtains
+//! "conflicts with the key state it holds rather than extending it". Whether
+//! that distinction can be drawn at all depends on what the VID's resolution
+//! returns, which is what [`KeyStateProvenance`] classifies.
+
+use crate::definitions::VerifiedVid;
+
+/// What an endpoint can learn about a VID's key state when it resolves it.
+///
+/// Spec 7.4.2 notes that whether an endpoint resolves key state for itself is
+/// a property of the deployment rather than of the VID type. This is the other
+/// half of the question, and is a property of the type: given that we did
+/// resolve, can the result be checked against what we already held?
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KeyStateProvenance {
+    /// The identifier is derived from the key state, so the key state cannot
+    /// change: a different document is a different VID. `did:peer`.
+    SelfCertifying,
+    /// Resolution returns a verifiable history, so an obtained state can be
+    /// checked to continue the held one. `did:webvh`, `did:scid`.
+    Provenanced,
+    /// Resolution returns current key state and no history, so a rotation and
+    /// a substitution look the same. `did:web`.
+    ///
+    /// A VID of this kind cannot satisfy the requirement in spec 2 that a VID's
+    /// key state be verifiable, which is why `did:web` is not among the types
+    /// the specification lists as suitable (spec 2.2). It is retained for
+    /// testing and demonstration.
+    Unprovenanced,
+}
+
+/// Classify a VID by what its resolution can tell us; see [`KeyStateProvenance`].
+pub fn key_state_provenance(vid: &str) -> KeyStateProvenance {
+    if vid.starts_with("did:peer:") {
+        KeyStateProvenance::SelfCertifying
+    } else if vid.starts_with("did:webvh:") || vid.starts_with("did:scid:") {
+        KeyStateProvenance::Provenanced
+    } else {
+        KeyStateProvenance::Unprovenanced
+    }
+}
+
+/// The leading integer of a `did:webvh` version id, which is of the form
+/// `<version number>-<entry hash>`.
+fn version_number(metadata: Option<&serde_json::Value>) -> Option<u64> {
+    metadata?["webvh_meta_data"]["versionId"]
+        .as_str()?
+        .split('-')
+        .next()?
+        .parse()
+        .ok()
+}
+
+fn scid(metadata: Option<&serde_json::Value>) -> Option<&str> {
+    metadata?["webvh_meta_data"]["scid"].as_str()
+}
+
+/// Whether newly resolved key state continues the state already held, rather
+/// than replacing it (spec 3.7).
+///
+/// A `false` here is not "the peer rotated"; it is "this endpoint cannot tell
+/// a rotation from a substitution", which spec 11.2 calls evidence of
+/// compromise rather than an error to be resolved by choosing one.
+pub fn extends_held_key_state(
+    held: &dyn VerifiedVid,
+    held_metadata: Option<&serde_json::Value>,
+    obtained: &dyn VerifiedVid,
+    obtained_metadata: Option<&serde_json::Value>,
+) -> bool {
+    match key_state_provenance(held.identifier()) {
+        // the keys are what the identifier is derived from, so resolving the
+        // same identifier cannot yield different keys
+        KeyStateProvenance::SelfCertifying => true,
+
+        // the history has to be the same history, and cannot go backwards
+        KeyStateProvenance::Provenanced => {
+            match (
+                scid(held_metadata),
+                scid(obtained_metadata),
+                version_number(held_metadata),
+                version_number(obtained_metadata),
+            ) {
+                (
+                    Some(held_scid),
+                    Some(obtained_scid),
+                    Some(held_version),
+                    Some(obtained_version),
+                ) => held_scid == obtained_scid && obtained_version >= held_version,
+                // without both histories there is nothing to compare, and an
+                // unverifiable claim about key state is not a confirmation
+                _ => false,
+            }
+        }
+
+        // nothing distinguishes a rotation from a substitution, so only an
+        // unchanged key state is a confirmation
+        KeyStateProvenance::Unprovenanced => {
+            held.verifying_key().as_ref() == obtained.verifying_key().as_ref()
+                && held.encryption_key().as_ref() == obtained.encryption_key().as_ref()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    fn webvh_metadata(scid: &str, version: u64) -> serde_json::Value {
+        json!({"webvh_meta_data": {"scid": scid, "versionId": format!("{version}-QmHash")}})
+    }
+
+    #[test]
+    fn classifies_by_what_resolution_returns() {
+        assert_eq!(
+            key_state_provenance("did:peer:4zQmHash"),
+            KeyStateProvenance::SelfCertifying
+        );
+        assert_eq!(
+            key_state_provenance("did:webvh:QmScid:example.com"),
+            KeyStateProvenance::Provenanced
+        );
+        assert_eq!(
+            key_state_provenance("did:web:example.com:user"),
+            KeyStateProvenance::Unprovenanced
+        );
+    }
+
+    fn vid(id: &str, key: u8) -> crate::vid::Vid {
+        crate::vid::Vid {
+            id: id.to_string(),
+            transport: url::Url::parse("tcp://127.0.0.1:1337").unwrap(),
+            sig_key_type: crate::definitions::VidSignatureKeyType::Ed25519,
+            public_sigkey: vec![key; 32].into(),
+            enc_key_type: crate::definitions::VidEncryptionKeyType::X25519,
+            public_enckey: vec![key; 32].into(),
+        }
+    }
+
+    #[test]
+    fn a_self_certifying_vid_cannot_change_its_key_state() {
+        // the identifier is derived from the document, so resolving the same
+        // identifier cannot produce different keys; nothing needs comparing
+        let held = vid("did:peer:4zQmHash", 1);
+        let obtained = vid("did:peer:4zQmHash", 1);
+
+        assert!(extends_held_key_state(&held, None, &obtained, None));
+    }
+
+    #[test]
+    fn a_history_must_continue_and_must_not_go_backwards() {
+        let held = vid("did:webvh:QmScid:example.com", 1);
+        let obtained = vid("did:webvh:QmScid:example.com", 2);
+        let at = |scid, version| Some(webvh_metadata(scid, version));
+
+        // the same history moving forward is a rotation
+        assert!(extends_held_key_state(
+            &held,
+            at("QmScid", 3).as_ref(),
+            &obtained,
+            at("QmScid", 4).as_ref()
+        ));
+        // the same version is the state we already hold
+        assert!(extends_held_key_state(
+            &held,
+            at("QmScid", 3).as_ref(),
+            &obtained,
+            at("QmScid", 3).as_ref()
+        ));
+
+        // a history that goes backwards is not an extension of this one
+        assert!(!extends_held_key_state(
+            &held,
+            at("QmScid", 4).as_ref(),
+            &obtained,
+            at("QmScid", 3).as_ref()
+        ));
+        // nor is a different history, however current it claims to be
+        assert!(!extends_held_key_state(
+            &held,
+            at("QmScid", 3).as_ref(),
+            &obtained,
+            at("QmOther", 9).as_ref()
+        ));
+        // and an absent history confirms nothing
+        assert!(!extends_held_key_state(
+            &held,
+            at("QmScid", 3).as_ref(),
+            &obtained,
+            None
+        ));
+    }
+
+    #[test]
+    fn without_a_history_only_an_unchanged_key_state_is_confirmation() {
+        // did:web resolution returns the current document and nothing else, so
+        // a rotation and a substitution are the same observation
+        let held = vid("did:web:example.com:user", 1);
+
+        assert!(extends_held_key_state(
+            &held,
+            None,
+            &vid("did:web:example.com:user", 1),
+            None
+        ));
+        assert!(!extends_held_key_state(
+            &held,
+            None,
+            &vid("did:web:example.com:user", 2),
+            None
+        ));
+    }
+}

--- a/tsp_sdk/src/vid/mod.rs
+++ b/tsp_sdk/src/vid/mod.rs
@@ -16,6 +16,8 @@ pub mod did;
 
 pub mod error;
 
+pub mod key_state;
+
 pub mod resolve;
 
 #[cfg(feature = "resolve")]
@@ -28,6 +30,8 @@ pub use did::peer::{
 };
 
 pub use error::VidError;
+
+pub use key_state::{KeyStateProvenance, extends_held_key_state, key_state_provenance};
 use url::Url;
 
 use crate::definitions::{VidEncryptionKeyType, VidSignatureKeyType};


### PR DESCRIPTION
Closes the one rule PR 3 left open: spec 3.7's requirement not to act on a message when the sender's key state can't be confirmed, or when what we resolve replaces what we hold rather than continuing it.

PR 3 built the three rules around re-resolution and stopped here, because this one needs a question those don't ask — given that we resolved, can the result be checked against what we already held? That's a property of the VID type:

| | resolution returns | a change is |
|---|---|---|
| `did:peer` | nothing to resolve — identifier is derived from the document | impossible |
| `did:webvh`, `did:scid` | a verifiable history | checkable: same SCID, version not going backwards |
| `did:web` | the current document, no history | indistinguishable from a substitution |

Resolution now compares obtained against held. A conflict keeps the held state and suspends reliance on the peer rather than adopting it — spec 11.2 treats a conflicting history as evidence of compromise, not something to settle by picking one. Receiving suspends too when a peer silent past the re-verification threshold can't be resolved, including when the rate limit declines the attempt; that previously fell through and the message was acted on.

A suspension lifts when the peer resolves to a state that does extend the held one. Retaining suspended messages for later is a MAY and isn't implemented — they're discarded like anything else that can't be acted on.

## did:web

The classification makes explicit what was already true: `did:web` can't satisfy spec 2's requirement that key state be verifiable, which is why spec 2.2 doesn't list it among suitable VID types. It's now documented as retained for testing and the demo servers. One consequence worth knowing: **a `did:web` rotation can no longer be adopted**, since nothing distinguishes it from a substitution.

The CLI walkthroughs still use `did:web` — moving those to `did:webvh` is left to PR 5, where the docs are swept and the wire dumps regenerated, rather than editing them twice.

## Verification

Feature matrix (default, `nacl`, `pq`, no-default `async,resolve`), clippy `--all-features`, fmt, wasm, both binding suites, the full `examples` suite, and the guardrail bench builds.