### PR TITLE
Surface XCTL, XPAD and caller-supplied padding

### DIFF
--- a/docs/src/cesr.md
+++ b/docs/src/cesr.md
@@ -146,6 +146,22 @@ routed message names the intermediaries it travels through. Either way the inner
 message is a complete TSP message, opaque to everyone but its own recipient — not to
 the intermediary that forwards it, nor to the endpoints of the enclosing relationship.
 
+`XSCS` and `XCTL` are the same shape and TSP treats them identically: it carries both
+opaquely and interprets neither. Two codes exist so that an upper layer can tell its
+control plane from its data plane without reserving part of its own format to say
+which is which. Send one with `--kind control`; it arrives as
+`ReceivedTspMessage::ControlMessage` rather than `GenericMessage`.
+
+`XPAD` carries nothing at all. It exists so that an observer counting or timing
+messages sees some that mean nothing. The receiver discards it — "silently", which
+constrains what goes back on the wire, not whether the application is told. Send one
+with `--kind padding`, and give it `--padding` bytes to choose its size.
+
+The padding field is not exclusive to `XPAD`: every payload layout carries one, and
+any message may use it to hide how long its real content is. It is excluded from the
+SAID digest, so padding a message does not change its thread id (spec 7.2.1). Pass
+`--padding N` to `send`, or `SendOptions::padding` through the SDK.
+
 Reading a message
 -----------------
 

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tsp_sdk::{
     Aliases, AskarSecureStorage, AsyncSecureStore, Error, ExportVid, OwnedVid,
     ReceivedRelationshipDelivery, ReceivedRelationshipForm, ReceivedTspMessage, RelationshipStatus,
-    SecureStorage, VerifiedVid, Vid, cesr,
+    SecureStorage, SendOptions, VerifiedVid, Vid, cesr,
     crypto::PayloadConfidentiality,
     definitions::Digest,
     vid::{
@@ -49,6 +49,24 @@ impl FromStr for DidType {
             "scid" => Ok(DidType::Scid),
             _ => Err(format!("invalid did type: {s}")),
         }
+    }
+}
+
+/// Which payload type `send` puts on the wire.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+enum PayloadKind {
+    #[default]
+    Message,
+    Control,
+    Padding,
+}
+
+fn parse_payload_kind(value: &str) -> Result<PayloadKind, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "message" | "generic" | "xscs" => Ok(PayloadKind::Message),
+        "control" | "ctl" | "xctl" => Ok(PayloadKind::Control),
+        "padding" | "pad" | "xpad" => Ok(PayloadKind::Padding),
+        _ => Err(format!("invalid payload kind: {value}")),
     }
 }
 
@@ -184,6 +202,20 @@ enum Commands {
             help = "Override outbound crypto: hpke (hpke-base), or sealed-box (nacl)"
         )]
         crypto: Option<cesr::CryptoType>,
+        #[arg(
+            long,
+            value_parser = parse_payload_kind,
+            help = "What kind of payload to send: message (XSCS, the default), control (XCTL, \
+                    the upper layer's own control plane), or padding (XPAD, which carries \
+                    nothing and exists to be counted by an observer)"
+        )]
+        kind: Option<PayloadKind>,
+        #[arg(
+            long,
+            help = "Bytes of padding to carry in the payload's padding field, for hiding how \
+                    long the real content is. Excluded from the message's thread id."
+        )]
+        padding: Option<usize>,
         #[arg(
             long,
             value_parser = parse_confidentiality,
@@ -1079,6 +1111,8 @@ async fn run() -> Result<(), Error> {
             ask,
             crypto,
             confidentiality,
+            kind,
+            padding,
         } => {
             let receiver_vid = vid_wallet.try_resolve_alias(&receiver_vid)?;
 
@@ -1090,19 +1124,36 @@ async fn run() -> Result<(), Error> {
                 .await
                 .expect("Could not read message from stdin");
 
-            let send_result = match (crypto, confidentiality) {
-                // the plain path keeps the relationship-forming behaviour of
-                // `send`, which the explicit ones reproduce
-                (None, None) => vid_wallet.send(&sender_vid, &receiver_vid, &message).await,
-                (crypto_type, confidentiality) => {
+            // padding is given as a length; its content carries no meaning, so
+            // zeros are as good as anything and cost nothing to generate
+            let padding = padding.map(|len| vec![0_u8; len]);
+            let options = SendOptions {
+                crypto_type: crypto,
+                confidentiality: confidentiality.unwrap_or_default(),
+                padding: padding.as_deref(),
+            };
+
+            let send_result = match kind.unwrap_or_default() {
+                PayloadKind::Control => {
                     vid_wallet
-                        .send_with(
-                            &sender_vid,
-                            &receiver_vid,
-                            &message,
-                            crypto_type,
-                            confidentiality.unwrap_or_default(),
-                        )
+                        .send_control_message(&sender_vid, &receiver_vid, &message, options)
+                        .await
+                }
+                PayloadKind::Padding => {
+                    vid_wallet
+                        .send_padding_message(&sender_vid, &receiver_vid, options)
+                        .await
+                }
+                // the plain path keeps the relationship-forming behaviour of
+                // `send`, which the explicit one reproduces
+                PayloadKind::Message
+                    if crypto.is_none() && confidentiality.is_none() && padding.is_none() =>
+                {
+                    vid_wallet.send(&sender_vid, &receiver_vid, &message).await
+                }
+                PayloadKind::Message => {
+                    vid_wallet
+                        .send_with(&sender_vid, &receiver_vid, &message, options)
                         .await
                 }
             };
@@ -1154,6 +1205,19 @@ async fn run() -> Result<(), Error> {
                 };
                 let handle_message = |message: ReceivedTspMessage| {
                     match message {
+                        ReceivedTspMessage::ControlMessage {
+                            sender, message, ..
+                        } => {
+                            info!(
+                                "received upper-layer control message ({} bytes) from {sender}",
+                                message.len()
+                            );
+                            println!("{}", String::from_utf8_lossy(&message));
+                        }
+                        // it carries nothing; saying so is the whole report
+                        ReceivedTspMessage::PaddingMessage { sender, .. } => {
+                            info!("received padding message from {sender}, discarding");
+                        }
                         ReceivedTspMessage::GenericMessage {
                             sender,
                             receiver: _,
@@ -1505,6 +1569,12 @@ async fn run() -> Result<(), Error> {
                     match message {
                         ReceivedTspMessage::GenericMessage { sender, .. } => {
                             info!("received generic message from {sender}")
+                        }
+                        ReceivedTspMessage::ControlMessage { sender, .. } => {
+                            info!("received upper-layer control message from {sender}")
+                        }
+                        ReceivedTspMessage::PaddingMessage { sender, .. } => {
+                            info!("received padding message from {sender}, discarding")
                         }
                         ReceivedTspMessage::RequestRelationship { sender, .. } => {
                             info!("received relationship request from {sender}")

--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -520,6 +520,14 @@ async fn new_message(
         Ok(ReceivedTspMessage::GenericMessage { sender, .. }) => {
             tracing::error!("received generic message from {sender}")
         }
+        Ok(ReceivedTspMessage::ControlMessage { sender, .. }) => {
+            tracing::error!("received an upper-layer control message from {sender}")
+        }
+        // padding exists to be ignored; an intermediary is not its destination
+        // and there is nothing in it to forward
+        Ok(ReceivedTspMessage::PaddingMessage { sender, .. }) => {
+            tracing::debug!("discarding a padding message from {sender}")
+        }
         Ok(ReceivedTspMessage::RequestRelationship {
             sender,
             receiver: _,

--- a/tsp_javascript/src/lib.rs
+++ b/tsp_javascript/src/lib.rs
@@ -435,6 +435,9 @@ pub enum ReceivedTspMessageVariant {
     CancelRelationship = 3,
     ForwardRequest = 4,
     PendingMessage = 5,
+    // appended: the numbers above are matched by value in tsp_node
+    ControlMessage = 6,
+    PaddingMessage = 7,
 }
 
 impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
@@ -450,6 +453,8 @@ impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
             tsp_sdk::ReceivedTspMessage::AcceptRelationship { .. } => Self::AcceptRelationship,
             tsp_sdk::ReceivedTspMessage::CancelRelationship { .. } => Self::CancelRelationship,
             tsp_sdk::ReceivedTspMessage::ForwardRequest { .. } => Self::ForwardRequest,
+            tsp_sdk::ReceivedTspMessage::ControlMessage { .. } => Self::ControlMessage,
+            tsp_sdk::ReceivedTspMessage::PaddingMessage { .. } => Self::PaddingMessage,
             _ => unreachable!("pending messages are handled before variant flattening"),
         }
     }
@@ -654,6 +659,14 @@ fn flatten_relationship_delivery(
     }
 }
 
+fn signature_type(signature_type: tsp_sdk::cesr::SignatureType) -> SignatureType {
+    match signature_type {
+        tsp_sdk::cesr::SignatureType::NoSignature => SignatureType::NoSignature,
+        tsp_sdk::cesr::SignatureType::Ed25519 => SignatureType::Ed25519,
+        tsp_sdk::cesr::SignatureType::MlDsa65 => SignatureType::MlDsa65,
+    }
+}
+
 fn crypto_type(crypto_type: tsp_sdk::cesr::CryptoType) -> CryptoType {
     match crypto_type {
         tsp_sdk::cesr::CryptoType::Plaintext => CryptoType::Plaintext,
@@ -696,6 +709,23 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
 
         #[allow(unreachable_patterns)]
         match value {
+            tsp_sdk::ReceivedTspMessage::ControlMessage {
+                sender,
+                receiver,
+                message,
+                message_type,
+            } => {
+                this.sender = Some(sender);
+                this.receiver = receiver;
+                this.message = Some(message.into());
+                this.crypto_type = Some(crypto_type(message_type.crypto_type));
+                this.enclosing_crypto_type = message_type.enclosing_crypto_type.map(crypto_type);
+                this.signature_type = Some(signature_type(message_type.signature_type));
+            }
+            tsp_sdk::ReceivedTspMessage::PaddingMessage { sender, receiver } => {
+                this.sender = Some(sender);
+                this.receiver = receiver;
+            }
             tsp_sdk::ReceivedTspMessage::GenericMessage {
                 sender,
                 receiver,
@@ -707,11 +737,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.message = Some(message.into());
                 this.crypto_type = Some(crypto_type(message_type.crypto_type));
                 this.enclosing_crypto_type = message_type.enclosing_crypto_type.map(crypto_type);
-                this.signature_type = match message_type.signature_type {
-                    tsp_sdk::cesr::SignatureType::NoSignature => Some(SignatureType::NoSignature),
-                    tsp_sdk::cesr::SignatureType::Ed25519 => Some(SignatureType::Ed25519),
-                    tsp_sdk::cesr::SignatureType::MlDsa65 => Some(SignatureType::MlDsa65),
-                };
+                this.signature_type = Some(signature_type(message_type.signature_type));
             }
             tsp_sdk::ReceivedTspMessage::RequestRelationship {
                 sender,

--- a/tsp_node/tsp.js
+++ b/tsp_node/tsp.js
@@ -161,6 +161,19 @@ class ReceivedTspMessage {
                     msg.opaque_payload,
                 );
 
+            case 6:
+                return new ControlMessage(
+                    msg.sender,
+                    msg.receiver,
+                    new Uint8Array(msg.message),
+                    msg.crypto_type,
+                    msg.signature_type,
+                    msg.enclosing_crypto_type
+                );
+
+            case 7:
+                return new PaddingMessage(msg.sender, msg.receiver);
+
             case 5: 
                 throw new Error("todo!");
 
@@ -184,6 +197,21 @@ class GenericMessage extends ReceivedTspMessage {
         this.crypto_type = crypto_type;
         this.signature_type = signature_type;
         this.enclosing_crypto_type = enclosing_crypto_type;
+    }
+}
+
+// An upper layer's own control payload (XCTL). Carried opaquely, exactly as a
+// GenericMessage is; the separate class exists so an upper layer can route its
+// control plane separately from its data plane.
+class ControlMessage extends GenericMessage {}
+
+// A padding message (XPAD). It carries nothing — it exists so that traffic
+// analysis sees messages that mean nothing. Discard it.
+class PaddingMessage extends ReceivedTspMessage {
+    constructor(sender, receiver) {
+        super();
+        this.sender = sender;
+        this.receiver = receiver;
     }
 }
 
@@ -245,6 +273,8 @@ module.exports = {
     Vid,
     ReceivedTspMessage,
     GenericMessage,
+    ControlMessage,
+    PaddingMessage,
     AcceptRelationship,
     CancelRelationship,
     RequestRelationship,

--- a/tsp_python/src/lib.rs
+++ b/tsp_python/src/lib.rs
@@ -406,6 +406,9 @@ enum ReceivedTspMessageVariant {
     CancelRelationship,
     ForwardRequest,
     PendingMessage,
+    // appended: the discriminants above are matched by number in tsp_node
+    ControlMessage,
+    PaddingMessage,
 }
 
 impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
@@ -417,6 +420,8 @@ impl From<&tsp_sdk::ReceivedTspMessage> for ReceivedTspMessageVariant {
             tsp_sdk::ReceivedTspMessage::CancelRelationship { .. } => Self::CancelRelationship,
             tsp_sdk::ReceivedTspMessage::ForwardRequest { .. } => Self::ForwardRequest,
             tsp_sdk::ReceivedTspMessage::PendingMessage { .. } => Self::PendingMessage,
+            tsp_sdk::ReceivedTspMessage::ControlMessage { .. } => Self::ControlMessage,
+            tsp_sdk::ReceivedTspMessage::PaddingMessage { .. } => Self::PaddingMessage,
         }
     }
 }
@@ -552,6 +557,14 @@ fn flatten_relationship_delivery(
     }
 }
 
+fn signature_type(signature_type: tsp_sdk::cesr::SignatureType) -> SignatureType {
+    match signature_type {
+        tsp_sdk::cesr::SignatureType::NoSignature => SignatureType::NoSignature,
+        tsp_sdk::cesr::SignatureType::Ed25519 => SignatureType::Ed25519,
+        tsp_sdk::cesr::SignatureType::MlDsa65 => SignatureType::MlDsa65,
+    }
+}
+
 fn crypto_type(crypto_type: tsp_sdk::cesr::CryptoType) -> CryptoType {
     match crypto_type {
         tsp_sdk::cesr::CryptoType::Plaintext => CryptoType::Plaintext,
@@ -587,6 +600,23 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
         };
 
         match value {
+            tsp_sdk::ReceivedTspMessage::ControlMessage {
+                sender,
+                receiver,
+                message,
+                message_type,
+            } => {
+                this.sender = Some(sender);
+                this.receiver = receiver;
+                this.message = Some(message.into());
+                this.crypto_type = Some(crypto_type(message_type.crypto_type));
+                this.enclosing_crypto_type = message_type.enclosing_crypto_type.map(crypto_type);
+                this.signature_type = Some(signature_type(message_type.signature_type));
+            }
+            tsp_sdk::ReceivedTspMessage::PaddingMessage { sender, receiver } => {
+                this.sender = Some(sender);
+                this.receiver = receiver;
+            }
             tsp_sdk::ReceivedTspMessage::GenericMessage {
                 sender,
                 receiver,
@@ -598,11 +628,7 @@ impl From<tsp_sdk::ReceivedTspMessage> for FlatReceivedTspMessage {
                 this.message = Some(message.into());
                 this.crypto_type = Some(crypto_type(message_type.crypto_type));
                 this.enclosing_crypto_type = message_type.enclosing_crypto_type.map(crypto_type);
-                this.signature_type = match message_type.signature_type {
-                    tsp_sdk::cesr::SignatureType::NoSignature => Some(SignatureType::NoSignature),
-                    tsp_sdk::cesr::SignatureType::Ed25519 => Some(SignatureType::Ed25519),
-                    tsp_sdk::cesr::SignatureType::MlDsa65 => Some(SignatureType::MlDsa65),
-                };
+                this.signature_type = Some(signature_type(message_type.signature_type));
             }
             tsp_sdk::ReceivedTspMessage::RequestRelationship {
                 sender,

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -566,8 +566,16 @@ impl AsyncSecureStore {
         message: &[u8],
         confidentiality: crate::crypto::PayloadConfidentiality,
     ) -> Result<(), Error> {
-        self.send_with(sender, receiver, message, None, confidentiality)
-            .await
+        self.send_with(
+            sender,
+            receiver,
+            message,
+            crate::SendOptions {
+                confidentiality,
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     /// Send a message, choosing both the cipher suite and how the payload
@@ -577,9 +585,59 @@ impl AsyncSecureStore {
         sender: &str,
         receiver: &str,
         message: &[u8],
-        crypto_type: Option<CryptoType>,
-        confidentiality: crate::crypto::PayloadConfidentiality,
+        options: crate::SendOptions<'_>,
     ) -> Result<(), Error> {
+        self.form_relationship_if_needed(sender, receiver).await?;
+        let (endpoint, message) = self
+            .inner
+            .seal_message_with(sender, receiver, message, options)?;
+
+        tracing::info!("sending message to {endpoint}");
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
+    /// Send an upper layer's own control payload (`XCTL`); see
+    /// [`SecureStore::seal_control_message`].
+    pub async fn send_control_message(
+        &self,
+        sender: &str,
+        receiver: &str,
+        message: &[u8],
+        options: crate::SendOptions<'_>,
+    ) -> Result<(), Error> {
+        self.form_relationship_if_needed(sender, receiver).await?;
+        let (endpoint, message) = self
+            .inner
+            .seal_control_message(sender, receiver, message, options)?;
+
+        tracing::info!("sending control message to {endpoint}");
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
+    /// Send a padding message (`XPAD`), which carries nothing; see
+    /// [`SecureStore::seal_padding_message`].
+    pub async fn send_padding_message(
+        &self,
+        sender: &str,
+        receiver: &str,
+        options: crate::SendOptions<'_>,
+    ) -> Result<(), Error> {
+        self.form_relationship_if_needed(sender, receiver).await?;
+        let (endpoint, message) = self.inner.seal_padding_message(sender, receiver, options)?;
+
+        tracing::info!("sending padding message to {endpoint}");
+        crate::transport::send_message(&endpoint, &message).await?;
+
+        Ok(())
+    }
+
+    /// The first message of a relationship must carry the relationship-forming
+    /// fields (spec 3.6), so form the relationship first when there is none.
+    async fn form_relationship_if_needed(&self, sender: &str, receiver: &str) -> Result<(), Error> {
         match self.inner.relation_status_for_vid_pair(sender, receiver) {
             Ok(relation) => {
                 if matches!(relation, RelationshipStatus::Unrelated) {
@@ -592,19 +650,7 @@ impl AsyncSecureStore {
                     .await?
             }
             Err(e) => return Err(e),
-        };
-
-        let (endpoint, message) = self.inner.seal_message_with(
-            sender,
-            receiver,
-            message,
-            crypto_type,
-            confidentiality,
-        )?;
-
-        tracing::info!("sending message to {endpoint}");
-
-        crate::transport::send_message(&endpoint, &message).await?;
+        }
 
         Ok(())
     }

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -31,7 +31,7 @@ pub(crate) struct ParallelSignatureInfo<'a> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct OutboundCryptoSelection {
+pub(crate) struct OutboundCryptoSelection<'a> {
     pub crypto_type: CryptoType,
     /// Whether to carry the sender's VID in the ESSR field of the confidential
     /// payload under HPKE-Base, where the specification makes it optional
@@ -41,9 +41,13 @@ pub(crate) struct OutboundCryptoSelection {
     /// How an upper layer's own payload is protected. TSP's control messages
     /// ignore this and are always encrypted.
     pub confidentiality: PayloadConfidentiality,
+    /// Bytes for the payload's padding field, which every payload layout
+    /// carries and which is excluded from the SAID digest (spec 7.2.1). `None`
+    /// encodes the empty field `4BAA`, which is what "no padding" means.
+    pub padding: Option<&'a [u8]>,
 }
 
-impl OutboundCryptoSelection {
+impl OutboundCryptoSelection<'_> {
     /// What this selection puts in the payload's ESSR sender field.
     ///
     /// The seal path and anything that has to agree with it — the parallel
@@ -146,7 +150,7 @@ impl RelationshipDigestAlgorithm {
 pub(crate) fn default_outbound_crypto_selection(
     sender: &dyn VerifiedVid,
     receiver: &dyn VerifiedVid,
-) -> OutboundCryptoSelection {
+) -> OutboundCryptoSelection<'static> {
     let _ = (sender, receiver);
 
     OutboundCryptoSelection {
@@ -155,6 +159,7 @@ pub(crate) fn default_outbound_crypto_selection(
         crypto_type: CryptoType::HpkeBase,
         essr_sender: EssrSender::default(),
         confidentiality: PayloadConfidentiality::default(),
+        padding: None,
     }
 }
 
@@ -378,6 +383,89 @@ pub(crate) fn verify_relationship_digest(
     Ok(())
 }
 
+/// Turn a decoded CESR payload into the SDK's own payload type.
+///
+/// Both confidential backends decode to the same shapes, so this lives here
+/// rather than being written out in each: two copies of a match over every
+/// payload type is two chances for them to disagree about one.
+/// A decoded payload, with the challenge a parallel referral must be checked
+/// against where the payload carried one.
+pub(crate) type OpenedPayload<'a> = (
+    Payload<'a, &'a [u8], &'a mut [u8]>,
+    Option<ParallelSignatureInfo<'a>>,
+);
+
+pub(crate) fn open_payload<'a>(
+    payload: crate::cesr::Payload<'a, &'a mut [u8], &'a [u8]>,
+    sender_identity: Option<&'a [u8]>,
+) -> Result<OpenedPayload<'a>, CryptoError> {
+    Ok(match payload {
+        crate::cesr::Payload::GenericMessage(data) => (Payload::Content(data as _), None),
+        crate::cesr::Payload::ControlMessage(data) => (Payload::ControlMessage(data as _), None),
+        // a padding message carries nothing but its own nonce; the receiver
+        // discards it, and the nonce is not surfaced because nothing above can
+        // act on it (spec 7.5)
+        crate::cesr::Payload::Padding { .. } => (Payload::Padding, None),
+        crate::cesr::Payload::RelationProposal {
+            request_digest,
+            nonce,
+            reply_path,
+            referral,
+        } => match referral {
+            None => (
+                open_relationship_request(
+                    *request_digest.as_bytes(),
+                    crate::definitions::RelationshipForm::Direct,
+                    reply_path,
+                ),
+                None,
+            ),
+            Some((new_vid, sig_new_vid)) => (
+                open_relationship_request(
+                    *request_digest.as_bytes(),
+                    crate::definitions::RelationshipForm::Parallel {
+                        new_vid,
+                        sig_new_vid,
+                    },
+                    reply_path.clone(),
+                ),
+                Some(ParallelSignatureInfo {
+                    new_vid,
+                    sig_new_vid,
+                    signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
+                        sender_identity,
+                        &nonce,
+                        request_digest,
+                        &reply_path,
+                        new_vid,
+                    )?,
+                }),
+            ),
+        },
+        crate::cesr::Payload::RelationAffirm {
+            request_digest,
+            reply_digest,
+        } => (
+            open_relationship_accept(
+                *request_digest.as_bytes(),
+                *reply_digest.as_bytes(),
+                crate::definitions::RelationshipForm::Direct,
+            ),
+            None,
+        ),
+        crate::cesr::Payload::RelationshipCancel { reply, .. } => (
+            Payload::CancelRelationship {
+                thread_id: *reply.as_bytes(),
+            },
+            None,
+        ),
+        crate::cesr::Payload::NestedMessage(data) => (Payload::NestedMessage(data), None),
+        crate::cesr::Payload::RoutedMessage(hops, data) => {
+            (Payload::RoutedMessage(hops, data as _), None)
+        }
+    })
+}
+
 pub(crate) fn open_relationship_request<'a>(
     thread_id: Digest,
     form: RelationshipForm<'a, &'a [u8]>,
@@ -511,6 +599,7 @@ pub fn seal_reproducibly(
             crypto_type,
             essr_sender: EssrSender::default(),
             confidentiality: PayloadConfidentiality::default(),
+            padding: None,
         },
         Some(seed),
     )
@@ -533,6 +622,7 @@ pub fn seal_and_hash_with_crypto_type(
             crypto_type,
             essr_sender: EssrSender::default(),
             confidentiality: PayloadConfidentiality::default(),
+            padding: None,
         },
     )
 }
@@ -598,6 +688,7 @@ pub(crate) fn seal_with_selection_seeded(
             digest,
             request_nonce_override,
             seed,
+            selection,
         ),
         CryptoType::HpkeBase => tsp_hpke::seal(
             sender,

--- a/tsp_sdk/src/crypto/tsp_hpke.rs
+++ b/tsp_sdk/src/crypto/tsp_hpke.rs
@@ -11,7 +11,7 @@ use rand::{RngCore, SeedableRng, rngs::StdRng};
 use super::{
     CryptoError, MessageContents, ParallelSignatureInfo, RelationshipDigestAlgorithm,
     append_signature, build_relationship_accept_payload, build_relationship_request_payload,
-    open_relationship_accept, open_relationship_request, signature_type,
+    signature_type,
 };
 
 type Aead = hpke::aead::ChaCha20Poly1305;
@@ -42,6 +42,12 @@ fn payload_for_seal<'a>(
 
     let payload = match secret_payload {
         Payload::Content(data) => crate::cesr::Payload::GenericMessage(*data),
+        Payload::ControlMessage(data) => crate::cesr::Payload::ControlMessage(*data),
+        // a padding message is nothing but a fresh nonce: it exists to be
+        // indistinguishable from traffic that means something (spec 7.5)
+        Payload::Padding => crate::cesr::Payload::Padding {
+            nonce: crate::cesr::Nonce::generate(|dst| csprng.fill_bytes(dst)),
+        },
         Payload::RequestRelationship {
             thread_id: _ignored,
             form,
@@ -201,7 +207,12 @@ fn seal_with_kem<Kem: KemTrait>(
     )?;
 
     let mut cesr_message = Vec::with_capacity(secret_payload.calculate_size(sender_in_payload));
-    crate::cesr::encode_payload(&secret_payload, sender_in_payload, None, &mut cesr_message)?;
+    crate::cesr::encode_payload(
+        &secret_payload,
+        sender_in_payload,
+        selection.padding,
+        &mut cesr_message,
+    )?;
 
     if let Some(digest) = digest {
         *digest = payload_digest_override.unwrap_or_else(|| digest_algorithm.hash(&cesr_message));
@@ -311,73 +322,7 @@ fn open_payload<'a>(
         return Err(CryptoError::UnexpectedSender);
     }
 
-    let (secret_payload, parallel_signature_info) = match payload {
-        crate::cesr::Payload::GenericMessage(data) => (Payload::Content(data as _), None),
-        crate::cesr::Payload::RelationProposal {
-            request_digest,
-            nonce,
-            reply_path,
-            referral,
-        } => {
-            let _ = reply_path;
-            match referral {
-                None => (
-                    open_relationship_request(
-                        *request_digest.as_bytes(),
-                        crate::definitions::RelationshipForm::Direct,
-                        reply_path,
-                    ),
-                    None,
-                ),
-                Some((new_vid, sig_new_vid)) => (
-                    open_relationship_request(
-                        *request_digest.as_bytes(),
-                        crate::definitions::RelationshipForm::Parallel {
-                            new_vid,
-                            sig_new_vid,
-                        },
-                        reply_path.clone(),
-                    ),
-                    Some(ParallelSignatureInfo {
-                        new_vid,
-                        sig_new_vid,
-                        signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
-                            sender_identity,
-                            &nonce,
-                            request_digest,
-                            &reply_path,
-                            new_vid,
-                        )?,
-                    }),
-                ),
-            }
-        }
-        crate::cesr::Payload::RelationAffirm {
-            request_digest,
-            reply_digest,
-        } => (
-            open_relationship_accept(
-                *request_digest.as_bytes(),
-                *reply_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Direct,
-            ),
-            None,
-        ),
-        crate::cesr::Payload::ControlMessage(_) | crate::cesr::Payload::Padding { .. } => {
-            // recognized on the wire, but not yet surfaced through the API
-            return Err(CryptoError::UnsupportedPayload);
-        }
-        crate::cesr::Payload::RelationshipCancel { reply, .. } => (
-            Payload::CancelRelationship {
-                thread_id: *reply.as_bytes(),
-            },
-            None,
-        ),
-        crate::cesr::Payload::NestedMessage(data) => (Payload::NestedMessage(data), None),
-        crate::cesr::Payload::RoutedMessage(hops, data) => {
-            (Payload::RoutedMessage(hops, data as _), None)
-        }
-    };
+    let (secret_payload, parallel_signature_info) = super::open_payload(payload, sender_identity)?;
 
     Ok((
         (

--- a/tsp_sdk/src/crypto/tsp_nacl.rs
+++ b/tsp_sdk/src/crypto/tsp_nacl.rs
@@ -4,10 +4,7 @@ use crate::{
 };
 use crypto_box::{PublicKey, SecretKey};
 
-use super::{
-    CryptoError, MessageContents, ParallelSignatureInfo, open_relationship_accept,
-    open_relationship_request,
-};
+use super::{CryptoError, MessageContents, ParallelSignatureInfo};
 use super::{
     RelationshipDigestAlgorithm, append_signature, build_relationship_accept_payload,
     build_relationship_request_payload, signature_type,
@@ -22,6 +19,7 @@ pub(crate) fn seal(
     digest: Option<&mut super::Digest>,
     request_nonce_override: Option<[u8; 16]>,
     seed: Option<[u8; 32]>,
+    selection: super::OutboundCryptoSelection<'_>,
 ) -> Result<TSPMessage, CryptoError> {
     let crypto_type = CryptoType::SealedBox;
     // a seed makes the message reproducible, which is what a published test
@@ -51,6 +49,12 @@ pub(crate) fn seal(
 
     let secret_payload = match secret_payload {
         Payload::Content(data) => crate::cesr::Payload::GenericMessage(data),
+        Payload::ControlMessage(data) => crate::cesr::Payload::ControlMessage(data),
+        // a padding message is nothing but a fresh nonce: it exists to be
+        // indistinguishable from traffic that means something (spec 7.5)
+        Payload::Padding => crate::cesr::Payload::Padding {
+            nonce: crate::cesr::Nonce::generate(|dst| csprng.fill_bytes(dst)),
+        },
         Payload::RequestRelationship {
             thread_id: _ignored,
             form,
@@ -100,7 +104,12 @@ pub(crate) fn seal(
     // prepare CESR-encoded ciphertext
     let mut cesr_message = Vec::new();
 
-    crate::cesr::encode_payload(&secret_payload, sender_in_payload, None, &mut cesr_message)?;
+    crate::cesr::encode_payload(
+        &secret_payload,
+        sender_in_payload,
+        selection.padding,
+        &mut cesr_message,
+    )?;
 
     // hash the raw bytes of the plaintext before encryption
     if let Some(digest) = digest {
@@ -158,73 +167,7 @@ pub(crate) fn open<'a>(
         None => return Err(CryptoError::MissingSender),
     }
 
-    let (secret_payload, parallel_signature_info) = match payload {
-        crate::cesr::Payload::GenericMessage(data) => (Payload::Content(data as _), None),
-        crate::cesr::Payload::RelationProposal {
-            request_digest,
-            nonce,
-            reply_path,
-            referral,
-        } => {
-            let _ = reply_path;
-            match referral {
-                None => (
-                    open_relationship_request(
-                        *request_digest.as_bytes(),
-                        crate::definitions::RelationshipForm::Direct,
-                        reply_path,
-                    ),
-                    None,
-                ),
-                Some((new_vid, sig_new_vid)) => (
-                    open_relationship_request(
-                        *request_digest.as_bytes(),
-                        crate::definitions::RelationshipForm::Parallel {
-                            new_vid,
-                            sig_new_vid,
-                        },
-                        reply_path.clone(),
-                    ),
-                    Some(ParallelSignatureInfo {
-                        new_vid,
-                        sig_new_vid,
-                        signed_data: crate::cesr::encode_parallel_relation_proposal_challenge(
-                            sender_identity,
-                            &nonce,
-                            request_digest,
-                            &reply_path,
-                            new_vid,
-                        )?,
-                    }),
-                ),
-            }
-        }
-        crate::cesr::Payload::RelationAffirm {
-            request_digest,
-            reply_digest,
-        } => (
-            open_relationship_accept(
-                *request_digest.as_bytes(),
-                *reply_digest.as_bytes(),
-                crate::definitions::RelationshipForm::Direct,
-            ),
-            None,
-        ),
-        crate::cesr::Payload::ControlMessage(_) | crate::cesr::Payload::Padding { .. } => {
-            // recognized on the wire, but not yet surfaced through the API
-            return Err(CryptoError::UnsupportedPayload);
-        }
-        crate::cesr::Payload::RelationshipCancel { reply, .. } => (
-            Payload::CancelRelationship {
-                thread_id: *reply.as_bytes(),
-            },
-            None,
-        ),
-        crate::cesr::Payload::NestedMessage(data) => (Payload::NestedMessage(data), None),
-        crate::cesr::Payload::RoutedMessage(hops, data) => {
-            (Payload::RoutedMessage(hops, data as _), None)
-        }
-    };
+    let (secret_payload, parallel_signature_info) = super::open_payload(payload, sender_identity)?;
 
     Ok((
         (

--- a/tsp_sdk/src/definitions/conversions.rs
+++ b/tsp_sdk/src/definitions/conversions.rs
@@ -29,6 +29,18 @@ impl<T: AsRef<[u8]>> ReceivedTspMessage<T> {
                 message: f(message),
                 message_type,
             },
+            ControlMessage {
+                sender,
+                receiver,
+                message,
+                message_type,
+            } => ControlMessage {
+                sender,
+                receiver,
+                message: f(message),
+                message_type,
+            },
+            PaddingMessage { sender, receiver } => PaddingMessage { sender, receiver },
             RequestRelationship {
                 sender,
                 receiver,

--- a/tsp_sdk/src/definitions/mod.rs
+++ b/tsp_sdk/src/definitions/mod.rs
@@ -132,6 +132,26 @@ pub enum ReceivedTspMessage<Data: AsRef<[u8]> = BytesMut> {
         message: Data,
         message_type: MessageType,
     },
+    /// An upper layer's own control payload (`XCTL`). Carried opaquely, exactly
+    /// as [`ReceivedTspMessage::GenericMessage`] is; it arrives as its own
+    /// variant so that an upper layer can route its control plane separately
+    /// from its data plane (spec 9.3).
+    ControlMessage {
+        sender: String,
+        receiver: Option<String>,
+        message: Data,
+        message_type: MessageType,
+    },
+    /// A padding message (`XPAD`). It carries nothing: it exists so that
+    /// traffic analysis sees messages that mean nothing. The specification says
+    /// the receiver SHOULD silently discard it — silence being about what goes
+    /// back on the wire, which is nothing. It is reported rather than swallowed
+    /// so that an application can account for what it received; there is simply
+    /// nothing in it to act on.
+    PaddingMessage {
+        sender: String,
+        receiver: Option<String>,
+    },
     RequestRelationship {
         sender: String,
         receiver: String,
@@ -180,6 +200,8 @@ impl<Data: AsRef<[u8]>> ReceivedTspMessage<Data> {
     pub fn sender(&self) -> Option<&str> {
         match self {
             ReceivedTspMessage::GenericMessage { sender, .. }
+            | ReceivedTspMessage::ControlMessage { sender, .. }
+            | ReceivedTspMessage::PaddingMessage { sender, .. }
             | ReceivedTspMessage::RequestRelationship { sender, .. }
             | ReceivedTspMessage::AcceptRelationship { sender, .. }
             | ReceivedTspMessage::CancelRelationship { sender, .. }
@@ -224,6 +246,15 @@ pub enum RelationshipForm<'a, Bytes: AsRef<[u8]>> {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Payload<'a, Bytes: AsRef<[u8]>, MaybeMutBytes: AsRef<[u8]> = Bytes> {
     Content(Bytes),
+    /// An upper layer's own control payload (`XCTL`). TSP carries it opaquely,
+    /// exactly as it carries [`Payload::Content`]; the separate type exists so
+    /// that an upper layer can tell its control plane from its data plane
+    /// without reserving part of its own format for the distinction (spec 9.3).
+    ControlMessage(Bytes),
+    /// A padding message (`XPAD`), which carries no information at all — it
+    /// exists so that traffic analysis sees messages that mean nothing. The
+    /// receiver discards it (spec 7.5).
+    Padding,
     NestedMessage(MaybeMutBytes),
     RoutedMessage(Vec<VidData<'a>>, Bytes),
     CancelRelationship {
@@ -247,6 +278,8 @@ impl<Bytes: AsRef<[u8]>, MaybeMutBytes: AsRef<[u8]>> Payload<'_, Bytes, MaybeMut
     pub fn as_bytes(&self) -> &[u8] {
         match self {
             Payload::Content(bytes) => bytes.as_ref(),
+            Payload::ControlMessage(bytes) => bytes.as_ref(),
+            Payload::Padding => &[],
             Payload::NestedMessage(bytes) => bytes.as_ref(),
             Payload::RoutedMessage(_, bytes) => bytes.as_ref(),
             Payload::CancelRelationship { .. } => &[],
@@ -262,6 +295,10 @@ impl<Bytes: AsRef<[u8]>> fmt::Display for Payload<'_, Bytes> {
             Payload::Content(bytes) => {
                 write!(f, "Content: {}", String::from_utf8_lossy(bytes.as_ref()))
             }
+            Payload::ControlMessage(bytes) => {
+                write!(f, "Control: {}", String::from_utf8_lossy(bytes.as_ref()))
+            }
+            Payload::Padding => write!(f, "Padding"),
             Payload::NestedMessage(bytes) => write!(
                 f,
                 "Nested Message: {}",

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -181,5 +181,5 @@ pub use definitions::{
     VerifiedVid,
 };
 pub use error::Error;
-pub use store::{Aliases, SecureStore, WalletMethodState};
+pub use store::{Aliases, SecureStore, SendOptions, WalletMethodState};
 pub use vid::{ExportVid, OwnedVid, ResolutionContext, VerifyVidOptions, Vid};

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -93,11 +93,31 @@ fn nested_digest_field<'a>(
     algorithm.field(digest)
 }
 
-fn selected_outbound_crypto(
+/// How an outbound message is formed, beyond what it says.
+///
+/// Every field has a default that is the right answer unless a caller has a
+/// reason otherwise: the cipher suite the recipient's keys call for, an
+/// encrypted payload, and no padding.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SendOptions<'a> {
+    /// The cipher suite. `None` is HPKE-Base, or its post-quantum KEM where the
+    /// recipient's encryption key type asks for one.
+    pub crypto_type: Option<crate::cesr::CryptoType>,
+    /// Whether the payload is encrypted or only signed. Meaningful under
+    /// nesting; see [`PayloadConfidentiality`].
+    pub confidentiality: PayloadConfidentiality,
+    /// Bytes for the payload's padding field, which hides the length of what
+    /// the message actually carries. `None` encodes the empty field `4BAA`.
+    /// The field is excluded from the SAID digest, so padding does not change
+    /// a message's thread id (spec 7.2.1).
+    pub padding: Option<&'a [u8]>,
+}
+
+fn selected_outbound_crypto<'a>(
     sender: &dyn VerifiedVid,
     receiver: &dyn VerifiedVid,
-    selection: Option<OutboundCryptoSelection>,
-) -> OutboundCryptoSelection {
+    selection: Option<OutboundCryptoSelection<'a>>,
+) -> OutboundCryptoSelection<'a> {
     selection.unwrap_or_else(|| crate::crypto::default_outbound_crypto_selection(sender, receiver))
 }
 
@@ -275,7 +295,7 @@ struct ParallelSignatureContext<'a> {
     /// The crypto this message will be sealed with, which decides what the
     /// payload's ESSR sender field holds — and that field is covered by the
     /// referral signature, so it has to be the same on both sides
-    selection: OutboundCryptoSelection,
+    selection: OutboundCryptoSelection<'static>,
 }
 
 fn random_nonce_bytes() -> [u8; 16] {
@@ -822,6 +842,7 @@ impl SecureStore {
                 crypto_type,
                 essr_sender: Default::default(),
                 confidentiality: Default::default(),
+                padding: None,
             }),
         )
     }
@@ -844,7 +865,15 @@ impl SecureStore {
         message: &[u8],
         confidentiality: PayloadConfidentiality,
     ) -> Result<(Url, Vec<u8>), Error> {
-        self.seal_message_with(sender, receiver, message, None, confidentiality)
+        self.seal_message_with(
+            sender,
+            receiver,
+            message,
+            SendOptions {
+                confidentiality,
+                ..Default::default()
+            },
+        )
     }
 
     /// Seal a TSP message, choosing both the cipher suite and how the payload
@@ -857,8 +886,49 @@ impl SecureStore {
         sender: &str,
         receiver: &str,
         message: &[u8],
-        crypto_type: Option<crate::cesr::CryptoType>,
-        confidentiality: PayloadConfidentiality,
+        options: SendOptions<'_>,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.seal_payload_with(sender, receiver, Payload::Content(message), options)
+    }
+
+    /// Seal an upper layer's own control payload (`XCTL`).
+    ///
+    /// TSP carries it opaquely, exactly as it carries an application message.
+    /// The separate payload type exists so that an upper layer can tell its
+    /// control plane from its data plane without reserving part of its own
+    /// format to say which is which (spec 9.3). It arrives as
+    /// [`crate::ReceivedTspMessage::ControlMessage`].
+    pub fn seal_control_message(
+        &self,
+        sender: &str,
+        receiver: &str,
+        message: &[u8],
+        options: SendOptions<'_>,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.seal_payload_with(sender, receiver, Payload::ControlMessage(message), options)
+    }
+
+    /// Seal a padding message (`XPAD`), which carries nothing.
+    ///
+    /// It exists so that an observer counting or timing messages sees ones that
+    /// mean nothing (spec 7.5). Give it `options.padding` to choose its size;
+    /// with none it is as small as a TSP message gets, which is its own kind of
+    /// signal, so a caller hiding a traffic pattern should pass some.
+    pub fn seal_padding_message(
+        &self,
+        sender: &str,
+        receiver: &str,
+        options: SendOptions<'_>,
+    ) -> Result<(Url, Vec<u8>), Error> {
+        self.seal_payload_with(sender, receiver, Payload::Padding, options)
+    }
+
+    fn seal_payload_with(
+        &self,
+        sender: &str,
+        receiver: &str,
+        payload: Payload<&[u8]>,
+        options: SendOptions<'_>,
     ) -> Result<(Url, Vec<u8>), Error> {
         let sender_vid = self.get_private_vid(sender)?;
         let receiver_vid = self.get_verified_vid(receiver)?;
@@ -870,11 +940,12 @@ impl SecureStore {
         self.seal_message_payload_and_hash_with_selection(
             sender,
             receiver,
-            Payload::Content(message),
+            payload,
             None,
             Some(OutboundCryptoSelection {
-                crypto_type: crypto_type.unwrap_or(selection.crypto_type),
-                confidentiality,
+                crypto_type: options.crypto_type.unwrap_or(selection.crypto_type),
+                confidentiality: options.confidentiality,
+                padding: options.padding,
                 ..selection
             }),
         )
@@ -1412,6 +1483,29 @@ impl SecureStore {
                             },
                         })
                     }
+                    Payload::ControlMessage(message) => {
+                        // an upper layer's control payload is addressed to a VID
+                        // and carries its data, so spec 7.2.2 applies to it as it
+                        // does to an application message
+                        self.check_relationship_gate(&intended_receiver, &sender)?;
+
+                        Ok(ReceivedTspMessage::ControlMessage {
+                            sender,
+                            receiver: Some(intended_receiver),
+                            message,
+                            message_type: MessageType {
+                                crypto_type,
+                                signature_type,
+                                enclosing_crypto_type: None,
+                            },
+                        })
+                    }
+                    // not gated: there is nothing in a padding message to accept
+                    // or refuse, and the receiver discards it either way
+                    Payload::Padding => Ok(ReceivedTspMessage::PaddingMessage {
+                        sender,
+                        receiver: Some(intended_receiver),
+                    }),
                     Payload::NestedMessage(inner) => {
                         if let Some(received_message) = self.try_open_nested_relationship_message(
                             &sender,
@@ -1681,6 +1775,7 @@ impl SecureStore {
                 crypto_type,
                 essr_sender: Default::default(),
                 confidentiality: Default::default(),
+                padding: None,
             }),
         )
     }
@@ -2491,7 +2586,7 @@ mod test {
     use crate::{
         Error, Payload, PendingParallelRelationship, ReceivedRelationshipDelivery,
         ReceivedRelationshipForm, ReceivedTspMessage, RelationshipForm, RelationshipStatus,
-        SecureStore, VerifiedVid,
+        SecureStore, SendOptions, VerifiedVid,
         crypto::{CryptoError, PayloadConfidentiality},
         store::RelationshipPolicy,
     };
@@ -4473,6 +4568,97 @@ mod test {
             Some(crate::cesr::CryptoType::Plaintext),
             "and the enclosing message it arrived in was encrypted"
         );
+    }
+
+    /// `XCTL`, `XPAD` and a caller's padding all reach the wire and come back.
+    ///
+    /// Before this they existed only at the CESR layer: the crypto layer
+    /// answered `UnsupportedPayload` for the two payload types, and the padding
+    /// field was hard-coded empty at every seal site.
+    #[test]
+    #[wasm_bindgen_test]
+    fn control_padding_and_a_padded_payload_round_trip() {
+        let a_store = create_test_store();
+        let b_store = create_test_store();
+        let a = create_test_vid();
+        let b = create_test_vid();
+
+        for (store, own, other) in [(&a_store, &a, &b), (&b_store, &b, &a)] {
+            store.add_private_vid(own.clone(), None).unwrap();
+            store.add_verified_vid(other.clone(), None).unwrap();
+            store
+                .set_relation_and_status_for_vid(
+                    other.identifier(),
+                    RelationshipStatus::Unidirectional {
+                        thread_id: Default::default(),
+                    },
+                    own.identifier(),
+                )
+                .unwrap();
+        }
+
+        // an upper layer's control payload arrives as its own kind, not as a
+        // generic message — that distinction is the whole point of XCTL
+        let (_, mut sealed) = a_store
+            .seal_control_message(
+                a.identifier(),
+                b.identifier(),
+                b"turn left",
+                Default::default(),
+            )
+            .unwrap();
+        let ReceivedTspMessage::ControlMessage { message, .. } =
+            b_store.open_message(&mut sealed).unwrap()
+        else {
+            panic!("a control payload must not arrive as anything else")
+        };
+        assert_eq!(message, b"turn left");
+
+        // a padding message carries nothing and says so
+        let (_, mut sealed) = a_store
+            .seal_padding_message(
+                a.identifier(),
+                b.identifier(),
+                SendOptions {
+                    padding: Some(&[0_u8; 64]),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(matches!(
+            b_store.open_message(&mut sealed).unwrap(),
+            ReceivedTspMessage::PaddingMessage { .. }
+        ));
+
+        // padding rides in any payload, lengthening the message without
+        // changing what it says
+        let plain = a_store
+            .seal_message(a.identifier(), b.identifier(), b"hello world")
+            .unwrap()
+            .1;
+        let (_, mut padded) = a_store
+            .seal_message_with(
+                a.identifier(),
+                b.identifier(),
+                b"hello world",
+                SendOptions {
+                    padding: Some(&[0_u8; 128]),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(
+            padded.len() > plain.len() + 100,
+            "padding must actually reach the wire: {} vs {}",
+            padded.len(),
+            plain.len()
+        );
+        let ReceivedTspMessage::GenericMessage { message, .. } =
+            b_store.open_message(&mut padded).unwrap()
+        else {
+            panic!("a padded message is still a generic message")
+        };
+        assert_eq!(message, b"hello world");
     }
 
     /// An addressed application message is dropped outside a relationship

--- a/tsp_sdk/src/test_vectors.rs
+++ b/tsp_sdk/src/test_vectors.rs
@@ -179,6 +179,9 @@ mod test {
                         "{name}"
                     );
                 }
+                Payload::ControlMessage(_) | Payload::Padding => {
+                    panic!("{name}: no vector carries these payload types yet")
+                }
                 Payload::NestedMessage(inner) => {
                     assert_eq!(declared_type, "XHOP", "{name}: payload type");
                     let e = &expect["payload"]["nested"];


### PR DESCRIPTION
Closes the open item from PR 1. All three existed at the CESR layer with nothing above able to reach them: the crypto layer answered `UnsupportedPayload` for the two payload types, and the padding field was hard-coded empty at every seal site.

### XCTL

The same shape as `XSCS`, and TSP treats it identically — it carries both opaquely and interprets neither. Two codes exist so that an upper layer can tell its control plane from its data plane without reserving part of its own format to say which is which (spec 9.3). It arrives as `ReceivedTspMessage::ControlMessage` rather than `GenericMessage`, and is relationship-gated like any other addressed payload.

### XPAD

Carries nothing. It exists so that an observer counting or timing messages sees some that mean nothing (spec 7.5). It is reported on arrival rather than swallowed — "silently discard" governs what goes back on the wire, which is nothing — and there is simply nothing in it to act on. Not gated: there is nothing to accept or refuse.

### Padding

Rides in `OutboundCryptoSelection`, which was already threaded to exactly where `encode_payload` needed it, so no new parameter on six signatures. It is not exclusive to `XPAD`: every payload layout carries the field, and it is excluded from the SAID digest, so padding a message does not change its thread id (spec 7.2.1).

### API

The three knobs — cipher suite, confidentiality, padding — become `SendOptions` rather than a growing argument list; `send_with`/`seal_message_with` take it in place of two positional arguments. New: `seal_control_message`/`send_control_message` and `seal_padding_message`/`send_padding_message`. The CLI gains `--kind message|control|padding` and `--padding N`. Python, JavaScript and the node wrapper carry the two new received kinds; the numeric variants node switches on are appended, so existing numbers do not move.

### Two things found on the way

**The cesr-to-SDK payload conversion was duplicated verbatim** between the HPKE and sealed-box backends — 71 identical lines. Adding the two new arms in both places is how these copies drift, so it is now written once.

**The JavaScript binding matched variants under a catch-all** with `#[allow(unreachable_patterns)]` and `_ => unreachable!()`. Adding variants compiled clean there and would have panicked at runtime on the first control or padding message. Explicit arms added. Both bindings also had the signature-type mapping written out inline; it is factored the way `crypto_type` already was.

### Verification

`fmt`; `cargo doc`; `clippy` on default and `--all-features`; tests on default and `--all-features`; the CLI suite; both binding crates; the `wasm32-unknown-unknown` target. A test covers all three round-tripping. Both new kinds were exercised end to end over a real relationship between two CLI processes.