### PR TITLE
Give the intermediaries stable identities

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,11 +74,18 @@ jobs:
       - name: Create intermediary declarations
         run: |-
           export TAG="${{ env.tag }}"
+          export DID_SERVER="did.teaspoon.world"
           export SERVICE="demo-intermediary-p"
           export DOMAIN="p.teaspoon.world"
+          export NAME="p"
+          export BUCKET="intermediary-p-teaspoon-data"
+          export WALLET_SECRET="projects/797284806017/secrets/intermediary-p-wallet/versions/latest"
           envsubst < deploy/intermediary.template.yaml > intermediary-p.yaml
           export SERVICE="demo-intermediary-q"
           export DOMAIN="q.teaspoon.world"
+          export NAME="q"
+          export BUCKET="intermediary-q-teaspoon-data"
+          export WALLET_SECRET="projects/797284806017/secrets/intermediary-q-wallet/versions/latest"
           envsubst < deploy/intermediary.template.yaml > intermediary-q.yaml
       - name: Create server declaration
         run: |-

--- a/deploy/intermediary.template.yaml
+++ b/deploy/intermediary.template.yaml
@@ -18,10 +18,16 @@ spec:
     spec:
       containerConcurrency: 80
       timeoutSeconds: 300
+      serviceAccountName: 797284806017-compute@developer.gserviceaccount.com
       containers:
         - name: demo-intermediary
           image: us-central1-docker.pkg.dev/teaspoon-world-demo/tsp/openwallet-foundation-labs/tsp/demo-intermediary:${TAG}
-          args: [ ${DOMAIN} ]
+          args: [ "${DOMAIN}", "--wallet", "/tmp/wallet", "--did-server", "${DID_SERVER}", "--name", "${NAME}", "--bucket", "${BUCKET}" ]
+          env:
+            # Only the name of the secret, which is not itself sensitive. The service reads the
+            # value at startup using its own identity, so the password never appears here.
+            - name: TSP_WALLET_SECRET
+              value: ${WALLET_SECRET}
           ports:
             - name: http1
               containerPort: 3001
@@ -35,6 +41,13 @@ spec:
             failureThreshold: 1
             tcpSocket:
               port: 3001
+          # The bucket is deliberately not mounted. A mounted bucket has to pretend a whole
+          # object can be edited in place, which is what a database file does constantly and
+          # what object storage cannot do. Instead the wallet lives on the instance's own disk
+          # and is written back whole on every change, which is the one thing object storage
+          # does exactly right.
+          #
+          # One bucket per intermediary: the wallet holds its own keys and is never shared.
   traffic:
     - percent: 100
       latestRevision: true

--- a/docs/src/cli/base.md
+++ b/docs/src/cli/base.md
@@ -79,11 +79,11 @@ will provide all resolved VIDs that the local VID has a relation with,
 including the alias, relation status, and transport.
 
 ```
-did:web:q.teaspoon.world
+did:webvh:QmTNAE7o3Ze2bR11R9wD1saxUJj3nnSfqwxNfBrocj5mZd:did.teaspoon.world:endpoint:q
 	 Relation Status: Bidirectional
 	 Alias: q
-	 Transport: https://q.teaspoon.world/transport/did:web:q.teaspoon.world
-	 DID doc: https://q.teaspoon.world/.well-known/did.json
+	 Transport: https://q.teaspoon.world/transport/[vid_placeholder]
+	 DID doc: https://did.teaspoon.world/endpoint/q/did.jsonl
 	 public enc key: slqqOWKP1WhCN+X/tuGgoUkrryA6F//f5rV6cqXsL3Q=
 	 public sign key: djnK+ljzZsA2gX/X/IUy1Y06+j5Souo1bzTDZ9RoJxc=
 ```

--- a/docs/src/cli/routed.md
+++ b/docs/src/cli/routed.md
@@ -85,8 +85,16 @@ tsp -w b print b | xargs tsp -w a verify --alias b
 
 The sender `a` also resolves and verifies the first intermediary `p`, and requests a relationship with this intermediary:
 
+Each intermediary publishes its own identifier on its home page, so read them from there rather
+than copying them from here:
+
 ```sh
-tsp -w a verify did:web:p.teaspoon.world --alias p
+DID_P=  # the identifier shown at https://p.teaspoon.world/
+DID_Q=  # the identifier shown at https://q.teaspoon.world/
+```
+
+```sh
+tsp -w a verify "$DID_P" --alias p
 tsp -w a request -s a -r p --wait
 ```
 
@@ -95,7 +103,7 @@ Our public demo intermediaries are configured to accept all incoming relationshi
 The receiver `b` resolves and verifies the second intermediary `q`, and requests a relationship with this second intermediary:
 
 ```sh
-tsp -w b verify did:web:q.teaspoon.world --alias q
+tsp -w b verify "$DID_Q" --alias q
 tsp -w b request -s b -r q --wait
 ```
 
@@ -112,7 +120,7 @@ echo "DID_Q2=$DID_Q2"
 Now that we have set up all the relations between the nodes, we can configure the route for messages that are to be delivered from `a` to `b`. We will route these messages via `p` to `q`, which drops them off at `b`'s nested VID `b2`:
 
 ```sh
-tsp -w a set-route b "p,did:web:q.teaspoon.world,$DID_B2"
+tsp -w a set-route b "p,$DID_Q,$DID_B2"
 ```
 
 Sending the routed message is trivial, now we have configured the relations and route.
@@ -151,8 +159,8 @@ OfUxSph1RUh4mgyOwdgIh855Y4V8A59URG4-TH3s8wy2cSkwXwTnFIZVtgJ3_Xla9uA5E2o6-CAX
 Note that the message is longer than a direct mode message, since the ciphertext contains another
 TSP message.
 
-Note also who the envelope names. `VID_sndr` is `a` and `VID_rcvr` is the *first intermediary*,
-`did:web:p.teaspoon.world` — not `b`. The rest of the route and the message for `b` are inside the
+Note also who the envelope names. `VID_sndr` is `a` and `VID_rcvr` is the *first intermediary* —
+not `b`. The rest of the route and the message for `b` are inside the
 ciphertext, which `p` decrypts to learn only the next hop and an opaque blob to forward. No
 intermediary sees the message, and none of them sees the whole route. See
 [CESR encoding](../cesr.md) for the codes.

--- a/docs/src/intermediary.md
+++ b/docs/src/intermediary.md
@@ -18,8 +18,13 @@ when no public address can be exposed, behind a firewall.
 
 We host two demo intermediaries publicly for testing:
 
-- [Intermediary P](https://p.teaspoon.world/), which has the identifier `did:web:p.teaspoon.world`
-- [Intermediary Q](https://q.teaspoon.world/), which has the identifier `did:web:q.teaspoon.world`
+- [Intermediary P](https://p.teaspoon.world/)
+- [Intermediary Q](https://q.teaspoon.world/)
+
+Each one publishes its own identifier on its home page. They use `did:webvh`, so the identifier
+carries a verifiable history of its keys: an intermediary can be restarted or redeployed without
+the relationships its clients hold with it becoming invalid. Read the identifier from the page
+rather than copying one from documentation, which can fall out of date.
 
 These two instances both run the `examples/src/intermediary.rs` server. These intermediaries also support buffering messages, which means they are able to hold messages for clients which are not currently listening (although there are no guarantees for how long the message will be held).
 

--- a/examples/cli-demo-routed-external.sh
+++ b/examples/cli-demo-routed-external.sh
@@ -23,8 +23,15 @@ for entity in a b; do
 	tsp --wallet "${entity%%[0-9]*}" create --type web --alias $entity `randuser`
 done
 DID_A=$(tsp --wallet a print a)
-DID_P="did:web:p.teaspoon.world"
-DID_Q="did:web:q.teaspoon.world"
+# The intermediaries publish their own identifiers, so read them rather than hard-coding them:
+# a did:webvh identifier is derived from its genesis log entry and is not predictable from the
+# domain, and it changes if an intermediary is ever re-created.
+did_of() {
+	curl -s "https://did.teaspoon.world/endpoint/$1/did.json" \
+		| grep -o '"id":"did:webvh:[^"]*"' | head -1 | cut -d'"' -f4
+}
+DID_P=$(did_of p)
+DID_Q=$(did_of q)
 DID_B=$(tsp --wallet b print b)
 
 wait

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -337,6 +337,21 @@ async fn write_wallet(vault: &AskarSecureStorage, db: &AsyncSecureStore) -> Resu
     Ok(())
 }
 
+/// Build a URL for the DID server.
+///
+/// A local DID server is reached over plain HTTP, which is also how a local identifier is
+/// resolved. Publishing has to agree with resolution, or an identifier is written to one place
+/// and read from another.
+fn did_server_url(did_server: &str, path: &str) -> String {
+    let scheme = if did_server.starts_with("localhost") || did_server.starts_with("127.0.0.1") {
+        "http"
+    } else {
+        "https"
+    };
+
+    format!("{scheme}://{did_server}/{path}")
+}
+
 async fn read_wallet(
     wallet_name: &str,
     password: &str,
@@ -550,9 +565,9 @@ async fn publish_scid_source(
     replace: bool,
 ) -> Result<(), Error> {
     let request = if replace {
-        client.put(format!("https://{did_server}/add-vid"))
+        client.put(did_server_url(did_server, "add-vid"))
     } else {
-        client.post(format!("https://{did_server}/add-vid"))
+        client.post(did_server_url(did_server, "add-vid"))
     };
 
     let _: Vid = request
@@ -574,14 +589,14 @@ async fn publish_scid_source(
 
     if let Some(source_history) = source_history {
         let request = if replace {
-            client.put(format!(
-                "https://{did_server}/add-history/{}",
-                source_vid.identifier()
+            client.put(did_server_url(
+                did_server,
+                &format!("add-history/{}", source_vid.identifier()),
             ))
         } else {
-            client.post(format!(
-                "https://{did_server}/add-history/{}",
-                source_vid.identifier()
+            client.post(did_server_url(
+                did_server,
+                &format!("add-history/{}", source_vid.identifier()),
             ))
         };
 
@@ -788,7 +803,7 @@ async fn run() -> Result<(), Error> {
                         .expect("Cannot store next update key reference");
 
                     let _: Vid = match client
-                        .post(format!("https://{did_server}/add-vid"))
+                        .post(did_server_url(&did_server, "add-vid"))
                         .json(&private_vid.vid())
                         .send()
                         .await
@@ -814,9 +829,9 @@ async fn run() -> Result<(), Error> {
                     );
 
                     match client
-                        .post(format!(
-                            "https://{did_server}/add-history/{}",
-                            private_vid.vid().identifier()
+                        .post(did_server_url(
+                            &did_server,
+                            &format!("add-history/{}", private_vid.vid().identifier()),
                         ))
                         .json(&history)
                         .send()
@@ -1021,9 +1036,9 @@ async fn run() -> Result<(), Error> {
                     .expect("Cannot update next update key reference");
 
                 client
-                    .put(format!(
-                        "https://{did_server}/add-history/{}",
-                        new_vid.identifier()
+                    .put(did_server_url(
+                        &did_server,
+                        &format!("add-history/{}", new_vid.identifier()),
                     ))
                     .json(&update_result.log_entry)
                     .send()
@@ -1031,7 +1046,7 @@ async fn run() -> Result<(), Error> {
                     .expect("Could not append history");
 
                 let update_response = client
-                    .put(format!("https://{did_server}/add-vid"))
+                    .put(did_server_url(&did_server, "add-vid"))
                     .json(new_vid.vid())
                     .send()
                     .await
@@ -1061,7 +1076,7 @@ async fn run() -> Result<(), Error> {
             info!("created identity from file {}", private_vid.identifier());
         }
         Commands::Discover => {
-            let url = format!("https://{did_server}/.well-known/endpoints.json");
+            let url = did_server_url(&did_server, ".well-known/endpoints.json");
             info!("discovering DIDs from {}", url);
 
             let dids = match client
@@ -1793,7 +1808,7 @@ async fn create_did_web(
     info!("created identity {}", private_vid.identifier());
 
     let response = client
-        .post(format!("https://{did_server}/add-vid"))
+        .post(did_server_url(did_server, "add-vid"))
         .json(&private_vid.vid())
         .send()
         .await

--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -122,11 +122,50 @@ async fn access_token() -> Result<String, Box<dyn std::error::Error>> {
 
 /// The files that make up the wallet.
 ///
-/// The second holds writes that have not yet been folded into the first, so a copy of the wallet
-/// is only complete with both. The shared-memory file is deliberately not included: it is rebuilt
-/// on open, and restoring a stale one would be worse than having none.
+/// The second holds writes not yet folded into the first, so a copy is only complete with both.
+/// The shared-memory file is deliberately absent: it is rebuilt on open, and restoring a stale
+/// one would be worse than having none.
 fn wallet_files(wallet: &str) -> [String; 2] {
     [format!("{wallet}.sqlite"), format!("{wallet}.sqlite-wal")]
+}
+
+/// The single object the wallet is kept in.
+fn wallet_object(wallet: &str) -> String {
+    format!("{wallet}.wallet")
+}
+
+/// Pack the wallet's files into one byte string, each preceded by its length.
+///
+/// The wallet is two files but must be stored as one object. A bucket writes an object completely
+/// or not at all, so one object can never be found half-written; two objects written in sequence
+/// can be, if the instance stops between them, leaving a database beside a log that does not
+/// belong to it.
+fn wallet_pack(parts: Vec<Vec<u8>>) -> Vec<u8> {
+    let mut packed = Vec::new();
+
+    for part in parts {
+        packed.extend_from_slice(&(part.len() as u64).to_be_bytes());
+        packed.extend_from_slice(&part);
+    }
+
+    packed
+}
+
+/// Undo `wallet_pack`.
+fn wallet_unpack(packed: &[u8]) -> Option<Vec<Vec<u8>>> {
+    let mut parts = Vec::new();
+    let mut rest = packed;
+
+    while !rest.is_empty() {
+        let (header, body) = rest.split_at_checked(8)?;
+        let length = u64::from_be_bytes(header.try_into().ok()?) as usize;
+        let (part, remainder) = body.split_at_checked(length)?;
+
+        parts.push(part.to_vec());
+        rest = remainder;
+    }
+
+    Some(parts)
 }
 
 /// Fetch the wallet from the bucket, if there is one there.
@@ -136,48 +175,59 @@ fn wallet_files(wallet: &str) -> [String; 2] {
 /// running, and the bucket holds the copy that outlives it.
 async fn wallet_download(bucket: &str, wallet: &str) -> Result<(), Box<dyn std::error::Error>> {
     let token = access_token().await?;
+    let object = wallet_object(wallet);
 
-    for file in wallet_files(wallet) {
-        let response = http_client()
-            .get(format!(
-                "https://storage.googleapis.com/storage/v1/b/{bucket}/o/{file}?alt=media"
-            ))
-            .bearer_auth(&token)
-            .send()
-            .await?;
+    let response = http_client()
+        .get(format!(
+            "https://storage.googleapis.com/storage/v1/b/{bucket}/o/{object}?alt=media"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await?;
 
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        tracing::info!("no wallet in {bucket} yet");
+
+        return Ok(());
+    }
+
+    let packed = response.error_for_status()?.bytes().await?;
+    let parts = wallet_unpack(&packed).ok_or("the stored wallet is malformed")?;
+
+    for (file, part) in wallet_files(wallet).iter().zip(parts) {
+        if part.is_empty() {
+            let _ = tokio::fs::remove_file(file).await;
+
             continue;
         }
 
-        let body = response.error_for_status()?.bytes().await?;
-        tokio::fs::write(&file, &body).await?;
-        tracing::info!("restored {file} ({} bytes)", body.len());
+        tokio::fs::write(file, &part).await?;
+        tracing::info!("restored {file} ({} bytes)", part.len());
     }
 
     Ok(())
 }
 
-/// Write the wallet back to the bucket as whole objects.
+/// Write the wallet back to the bucket as a single object.
 async fn wallet_upload(bucket: &str, wallet: &str) -> Result<(), Box<dyn std::error::Error>> {
     let token = access_token().await?;
+    let object = wallet_object(wallet);
 
+    let mut parts = Vec::new();
     for file in wallet_files(wallet) {
-        let Ok(body) = tokio::fs::read(&file).await else {
-            continue;
-        };
-
-        http_client()
-            .post(format!(
-                "https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={file}"
-            ))
-            .bearer_auth(&token)
-            .header("Content-Type", "application/octet-stream")
-            .body(body)
-            .send()
-            .await?
-            .error_for_status()?;
+        parts.push(tokio::fs::read(&file).await.unwrap_or_default());
     }
+
+    http_client()
+        .post(format!(
+            "https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={object}"
+        ))
+        .bearer_auth(&token)
+        .header("Content-Type", "application/octet-stream")
+        .body(wallet_pack(parts))
+        .send()
+        .await?
+        .error_for_status()?;
 
     Ok(())
 }
@@ -621,6 +671,9 @@ struct IntermediaryState {
     /// Where the wallet is kept between runs, and the name of its files on local disk.
     bucket: Option<String>,
     wallet: String,
+    /// Held across a save so that two of them cannot interleave. Without it one save could read
+    /// the wallet's files for storing while another is part way through writing them.
+    saving: Mutex<()>,
     /// Per-recipient message buffers with monotonic IDs
     buffers: RwLock<HashMap<String, RecipientBuffer>>,
     /// Per-recipient SSE subscriber notifications
@@ -682,6 +735,8 @@ impl IntermediaryState {
     /// state. The whole wallet is rewritten each time, which is sound for a single instance;
     /// per-record writes are what several instances would need.
     async fn save(&self) {
+        let _saving = self.saving.lock().await;
+
         let state = match self.db.read().await.export() {
             Ok(state) => state,
             Err(e) => {
@@ -852,6 +907,7 @@ async fn main() {
         vault,
         bucket: args.bucket.clone(),
         wallet: args.wallet.clone(),
+        saving: Mutex::new(()),
         buffers: RwLock::new(HashMap::new()),
         subscribers: Mutex::new(SseSubscribers::new()),
         buffer_ttl,
@@ -1429,4 +1485,35 @@ async fn log_websocket_handler(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{wallet_pack, wallet_unpack};
+
+    #[test]
+    fn packing_a_wallet_is_reversible() {
+        let parts = vec![b"a database".to_vec(), b"a log".to_vec()];
+
+        assert_eq!(wallet_unpack(&wallet_pack(parts.clone())), Some(parts));
+    }
+
+    #[test]
+    fn an_absent_log_survives_the_round_trip() {
+        let parts = vec![b"a database".to_vec(), Vec::new()];
+
+        assert_eq!(wallet_unpack(&wallet_pack(parts.clone())), Some(parts));
+    }
+
+    #[test]
+    fn a_truncated_wallet_is_refused_rather_than_half_read() {
+        let packed = wallet_pack(vec![b"a database".to_vec(), b"a log".to_vec()]);
+
+        for length in 1..packed.len() {
+            assert_ne!(
+                wallet_unpack(&packed[..length]),
+                Some(vec![b"a database".to_vec(), b"a log".to_vec()])
+            );
+        }
+    }
 }

--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -1,7 +1,7 @@
 use axum::{
     Router,
     body::Bytes,
-    extract::{Path, State, WebSocketUpgrade, ws::Message},
+    extract::{FromRequestParts, State, WebSocketUpgrade, ws::Message},
     http::{HeaderMap, StatusCode},
     response::{
         Html, IntoResponse, Response,
@@ -13,7 +13,6 @@ use base64ct::{Base64UrlUnpadded, Encoding};
 use bytes::BytesMut;
 use clap::Parser;
 use futures::{sink::SinkExt, stream::Stream, stream::StreamExt};
-use reqwest::header;
 use serde::Serialize;
 use std::{
     collections::{HashMap, VecDeque},
@@ -24,9 +23,8 @@ use std::{
 use tokio::sync::{Mutex, Notify, RwLock, RwLockWriteGuard, broadcast, mpsc};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tsp_sdk::{
-    AsyncSecureStore, OwnedVid, ReceivedRelationshipDelivery, ReceivedRelationshipForm,
-    ReceivedTspMessage, VerifiedVid, cesr, definitions::Digest, transport,
-    vid::vid_to_did_document,
+    AskarSecureStorage, AsyncSecureStore, ReceivedRelationshipDelivery, ReceivedRelationshipForm,
+    ReceivedTspMessage, SecureStorage, VerifiedVid, cesr, definitions::Digest, transport,
 };
 use url::Url;
 use uuid::Uuid;
@@ -56,6 +54,441 @@ struct Cli {
         help = "Max buffered messages per recipient (default: 2000)"
     )]
     buffer_max: usize,
+    #[arg(
+        long,
+        default_value = "wallet",
+        help = "Wallet name; stored at <name>.sqlite next to the working directory"
+    )]
+    wallet: String,
+    #[arg(
+        long,
+        default_value = "did.teaspoon.world",
+        help = "DID server hosting this intermediary's identity"
+    )]
+    did_server: String,
+    #[arg(
+        long,
+        help = "Name to publish the identity under (default: the first label of the domain)"
+    )]
+    name: Option<String>,
+    #[arg(
+        long,
+        help = "Bucket holding the wallet between runs. The wallet is kept on local disk while \
+                running and written back whole on every change; the bucket is never mounted."
+    )]
+    bucket: Option<String>,
+}
+
+/// Read the wallet password.
+///
+/// In a deployment the service asks the secret store for it, authenticating as itself, so that
+/// nothing sensitive appears in the deployment configuration. `TSP_WALLET_SECRET` names the
+/// secret version to read. For local runs `TSP_WALLET_PASSWORD` supplies it directly.
+///
+/// There is deliberately no prompt: the service is headless, so a missing password must fail
+/// at startup rather than block.
+async fn wallet_password() -> String {
+    if let Ok(resource) = std::env::var("TSP_WALLET_SECRET") {
+        return fetch_secret(&resource)
+            .await
+            .expect("could not read the wallet password from the secret store");
+    }
+
+    if let Ok(password) = std::env::var("TSP_WALLET_PASSWORD") {
+        return password;
+    }
+
+    panic!("no wallet password: set TSP_WALLET_SECRET or TSP_WALLET_PASSWORD");
+}
+
+/// An access token for the identity attached to this instance.
+async fn access_token() -> Result<String, Box<dyn std::error::Error>> {
+    #[derive(serde::Deserialize)]
+    struct Token {
+        access_token: String,
+    }
+
+    let token: Token = http_client()
+        .get("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+        .header("Metadata-Flavor", "Google")
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    Ok(token.access_token)
+}
+
+/// The files that make up the wallet.
+///
+/// The second holds writes that have not yet been folded into the first, so a copy of the wallet
+/// is only complete with both. The shared-memory file is deliberately not included: it is rebuilt
+/// on open, and restoring a stale one would be worse than having none.
+fn wallet_files(wallet: &str) -> [String; 2] {
+    [format!("{wallet}.sqlite"), format!("{wallet}.sqlite-wal")]
+}
+
+/// Fetch the wallet from the bucket, if there is one there.
+///
+/// The bucket holds whole objects, which is what it is good at, and the wallet is read and
+/// written whole anyway. Nothing is mounted: the wallet lives on the instance's own disk while
+/// running, and the bucket holds the copy that outlives it.
+async fn wallet_download(bucket: &str, wallet: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let token = access_token().await?;
+
+    for file in wallet_files(wallet) {
+        let response = http_client()
+            .get(format!(
+                "https://storage.googleapis.com/storage/v1/b/{bucket}/o/{file}?alt=media"
+            ))
+            .bearer_auth(&token)
+            .send()
+            .await?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            continue;
+        }
+
+        let body = response.error_for_status()?.bytes().await?;
+        tokio::fs::write(&file, &body).await?;
+        tracing::info!("restored {file} ({} bytes)", body.len());
+    }
+
+    Ok(())
+}
+
+/// Write the wallet back to the bucket as whole objects.
+async fn wallet_upload(bucket: &str, wallet: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let token = access_token().await?;
+
+    for file in wallet_files(wallet) {
+        let Ok(body) = tokio::fs::read(&file).await else {
+            continue;
+        };
+
+        http_client()
+            .post(format!(
+                "https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={file}"
+            ))
+            .bearer_auth(&token)
+            .header("Content-Type", "application/octet-stream")
+            .body(body)
+            .send()
+            .await?
+            .error_for_status()?;
+    }
+
+    Ok(())
+}
+
+/// Fetch a secret version, authenticating with the identity attached to this instance.
+async fn fetch_secret(resource: &str) -> Result<String, Box<dyn std::error::Error>> {
+    #[derive(serde::Deserialize)]
+    struct Payload {
+        data: String,
+    }
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Secret {
+        payload: Payload,
+    }
+
+    let token = access_token().await?;
+
+    let secret: Secret = http_client()
+        .get(format!(
+            "https://secretmanager.googleapis.com/v1/{resource}:access"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    Ok(String::from_utf8(base64ct::Base64::decode_vec(
+        &secret.payload.data,
+    )?)?)
+}
+
+/// Build a URL for the DID server.
+///
+/// Identity creation and resolution treat a local DID server as plain HTTP, so publishing has to
+/// agree with them or it would post to a different place than the one clients read from.
+fn did_server_url(did_server: &str, path: &str) -> String {
+    let scheme = if did_server.starts_with("localhost") || did_server.starts_with("127.0.0.1") {
+        "http"
+    } else {
+        "https"
+    };
+
+    format!("{scheme}://{did_server}/{path}")
+}
+
+/// An HTTP client that trusts the test certificate when built for local testing.
+fn http_client() -> reqwest::Client {
+    let client = reqwest::ClientBuilder::new()
+        .user_agent(format!("TSP intermediary / {}", env!("CARGO_PKG_VERSION")));
+
+    #[cfg(feature = "use_local_certificate")]
+    let client = client.add_root_certificate({
+        tracing::warn!("using the local root CA; for local testing only");
+        reqwest::Certificate::from_pem(include_bytes!("../test/root-ca.pem")).unwrap()
+    });
+
+    client.build().unwrap()
+}
+
+/// The `{did}` path segment exactly as it appears in the URL.
+///
+/// An identifier can contain a percent-encoded colon, which the usual path extractor would
+/// decode. Messages are buffered under the receiver identifier taken verbatim from the wire, so
+/// decoding here would read under a different key than the one written, and buffered messages
+/// would never be found. The raw text keeps both sides identical.
+struct RawDid(String);
+
+impl<S: Send + Sync> FromRequestParts<S> for RawDid {
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        // Taken from the request path rather than through a path extractor: those decode the
+        // capture while routing, which is exactly what has to be avoided here. Every route that
+        // uses this puts the identifier in the final segment, and an identifier never contains a
+        // slash, so the last segment is the whole of it.
+        parts
+            .uri
+            .path()
+            .rsplit('/')
+            .next()
+            .filter(|segment| !segment.is_empty())
+            .map(|segment| RawDid(segment.to_string()))
+            .ok_or(StatusCode::BAD_REQUEST)
+    }
+}
+
+/// Alias under which the intermediary records its own identity.
+const SELF_ALIAS: &str = "self";
+
+/// Wallet key holding what is needed to publish the identity.
+const PUBLISH_KEY: &str = "publish";
+
+/// Wallet key recording the identity that has been published.
+const PUBLISHED_KEY: &str = "published";
+
+const PUBLISH_ATTEMPTS: u64 = 5;
+
+/// Check the identity held in the wallet against the configuration and against what is published.
+///
+/// The wallet, the arguments and the DID server each carry part of the same fact, and a wrong
+/// bucket or a copied deployment line can put them out of step. Running on regardless would mean
+/// serving one identity while clients look up another, which is invisible from inside.
+///
+/// Returns whether the identity still needs publishing.
+async fn check_identity(
+    db: &AsyncSecureStore,
+    did_server: &str,
+    name: &str,
+    domain: &str,
+    did: &str,
+) -> bool {
+    // Where the identifier says it is published, which must be where this instance was told to
+    // publish. Compared without a network call.
+    let published_as = format!("{}:endpoint:{name}", did_server.replace(':', "%3A"));
+    if !did.ends_with(&format!(":{published_as}")) {
+        panic!(
+            "the wallet holds {did}, which is not published as {published_as}. The wrong wallet \
+             is configured, or --did-server and --name do not match it."
+        );
+    }
+
+    // Where the identifier tells clients to send, which must be this instance.
+    if let Ok(vid) = db.get_verified_vid(did) {
+        let endpoint = vid.endpoint();
+        let reachable_at = match endpoint.port() {
+            Some(port) => format!("{}:{port}", endpoint.host_str().unwrap_or_default()),
+            None => endpoint.host_str().unwrap_or_default().to_string(),
+        };
+
+        if reachable_at != domain {
+            panic!(
+                "the wallet holds {did}, which directs clients to {reachable_at}, but this \
+                 instance was started for {domain}. The wrong wallet is configured, or the \
+                 domain does not match it."
+            );
+        }
+    }
+
+    // What the DID server actually serves under this name. Only checked if it answers, so that an
+    // unreachable DID server does not stop the intermediary from starting.
+    let url = did_server_url(did_server, &format!("endpoint/{name}/did.json"));
+    let Ok(response) = http_client().get(&url).send().await else {
+        return false;
+    };
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        tracing::warn!("{name} is not published at {did_server}; publishing it again");
+
+        return true;
+    }
+
+    let registered = response
+        .json::<serde_json::Value>()
+        .await
+        .ok()
+        .and_then(|doc| doc["id"].as_str().map(str::to_string));
+
+    match registered {
+        Some(registered) if registered == did => false,
+        Some(registered) => panic!(
+            "the name {name} at {did_server} is registered to {registered}, but this wallet holds \
+             {did}. The wrong wallet is configured. Clients resolve the registered identity, so \
+             this instance would be unreachable."
+        ),
+        None => false,
+    }
+}
+
+/// Refuse to start if the name is already registered but the wallet holds no identity.
+///
+/// The name is fixed in configuration, so this can only mean the wallet has been lost or the
+/// service was pointed at the wrong one. Creating a second identity under the same name would
+/// leave the intermediary unresolvable, and every client that already trusts the registered one
+/// would be silently stranded. Stopping makes it an operator decision.
+async fn refuse_if_name_taken(did_server: &str, name: &str) {
+    let url = did_server_url(did_server, &format!("endpoint/{name}/did.json"));
+
+    let Ok(response) = http_client().get(&url).send().await else {
+        // Unreachable at startup is the ordinary first-boot case, and publishing retries anyway.
+        return;
+    };
+
+    if response.status().is_success() {
+        panic!(
+            "the name {name} is already registered at {did_server} but this wallet holds no \
+             identity. The wallet is missing or the wrong one is configured. Restore it, or \
+             choose a different name deliberately."
+        );
+    }
+}
+
+/// Create this intermediary's identity and record it, with everything needed to publish it.
+async fn create_identity(
+    vault: &AskarSecureStorage,
+    db: &AsyncSecureStore,
+    did_server: &str,
+    name: &str,
+    transport: Url,
+) -> String {
+    refuse_if_name_taken(did_server, name).await;
+
+    let (private_vid, history, keys) =
+        tsp_sdk::vid::did::webvh::create_webvh(&format!("{did_server}/endpoint/{name}"), transport)
+            .await
+            .expect("could not create an identity");
+
+    let did = private_vid.identifier().to_string();
+
+    // Both update keys are kept. The current one authorises the next log entry; the other is
+    // committed in advance by hash. Without them the identity can never be updated again.
+    db.add_secret_key(keys.update_kid.clone(), keys.update_key)
+        .expect("could not store the update key");
+    db.add_secret_key(keys.next_update_kid.clone(), keys.next_update_key)
+        .expect("could not store the next update key");
+    db.set_alias(format!("__next_update_kid:{did}"), keys.next_update_kid)
+        .expect("could not record the next update key");
+
+    // Kept so publishing can be retried on a later start without creating a second identity.
+    vault
+        .store_kv(
+            PUBLISH_KEY,
+            &serde_json::to_vec(&serde_json::json!({
+                "vid": private_vid.vid(),
+                "history": history,
+            }))
+            .expect("could not encode the identity"),
+        )
+        .await
+        .expect("could not record the identity");
+
+    db.add_private_vid(private_vid, None)
+        .expect("could not store the identity");
+    db.set_alias(SELF_ALIAS.to_string(), did.clone())
+        .expect("could not record the identity");
+
+    tracing::info!("created identity {did}");
+
+    did
+}
+
+/// Publish the identity unless that has already been done.
+///
+/// Whether it was published is recorded in the wallet rather than tested by resolving it. The
+/// wallet is the record of what this intermediary has done, resolution depends on the DID server
+/// being reachable at startup, and a failed publish simply leaves the record unset so the next
+/// start tries again.
+async fn ensure_published(vault: &AskarSecureStorage, did_server: &str, did: &str) {
+    if matches!(vault.get_kv(PUBLISHED_KEY).await, Ok(Some(ref published)) if published == did.as_bytes())
+    {
+        tracing::info!("identity {did} is already published");
+
+        return;
+    }
+
+    let Ok(Some(stored)) = vault.get_kv(PUBLISH_KEY).await else {
+        panic!("identity {did} does not resolve and the wallet holds nothing to publish with");
+    };
+    let stored: serde_json::Value =
+        serde_json::from_slice(&stored).expect("could not decode the stored identity");
+
+    let client = http_client();
+
+    for attempt in 1..=PUBLISH_ATTEMPTS {
+        match publish(&client, did_server, did, &stored).await {
+            Ok(()) => {
+                if let Err(e) = vault.store_kv(PUBLISHED_KEY, did.as_bytes()).await {
+                    tracing::error!("published {did} but could not record that: {e}");
+                }
+                tracing::info!("published identity {did}");
+
+                return;
+            }
+            Err(e) => {
+                tracing::warn!("could not publish the identity (attempt {attempt}): {e}");
+                tokio::time::sleep(Duration::from_secs(2 * attempt)).await;
+            }
+        }
+    }
+
+    // Not fatal. The identity is safe in the wallet, the next start tries again, and clients that
+    // already know this intermediary can still reach it in the meantime.
+    tracing::error!("could not publish identity {did}; it will be retried on the next start");
+}
+
+async fn publish(
+    client: &reqwest::Client,
+    did_server: &str,
+    did: &str,
+    stored: &serde_json::Value,
+) -> Result<(), reqwest::Error> {
+    client
+        .post(did_server_url(did_server, "add-vid"))
+        .json(&stored["vid"])
+        .send()
+        .await?
+        .error_for_status()?;
+
+    client
+        .post(did_server_url(did_server, &format!("add-history/{did}")))
+        .json(&stored["history"])
+        .send()
+        .await?
+        .error_for_status()?;
+
+    Ok(())
 }
 
 /// A buffered message waiting for delivery via SSE.
@@ -182,6 +615,12 @@ struct IntermediaryState {
     domain: String,
     did: String,
     db: RwLock<AsyncSecureStore>,
+    /// The wallet is the authoritative copy; `db` is a working copy of it held in memory.
+    /// Anything that changes `db` is written back through here.
+    vault: AskarSecureStorage,
+    /// Where the wallet is kept between runs, and the name of its files on local disk.
+    bucket: Option<String>,
+    wallet: String,
     /// Per-recipient message buffers with monotonic IDs
     buffers: RwLock<HashMap<String, RecipientBuffer>>,
     /// Per-recipient SSE subscriber notifications
@@ -237,6 +676,35 @@ impl IntermediaryState {
         self.internal_log(text).await;
     }
 
+    /// Write the in-memory copy back to the wallet.
+    ///
+    /// Called after anything that changes the store, so that a restart resumes from the same
+    /// state. The whole wallet is rewritten each time, which is sound for a single instance;
+    /// per-record writes are what several instances would need.
+    async fn save(&self) {
+        let state = match self.db.read().await.export() {
+            Ok(state) => state,
+            Err(e) => {
+                tracing::error!("could not export the wallet: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) = self.vault.persist(state).await {
+            tracing::error!("could not write the wallet: {e}");
+
+            return;
+        }
+
+        // Written back whole, which is what a bucket does well and what the wallet is written as
+        // anyway. If this fails the change survives only until the instance stops.
+        if let Some(bucket) = &self.bucket
+            && let Err(e) = wallet_upload(bucket, &self.wallet).await
+        {
+            tracing::error!("could not write the wallet to {bucket}: {e}");
+        }
+    }
+
     async fn verify_vid(&self, vid: &str) -> Result<(), tsp_sdk::Error> {
         if self.db.read().await.has_verified_vid(vid)? {
             tracing::trace!("VID {} already verified", vid);
@@ -253,6 +721,8 @@ impl IntermediaryState {
             .await
             .add_verified_vid(verified_vid, metadata)?;
         tracing::trace!("stored resolved vid: {vid}");
+        self.save().await;
+
         Ok(())
     }
 }
@@ -277,15 +747,93 @@ async fn main() {
 
     let args = Cli::parse();
 
-    // Generate PIV
-    let did = format!("did:web:{}", args.domain.replace(":", "%3A"));
-    let transport =
-        Url::parse(format!("https://{}/transport/{did}", args.domain).as_str()).unwrap();
-    let private_vid = OwnedVid::bind(did.clone(), transport);
-    let did_doc = vid_to_did_document(private_vid.vid()).to_string();
+    let name = args.name.clone().unwrap_or_else(|| {
+        args.domain
+            .split('.')
+            .next()
+            .unwrap_or("intermediary")
+            .to_string()
+    });
 
-    let db = AsyncSecureStore::new();
-    db.add_private_vid(private_vid, None).unwrap();
+    // The transport carries a placeholder rather than the identifier. A did:webvh identifier is
+    // derived from its own genesis log entry, so it is not known until the identity exists; the
+    // placeholder is substituted with the recipient's identifier when a message is sent.
+    let transport = Url::parse(&format!(
+        "https://{}/transport/[vid_placeholder]",
+        args.domain
+    ))
+    .unwrap();
+
+    let password = wallet_password().await;
+
+    // Starting without it would look like a first run and create a second identity, which the
+    // startup checks would then refuse anyway. Failing here says why.
+    if let Some(bucket) = &args.bucket
+        && let Err(e) = wallet_download(bucket, &args.wallet).await
+    {
+        panic!("could not fetch the wallet from {bucket}: {e}");
+    }
+
+    let wallet_url = format!("sqlite://{}.sqlite", args.wallet);
+
+    let (vault, db) = match AskarSecureStorage::open(&wallet_url, password.as_bytes()).await {
+        Ok(vault) => {
+            let (vids, aliases, keys) = vault.read().await.expect("could not read the wallet");
+            let db = AsyncSecureStore::new();
+            db.import(vids, aliases, keys)
+                .expect("could not load the wallet");
+            tracing::info!("opened wallet {}", args.wallet);
+
+            (vault, db)
+        }
+        Err(_) => {
+            let vault = AskarSecureStorage::new(&wallet_url, password.as_bytes())
+                .await
+                .expect("could not create a wallet");
+            tracing::info!("created wallet {}", args.wallet);
+
+            (vault, AsyncSecureStore::new())
+        }
+    };
+
+    // The identity is created once and then reused for the life of the wallet. This is the whole
+    // point of the wallet: without it the intermediary published a new key set on every start,
+    // and every relationship a client held with it died.
+    // An unknown alias resolves to itself, so the result only counts if the wallet actually holds
+    // the private keys for it.
+    let held = db
+        .try_resolve_alias(SELF_ALIAS)
+        .ok()
+        .filter(|did| db.has_private_vid(did).unwrap_or(false));
+
+    let did = match held {
+        Some(did) => {
+            tracing::info!("reusing the identity held in the wallet: {did}");
+
+            if check_identity(&db, &args.did_server, &name, &args.domain, &did).await {
+                // Recorded as published but no longer served, so let it be published again.
+                let _ = vault.remove_kv(PUBLISHED_KEY).await;
+            }
+
+            did
+        }
+        None => create_identity(&vault, &db, &args.did_server, &name, transport).await,
+    };
+
+    // Publishing is checked on every start rather than only at creation, so that an identity
+    // created while the DID server was unreachable is published later without operator action.
+    ensure_published(&vault, &args.did_server, &did).await;
+
+    vault
+        .persist(db.export().expect("could not export the wallet"))
+        .await
+        .expect("could not write the wallet");
+
+    if let Some(bucket) = &args.bucket {
+        wallet_upload(bucket, &args.wallet)
+            .await
+            .expect("could not write the wallet to the bucket");
+    }
 
     let buffer_ttl = Duration::from_secs(args.buffer_ttl);
     let buffer_max = args.buffer_max;
@@ -301,6 +849,9 @@ async fn main() {
         domain: args.domain.to_owned(),
         did,
         db: RwLock::new(db),
+        vault,
+        bucket: args.bucket.clone(),
+        wallet: args.wallet.clone(),
         buffers: RwLock::new(HashMap::new()),
         subscribers: Mutex::new(SseSubscribers::new()),
         buffer_ttl,
@@ -348,10 +899,8 @@ async fn main() {
         // Legacy WebSocket endpoint for backward compatibility
         .route("/ws/transport/{did}", get(websocket_handler))
         .route("/ws/endpoint/{did}", get(websocket_handler))
-        .route(
-            "/.well-known/did.json",
-            get(async || ([(header::CONTENT_TYPE, "application/json")], did_doc)),
-        )
+        // The intermediary no longer serves its own DID document: a did:webvh identity resolves
+        // at the DID server, which is what makes its key history verifiable.
         .route("/logs", get(log_websocket_handler))
         .with_state(state);
 
@@ -381,7 +930,7 @@ async fn index(State(state): State<Arc<IntermediaryState>>) -> Html<String> {
 
 async fn new_message(
     State(state): State<Arc<IntermediaryState>>,
-    Path(did): Path<String>,
+    RawDid(did): RawDid,
     body: Bytes,
 ) -> Response {
     let mut message: BytesMut = body.into();
@@ -551,6 +1100,9 @@ async fn new_message(
                 return discard("error accepting relationship");
             }
 
+            // The relationship now exists, so it has to outlive this process.
+            state.save().await;
+
             state.log(if let Some(nested_vid) = nested_vid {
                     format!(
                         "Accepted nested relationship request from {sender} with nested VID {nested_vid}"
@@ -601,6 +1153,7 @@ async fn new_message(
                 }
                 tracing::trace!("Releasing lock guard on AsyncStore");
                 drop(store);
+                state.save().await;
             }
 
             let (transport, message) = match state.db.read().await.make_next_routed_message(
@@ -617,7 +1170,7 @@ async fn new_message(
 
             if transport.host_str() == Some(&state.domain) {
                 tracing::debug!("Forwarding message to myself...");
-                return Box::pin(new_message(State(state), Path(did), message.into())).await;
+                return Box::pin(new_message(State(state), RawDid(did), message.into())).await;
             } else {
                 tracing::debug!("Sending forwarded message...");
 
@@ -647,7 +1200,7 @@ async fn new_message(
 /// Server sends keepalive comments every 15 seconds to detect dead connections.
 async fn sse_handler(
     State(state): State<Arc<IntermediaryState>>,
-    Path(did): Path<String>,
+    RawDid(did): RawDid,
     headers: HeaderMap,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     // Parse Last-Event-ID for replay
@@ -732,7 +1285,7 @@ async fn sse_handler(
 /// from the recipient's buffer.
 async fn ack_handler(
     State(state): State<Arc<IntermediaryState>>,
-    Path(did): Path<String>,
+    RawDid(did): RawDid,
     body: Bytes,
 ) -> Response {
     // Parse the ack body
@@ -783,7 +1336,7 @@ async fn ack_handler(
 async fn websocket_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<IntermediaryState>>,
-    Path(did): Path<String>,
+    RawDid(did): RawDid,
 ) -> impl IntoResponse {
     tracing::info!("{} listening for messages intended for {did}", state.domain);
     let mut messages_rx = state.message_tx.subscribe();

--- a/tsp_sdk/src/store.rs
+++ b/tsp_sdk/src/store.rs
@@ -351,6 +351,26 @@ pub struct SecureStore {
 }
 
 /// This wallet is used to store and resolve VIDs
+/// The transport to use when sending to `vid`.
+///
+/// A transport may carry a placeholder where the identifier belongs. For identifier methods whose
+/// identifier is derived from the document that holds the transport, the transport cannot name
+/// that identifier without defining it circularly, so it is filled in at the point of use. The
+/// identifier is inserted verbatim: it is one path segment, and a receiver keying anything by it
+/// has to see exactly the text the identifier is written with.
+fn sending_endpoint(vid: &dyn VerifiedVid) -> url::Url {
+    let mut endpoint = vid.endpoint().clone();
+
+    if endpoint.path().contains("[vid_placeholder]") {
+        let path = endpoint
+            .path()
+            .replace("[vid_placeholder]", vid.identifier());
+        endpoint.set_path(&path);
+    }
+
+    endpoint
+}
+
 impl SecureStore {
     /// Create a new, empty VID wallet
     pub fn new() -> Self {
@@ -1096,7 +1116,7 @@ impl SecureStore {
             selection,
         )?;
 
-        Ok((receiver_context.vid.endpoint().clone(), tsp_message))
+        Ok((sending_endpoint(&*receiver_context.vid), tsp_message))
     }
 
     /// Sign a unencrypted message, without a specified recipient
@@ -1933,7 +1953,7 @@ impl SecureStore {
             sender_new_vid.identifier(),
         )?;
 
-        Ok((receiver.endpoint().clone(), tsp_message.to_owned()))
+        Ok((sending_endpoint(&*receiver), tsp_message.to_owned()))
     }
 
     /// Accept a direct relationship between the resolved VIDs identifier by `sender` and `receiver`.
@@ -2012,7 +2032,7 @@ impl SecureStore {
         )?;
         self.remove_pending_incoming_parallel_request(receiver_new_vid.identifier(), thread_id)?;
 
-        Ok((receiver_new_vid.endpoint().clone(), tsp_message.to_owned()))
+        Ok((sending_endpoint(&*receiver_new_vid), tsp_message.to_owned()))
     }
 
     /// Cancels a direct relationship between the resolved `sender` and `receiver` VIDs.


### PR DESCRIPTION
An intermediary generated fresh keys on every start, so it published the same identifier with
different key material after each deploy, and every relationship a client held with it became
invalid. The previous revision let clients accept the new keys silently; this one refuses them,
because the identifier method carried no history and a key change could not be told from a
substitution.

## What changes

The intermediary keeps a wallet. It creates a `did:webvh` identity once, publishes it, and reuses
it thereafter, retrying the publish on a later start if the DID server was unreachable. It no
longer serves its own DID document, since a `did:webvh` identity resolves at the DID server, which
is what makes its key history verifiable.

The wallet is kept in a bucket as a single object rather than through a mounted filesystem. Object
storage replaces an object completely or not at all, which is how the wallet is written anyway,
and cannot support the in-place edits a database file makes constantly. The wallet therefore lives
on the instance's own disk while running and is written back whole on every change. A database
service remains the path for when the wallet grows large enough that this is wasteful, or when
more than one instance writes to it.

The wallet password is read at startup from Secret Manager using the service's own identity, so it
appears nowhere in the deployment configuration.

Four startup checks stop the service when the wallet, the arguments and the DID server disagree,
each naming the conflict; a fifth republishes an identity the DID server no longer serves. Without
them a wrong bucket or a copied deployment line would leave an intermediary serving one identity
while clients look up another, which is invisible from inside.

## Defects found while testing this

- **The transport placeholder was never filled in when sending.** A transport may carry a
  placeholder where the receiver's identifier belongs, because an identifier derived from the
  document that holds the transport cannot be named by it without circularity. The substitution
  was performed when listening for messages but not when sending one, so sending to such a VID
  posted to a URL containing the literal placeholder. It went unnoticed because the identifier
  method in general use embeds no derived value, and because the command line tool performs the
  substitution itself.

- **The message buffer was keyed two different ways.** Messages were buffered under the receiver
  identifier taken verbatim from the wire but read back under the URL path segment, which the web
  framework percent-decodes. An identifier holding a percent-encoded colon was stored under one
  key and looked up under another, so its buffered messages were never found.

- **Publishing an identity always used HTTPS** while resolving one addresses a local DID server
  over plain HTTP, so an identity created against a local DID server was written to one place and
  read from another. This prevented end to end testing against local services.

## Verified by running it

- The identifier is unchanged across a restart, and a client re-verifies it without the key state
  conflict that this fixes.
- A relationship formed with an intermediary survives the wallet being copied while the service is
  running, wiped, and restored.
- Each of three misconfigurations is refused at startup with the conflict named.
- The buffer key now preserves a percent-encoded colon.

The calls to Secret Manager and to the bucket cannot be exercised outside the cloud and are
unverified.

## Deployment

Each intermediary needs a bucket and a secret holding its wallet password, with the runtime service
account granted object admin on the bucket and secret accessor on the secret. The service account
is new to the intermediary template and was taken from the DID server's; it should be confirmed
against what Cloud Run actually uses.

Documentation no longer spells out intermediary identifiers, which cannot be known before
deployment. One captured session in the routed walkthrough still shows the old identifiers inside
an encoded message and has to be recaptured once the intermediaries are deployed.