### PR TITLE
Build without default features again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,18 @@ jobs:
       - run: |
           cargo test --features "${{ matrix.features }}"
 
+  check-deployed-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # The container image builds these three with no default features. Nothing else here does,
+      # so code that only compiles with the defaults passes every check and then fails when the
+      # image is built, after the merge that was supposed to deploy it.
+      - name: Build the deployed binaries the way the image does
+        run: cargo build --bin demo-intermediary --bin demo-server --bin did-server --no-default-features
+
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/tsp_sdk/Cargo.toml
+++ b/tsp_sdk/Cargo.toml
@@ -40,7 +40,7 @@ async = [
   "dep:quinn",
 ]
 resolve = ["serialize", "dep:reqwest", "dep:didwebvh-rs"]
-serialize = ["dep:serde", "dep:serde_with"]
+serialize = ["dep:serde_with"]
 use_local_certificate = []
 postgres = ["async", "aries-askar/postgres"]
 
@@ -80,7 +80,7 @@ quinn = { workspace = true, optional = true }
 # resolve
 reqwest = { workspace = true, optional = true }
 # serialize
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = false }
 serde_json = { workspace = true, optional = false }
 serde_with = { workspace = true, optional = true }
 bs58 = { workspace = true, optional = false }


### PR DESCRIPTION
The container image builds the three deployed binaries with `--no-default-features`. The library
stopped compiling that way: the `did:peer` numalgo 4 work introduced a DID document built with
serde, but serde was optional, enabled only by the `serialize` feature. Constructing a numalgo 4
identifier is core rather than optional, so serde is now a required dependency.

The reason this reached `main` is that nothing in the checks builds that configuration. The test
matrix varies `--features` but always keeps the defaults. So the code passed every check and
failed only when the image was built — that is, after the merge that was meant to deploy it, with
the deployment step skipped and nothing released.

A check now builds the same three binaries the same way the image does.