### PR TITLE
Build on the minimum supported compiler again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,11 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned to the minimum supported version in the workspace manifest, and not `stable`.
+      # Every other job here runs the newest compiler, so nothing establishes that the version
+      # the workspace claims to support can build this at all.
+      - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
       # The container image builds these three with no default features. Nothing else here does,
-      # so code that only compiles with the defaults passes every check and then fails when the
-      # image is built, after the merge that was supposed to deploy it.
+      # so code that only compiles with the defaults, or only on a newer compiler, passes every
+      # check and then fails when the image is built, after the merge meant to deploy it.
       - name: Build the deployed binaries the way the image does
         run: cargo build --bin demo-intermediary --bin demo-server --bin did-server --no-default-features
 

--- a/tsp_sdk/src/crypto/mod.rs
+++ b/tsp_sdk/src/crypto/mod.rs
@@ -234,7 +234,7 @@ pub(crate) fn build_parallel_request_signed_data(
 ) -> Result<Vec<u8>, CryptoError> {
     // the digest is derived first (its own slot dummied, the new-VID signature
     // not yet present); the signature is then made over the final digest
-    let payload = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
+    let payload: crate::cesr::Payload<'_, &[u8], &[u8]> = crate::cesr::Payload::RelationProposal {
         request_digest: digest_algorithm.field(&*request_digest),
         nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
         reply_path: reply_path.to_vec(),
@@ -946,7 +946,7 @@ mod tests {
         let algorithm = super::RelationshipDigestAlgorithm::Sha2_256;
         let nonce_bytes = [7_u8; 16];
         let mut digest = [0_u8; 32];
-        let payload = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
+        let payload = crate::cesr::Payload::<'_, &[u8], &[u8]>::RelationProposal {
             request_digest: algorithm.field(&digest),
             nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
             reply_path: vec![],
@@ -957,7 +957,7 @@ mod tests {
             .unwrap();
         digest = algorithm.hash(&input);
 
-        let good = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
+        let good = crate::cesr::Payload::<'_, &[u8], &[u8]>::RelationProposal {
             request_digest: algorithm.field(&digest),
             nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
             reply_path: vec![],
@@ -967,7 +967,7 @@ mod tests {
 
         let mut tampered_digest = digest;
         tampered_digest[0] ^= 0x01;
-        let tampered = crate::cesr::Payload::<&[u8], &[u8]>::RelationProposal {
+        let tampered = crate::cesr::Payload::<'_, &[u8], &[u8]>::RelationProposal {
             request_digest: algorithm.field(&tampered_digest),
             nonce: crate::cesr::Nonce::generate(|dst| *dst = nonce_bytes),
             reply_path: vec![],


### PR DESCRIPTION
The container image builds with the compiler version the workspace names as its minimum. The
library no longer compiled there: a payload was constructed by naming the enum's generic arguments
on the variant, and that compiler rejects generic arguments on a variant path when a lifetime is
among them. The arguments now sit on the binding instead, which both compilers accept.

Verified by building the three deployed binaries with that compiler, not by reading release notes.

## Why this reached `main` twice

The previous fix added a check for the image's feature selection but ran it on the newest
compiler, as every other check here does. So it closed one of the two differences between what is
checked and what is built, and left the other open.

That check is now pinned to the version the workspace declares. Nothing previously established
that the declared minimum could build the workspace at all, which is how the code drifted past it
unnoticed.