### PR TITLE
Add raw signing accessors for external issuance

### DIFF
--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -415,6 +415,43 @@ impl AsyncSecureStore {
     /// Retrieve a previously stored raw secret key by `kid`.
     ///
     /// Returns `None` if no key is stored under `kid`.
+    /// Return the raw 32-byte Ed25519 private signing key for `vid`.
+    ///
+    /// SECURITY: This surfaces private key material. Only use it when
+    /// interoperating with an external signing scheme that embeds the
+    /// signing step in its own construction (e.g. biscuit-auth token
+    /// building). For detached signatures over arbitrary bytes, prefer
+    /// `sign_raw` — it keeps the key inside the store.
+    ///
+    /// Errors if the VID is not present in the store, has no private
+    /// key material, or uses a non-Ed25519 signature key type.
+    pub fn ed25519_signing_key(&self, vid: &str) -> Result<[u8; 32], Error> {
+        let signer = self.inner.get_private_vid(vid)?;
+        if signer.signature_key_type() != crate::definitions::VidSignatureKeyType::Ed25519 {
+            return Err(Error::UnsupportedSignatureKeyType);
+        }
+        let slice = signer.signing_key().as_slice();
+        <[u8; 32]>::try_from(slice).map_err(|_| Error::UnsupportedSignatureKeyType)
+    }
+
+    /// Produce a raw detached signature over `data` using the private
+    /// signing key of the private VID identified by `vid`.
+    ///
+    /// Does not construct a CESR envelope — the caller is responsible
+    /// for any domain-separation prefix or framing. The returned bytes
+    /// are the signature only; their format depends on the VID's
+    /// signature key type (Ed25519 → 64 bytes; MlDsa65 → ML-DSA-65
+    /// signature).
+    ///
+    /// Typical callers: issuers of non-TSP-envelope artefacts (e.g.
+    /// Biscuit capabilities) that want to sign with the VID key.
+    /// Verifiers should resolve the matching public key via
+    /// `verify_vid(…)` and use the corresponding primitive.
+    pub fn sign_raw(&self, vid: &str, data: &[u8]) -> Result<Vec<u8>, Error> {
+        let signer = self.inner.get_private_vid(vid)?;
+        Ok(crate::crypto::sign_detached(signer.as_ref(), data)?)
+    }
+
     pub fn get_secret_key(&self, kid: &str) -> Result<Option<Vec<u8>>, Error> {
         self.inner.get_secret_key(kid)
     }

--- a/tsp_sdk/src/error.rs
+++ b/tsp_sdk/src/error.rs
@@ -1,6 +1,8 @@
 /// Error originating from the TSP library
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("Unsupported signature key type for this operation")]
+    UnsupportedSignatureKeyType,
     #[error("Error: {0}")]
     Encode(#[from] crate::cesr::error::EncodeError),
     #[error("Error: {0}")]


### PR DESCRIPTION
Two narrow accessors on the store, for signing schemes that do not use a TSP envelope.

- `ed25519_signing_key(vid)` returns the raw private key. Needed where a scheme embeds the signing
  step in its own construction and offers no way to pass a signing callback.
- `sign_raw(vid, data)` produces a detached signature over arbitrary bytes and keeps the key
  inside the store, which is preferable wherever it is sufficient.

Both are additive and change no existing path.

They were written when an external consumer's capability issuance first needed them, against an
earlier revision, and never merged. Most of that work turned out to be unnecessary: a detached
signing primitive covering both signature key types has since been added for the protocol's own
use, so these are thin wrappers over it rather than a second implementation of the same thing.