### PR TITLE
Bound the network calls made before the port opens

### DIFF
--- a/examples/src/intermediary.rs
+++ b/examples/src/intermediary.rs
@@ -313,7 +313,12 @@ fn did_server_url(did_server: &str, path: &str) -> String {
 /// An HTTP client that trusts the test certificate when built for local testing.
 fn http_client() -> reqwest::Client {
     let client = reqwest::ClientBuilder::new()
-        .user_agent(format!("TSP intermediary / {}", env!("CARGO_PKG_VERSION")));
+        .user_agent(format!("TSP intermediary / {}", env!("CARGO_PKG_VERSION")))
+        // Every one of these calls happens before the port is opened. Without a bound, one that
+        // hangs stops the service from ever starting, and the host kills it for not listening —
+        // reporting a timeout, with nothing in the log to say what was waiting.
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(20));
 
     #[cfg(feature = "use_local_certificate")]
     let client = client.add_root_certificate({


### PR DESCRIPTION
An intermediary failed to start with no panic in its log — only the host reporting that the
container never listened on its port.

Startup reads a token from the metadata server, checks the bucket exists, fetches the wallet, and
may publish the identity. None of those requests had a timeout. One that hangs stops the service
from ever opening its port, and the failure then looks like silence rather than an error.

An intermediary that has to publish does much more of this than one reusing what it already holds
— five attempts with backoff, none bounded. That is the one that failed, while its sibling, which
had nothing to publish, started normally.

Requests now have a connect and a total timeout. The worst case is about two minutes, inside the
host's allowance, and a hung call fails with a message naming it.

**This is the suspected cause of that failure rather than a confirmed one** — the container
produced no output to confirm it with, which is itself consistent with a hang. The missing
timeouts are a defect regardless of whether they explain that particular start.