### PR TITLE
Rewrite the readme around what the protocol does

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,17 @@ Prototype Rust SDK for the [Trust Spanning Protocol](https://trustoverip.github.
 
 ## Status
 
-This project is in its initial state. Development is ongoing and interfaces or
-structure of the repository are likely to change. Nothing in this repository at
-this moment represents a "final design" or to be overriding the Trust Spanning Protocol specification, or indicating a
+This implements revision 3 of the specification. Development is ongoing and interfaces or
+structure of the repository are likely to change. Nothing in this repository at this moment
+represents a "final design", overrides the Trust Spanning Protocol specification, or indicates a
 future direction of the Trust Spanning Protocol.
 
 In short, it is not the reference implementation _yet_.
+
+Messages produced by this revision do not interoperate with earlier ones: the wire version
+changed, the default encryption changed, and `did:peer` identifiers now use numalgo 4. Wallets
+created by earlier versions still open, and `did:web` and `did:webvh` identifiers created by them
+still resolve.
 
 ## How to build this project
 
@@ -58,12 +63,14 @@ The code is organized in various directories:
   - `cesr/` provides minimalist CESR encoding/decoding support that is sufficient for generating and parsing TSP
     messages; to keep complexity to a minimum, we explicitly do not provide a full CESR decoder/encoder.
   - `crypto/` contains the cryptographic core:
-    - generating non-confidential messages signed using Ed25519
-    - generating confidential messages encrypted using [HPKE-Auth](https://datatracker.ietf.org/doc/rfc9180/); using
-      DHKEM(X25519, HKDF-SHA256) as asymmetric primitives and ChaCha20/Poly1305 as underlying AEAD encrypting scheme,
-      and signed using Ed25519 to achieve **non-repudiation** (more precisely "strong receiver-unforgeability under
-      chosen ciphertext" or [RUF-CTXT](https://eprint.iacr.org/2001/079)
-      or [Insider-Auth](https://eprint.iacr.org/2020/1499.pdf)).
+    - signed-only messages, whose payload travels in the clear, signed with Ed25519 or ML-DSA-65
+    - confidential messages encrypted with [HPKE](https://datatracker.ietf.org/doc/rfc9180/) in Base mode, using
+      HKDF-SHA256 and ChaCha20/Poly1305, and signed. The key encapsulation follows the recipient's encryption key
+      type — X25519, or X25519MLKEM768 for post-quantum — so there is no separate post-quantum mode to select.
+    - the sender's own identifier travels *inside* the encrypted payload rather than beside it, which is what binds
+      a message to its sender. The properties this provides, and the argument for them, are in the security
+      considerations of the specification rather than restated here.
+    - the libsodium anonymous sealed box remains available for existing implementations.
   - `definitions/` defines several common data structures, traits and error types that are used throughout the project.
   - `transport/` code (built using [tokio](https://tokio.rs/) foundations) for actually sending and receiving data over
     a transport layer.
@@ -90,7 +97,7 @@ cargo install --path examples/ --bin tsp
 To create an identity:
 
 ```sh
-tsp create --type web --alias bob bob
+tsp create --type webvh --alias bob bob
 ```
 
 To verify a VID:

--- a/README.md
+++ b/README.md
@@ -6,119 +6,134 @@
 
 # TSP SDK
 
-Prototype Rust SDK for the [Trust Spanning Protocol](https://trustoverip.github.io/tswg-tsp-specification/)
+A Rust implementation of the [Trust Spanning Protocol](https://trustoverip.github.io/tswg-tsp-specification/).
+
+TSP lets two parties who each have a verifiable identifier — a `did:webvh`, a `did:peer`, or an
+identifier from some other system entirely — exchange messages that are authentic, confidential,
+and attributable to the identifier rather than to a key. It is a spanning layer: it does not
+replace the network you send over, and it does not care which identifier system either side uses,
+only that both can be resolved and verified.
+
+This crate gives you a wallet holding your own identifiers and the ones you have verified, and a
+small API for sending and receiving over that wallet. Where the message travels — HTTP, TCP, TLS,
+QUIC, or through an intermediary that holds it until you collect it — is a property of the
+identifier you are sending to, not something you choose at each call.
+
+## What using it looks like
+
+```rust
+let mut alice = AsyncSecureStore::new();
+alice.add_private_vid(OwnedVid::from_file("alice/piv.json").await?, None)?;
+alice.verify_vid("did:webvh:...:bob", Some("bob".into())).await?;
+
+alice.send(alice_vid, bob_vid, b"hello world").await?;
+```
+
+Bob receives a stream, because a message is not the only thing that can arrive — a first contact
+also brings a request to form a relationship:
+
+```rust
+while let Some(message) = bobs_messages.next().await {
+    match message? {
+        ReceivedTspMessage::GenericMessage { sender, message, .. } => { /* ... */ }
+        ReceivedTspMessage::RequestRelationship { sender, .. } => { /* ... */ }
+        _ => {}
+    }
+}
+```
+
+The complete, compiling version of this is in the [crate documentation](https://docs.rs/tsp_sdk/),
+where it runs as part of the test suite.
 
 ## Status
 
-This implements revision 3 of the specification. Development is ongoing and interfaces or
-structure of the repository are likely to change. Nothing in this repository at this moment
-represents a "final design", overrides the Trust Spanning Protocol specification, or indicates a
-future direction of the Trust Spanning Protocol.
-
-In short, it is not the reference implementation _yet_.
+This implements revision 3 of the specification. Development is ongoing, and interfaces or the
+structure of the repository are likely to change. Nothing here represents a "final design",
+overrides the specification, or indicates a future direction for it. It is not the reference
+implementation _yet_.
 
 Messages produced by this revision do not interoperate with earlier ones: the wire version
-changed, the default encryption changed, and `did:peer` identifiers now use numalgo 4. Wallets
-created by earlier versions still open, and `did:web` and `did:webvh` identifiers created by them
+changed, the default encryption changed, and `did:peer` identifiers moved to numalgo 4. Wallets
+written by earlier versions still open, and `did:web` and `did:webvh` identifiers created by them
 still resolve.
 
-## How to build this project
+## Building and testing
 
-You will need to install the most recent Rust compiler, by following the
-[these instructions](https://www.rust-lang.org/tools/install).
-
-Then, you can use these commands to check out and test the repository:
+Install a recent Rust compiler by [following these instructions](https://www.rust-lang.org/tools/install),
+then:
 
 ```sh
 git clone https://github.com/openwallet-foundation-labs/tsp.git
-cd tsp/tsp_sdk
+cd tsp
 cargo test
 ```
 
-If you want to test the language bindings for Python and JavaScript as well, you can run `cargo test` in the top level
-directory of this repository. Please be aware that this requires a working Python installation on your system.
+Running `cargo test` from the top level also exercises the Python and JavaScript bindings, which
+needs a working Python installation. To test only the library, run it in `tsp_sdk/` instead.
 
-To build the documentation, run:
+To build the documentation:
 
 ```sh
 cargo doc --workspace --no-deps
 ```
 
-Apart from the library, there are a few example executables.
-The CLI is most useful, see below how to install and use the CLI.
+## The command line tool
 
-## Organization of the project folder
-
-At this point in time, this repository is organized
-using [Cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html).
-The workspace contains five crates, the TSP SDK crate, an examples crate, bindings for Python and JavaScript, and one
-for fuzzing.
-
-The code is organized in various directories:
-
-- `examples/` contains example programs
-- `tsp_python` contains the Python bindings
-- `tsp_javascript` contains the JavaScript bindings
-- `tsp_sdk/` contains the TSP library, the source code is divided in the following modules / folders:
-  - `cesr/` provides minimalist CESR encoding/decoding support that is sufficient for generating and parsing TSP
-    messages; to keep complexity to a minimum, we explicitly do not provide a full CESR decoder/encoder.
-  - `crypto/` contains the cryptographic core:
-    - signed-only messages, whose payload travels in the clear, signed with Ed25519 or ML-DSA-65
-    - confidential messages encrypted with [HPKE](https://datatracker.ietf.org/doc/rfc9180/) in Base mode, using
-      HKDF-SHA256 and ChaCha20/Poly1305, and signed. The key encapsulation follows the recipient's encryption key
-      type — X25519, or X25519MLKEM768 for post-quantum — so there is no separate post-quantum mode to select.
-    - the sender's own identifier travels *inside* the encrypted payload rather than beside it, which is what binds
-      a message to its sender. The properties this provides, and the argument for them, are in the security
-      considerations of the specification rather than restated here.
-    - the libsodium anonymous sealed box remains available for existing implementations.
-  - `definitions/` defines several common data structures, traits and error types that are used throughout the project.
-  - `transport/` code (built using [tokio](https://tokio.rs/) foundations) for actually sending and receiving data over
-    a transport layer.
-  - `vid/` contains code for handling _verified identifiers_ and identities. Currently, `did:peer`, `did:web` and `did:webvh` are
-    supported.
-
-## Documentation
-
-Documentation on TSP and how to use our example projects (CLI / web interface)
-can be found on <https://docs.teaspoon.world>.
-
-The development documentation is available at [docs.rs](https://docs.rs/tsp_sdk/).
-
-## Test CLI
-
-The `examples` crate contains a test CLI interface for this library.
-
-Install it by running the following command in the project root:
+The `examples` crate contains a command line tool, which is the quickest way to see the protocol
+work end to end. Install it from the project root:
 
 ```sh
 cargo install --path examples/ --bin tsp
 ```
 
-To create an identity:
+Create an identity, and verify someone else's:
 
 ```sh
 tsp create --type webvh --alias bob bob
-```
-
-To verify a VID:
-
-```sh
 tsp verify --alias alice did:web:raw.githubusercontent.com:openwallet-foundation-labs:tsp:main:examples:test:alice
 ```
 
-See <https://docs.teaspoon.world> for the full documentation.
+The [documentation](https://docs.teaspoon.world) walks through sending directly, sending through
+an intermediary so that neither correspondent learns the other's address, and nesting one message
+inside another.
 
-## Implement custom VIDs
+## Cryptography
 
-See [the documentation](https://docs.teaspoon.world/custom-vids.html) on how to implement custom
-VIDs.
+Confidential messages are encrypted with [HPKE](https://datatracker.ietf.org/doc/rfc9180/) in Base
+mode, using HKDF-SHA256 and ChaCha20/Poly1305, and signed. The key encapsulation follows the
+recipient's encryption key type — X25519, or X25519MLKEM768 for post-quantum — so there is no
+separate post-quantum mode to select. Signatures are Ed25519 or ML-DSA-65. A message may also be
+signed without being encrypted, in which case its payload travels in the clear.
 
-## Intermediary server
+What binds a message to its sender is that the sender's own identifier travels *inside* the
+encrypted payload rather than beside it, where an attacker could change it. The properties this
+provides are argued in the security considerations of the specification rather than restated here.
 
-See [the documentation](https://docs.teaspoon.world/intermediary.html) on how to create / set up an
-intermediary server.
+The libsodium anonymous sealed box remains available for existing implementations.
 
-## Technical specification
+## Repository layout
 
-See [the documentation](https://docs.teaspoon.world/TSP-technical-specification.html) for the
-technical specification.
+The workspace holds five crates:
+
+- `tsp_sdk/` — the library
+- `examples/` — the command line tool, a demo server, an intermediary, and a DID server
+- `tsp_python/`, `tsp_javascript/` — bindings
+- `fuzz/` — fuzzing targets
+
+Inside the library:
+
+- `cesr/` — encoding and decoding of the wire format. Deliberately minimal: enough to produce and
+  parse TSP messages, not a general CESR implementation.
+- `crypto/` — the cryptographic core described above.
+- `vid/` — verified identifiers. `did:peer`, `did:web` and `did:webvh` are supported; see
+  [the documentation](https://docs.teaspoon.world/custom-vids.html) for adding your own.
+- `transport/` — sending and receiving over HTTP, TCP, TLS and QUIC, built on
+  [tokio](https://tokio.rs/).
+- `definitions/` — the data structures, traits and errors shared across the above.
+
+## Further reading
+
+- [docs.teaspoon.world](https://docs.teaspoon.world) — guides, the command line tool, and how to
+  [run an intermediary](https://docs.teaspoon.world/intermediary.html)
+- [docs.rs/tsp_sdk](https://docs.rs/tsp_sdk/) — API documentation
+- [the specification](https://trustoverip.github.io/tswg-tsp-specification/)

--- a/examples/src/cli.rs
+++ b/examples/src/cli.rs
@@ -143,7 +143,7 @@ enum Commands {
     Print { alias: String },
     #[command(
         arg_required_else_help = true,
-        about = "create and register a did:web identifier"
+        about = "create an identifier and register it, of the type given by --type"
     )]
     Create {
         #[arg(short, long)]

--- a/tsp_sdk/src/lib.rs
+++ b/tsp_sdk/src/lib.rs
@@ -81,13 +81,20 @@
 pub mod cesr;
 
 /// Contains the cryptographic core of the TSP protocol
-///   - generating non-confidential messages signed using Ed25519
-///   - generating confidential messages encrypted using
-///     [HPKE-Auth](https://datatracker.ietf.org/doc/rfc9180/);
-///     using DHKEM(X25519, HKDF-SHA256) as asymmetric primitives and
-///     ChaCha20/Poly1305 as underlying AEAD encrypting scheme,
-///     and signed using Ed25519 to achieve **non-repudiation**
-///     (more precisely "strong receiver-unforgeability under chosen
+///   - signed-only messages, whose payload travels in the clear,
+///     signed with Ed25519 or ML-DSA-65
+///   - confidential messages encrypted with
+///     [HPKE](https://datatracker.ietf.org/doc/rfc9180/) in Base mode,
+///     using HKDF-SHA256 and ChaCha20/Poly1305, and signed. The key
+///     encapsulation follows the recipient's encryption key type —
+///     X25519, or X25519MLKEM768 for post-quantum — so there is no
+///     separate post-quantum mode to select.
+///   - the sender's own identifier travels inside the encrypted payload
+///     rather than beside it, which is what binds a message to its
+///     sender. The properties this provides are argued in the security
+///     considerations of the specification.
+///   - the libsodium anonymous sealed box remains available for existing
+///     implementations.
 pub mod crypto;
 
 #[cfg(feature = "bench-network-timings")]


### PR DESCRIPTION
The readme never said what the protocol is for. It opened with a self-assessment, then build
instructions, then a directory listing as its longest section, and showed no code at all — so a
reader arriving without already knowing what TSP is left knowing only that this implements it.

It also described **HPKE-Auth**, which this revision removed, and carried a non-repudiation
argument resting on that mode being used. So it was wrong about the cryptographic core, not merely
out of date.

## What it says now

- what the protocol does, and what the library gives you, before anything about this repository
- what a send and a receive actually look like. The example is the shortened form of the one in
  the crate documentation, which runs as a doctest — so the complete version is one link away and
  cannot quietly stop compiling
- the cryptography in a section of its own: HPKE in Base mode with the key encapsulation following
  the recipient's key type, so there is no separate post-quantum mode to select; signatures
  Ed25519 or ML-DSA-65; the sealed box retained for existing implementations
- what binds a message to its sender, which is that the sender's identifier travels inside the
  encrypted payload rather than beside it. The argument for the properties that follow is left in
  the specification — restating it is how this file came to contradict it
- which revision this is, and what does and does not interoperate with earlier versions
- the repository layout at the end, and the scattered one-line sections pointing at the hosted
  documentation gathered into one list

Everything factual in it was checked against the code: the transports, the identifier methods, the
crate list, and the command line syntax.

## Also

The command line tool's own description of `create` said it makes a did:web identifier — one of
three types it can make, and the one this revision demotes.

## Noted, not changed

The workspace version is still `0.9.1-rev2`, which looked like a release decision rather than a
documentation fix.