### PR TITLE
Version 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.9.1-rev2"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "async-stream",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "tsp_javascript"
-version = "0.9.1-rev2"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "tsp_python"
-version = "0.9.1-rev2"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "futures",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "tsp_sdk"
-version = "0.9.1-rev2"
+version = "0.10.0"
 dependencies = [
  "arbitrary",
  "aries-askar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["tsp_sdk", "examples", "fuzz", "tsp_python", "tsp_javascript"]
 exclude = ["demo"]
 
 [workspace.package]
-version = "0.9.1-rev2"
+version = "0.10.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/openwallet-foundation-labs/tsp"
@@ -107,4 +107,4 @@ clap = { version = "4.5", features = ["derive"] }
 axum = { version = "0.8.1", features = ["ws", "macros"] }
 tower-http = { version = "0.6.2", features = ["cors"] }
 
-tsp_sdk = { path = "./tsp_sdk", version = "0.9.1-rev2" }
+tsp_sdk = { path = "./tsp_sdk", version = "0.10.0" }


### PR DESCRIPTION
The version said `0.9.1-rev2` while the code implements revision 3. It was never released — no
tag exists for it, and crates.io still carries `0.9.0-alpha2` — so nothing depends on the number.

## Why not `0.9.1-rev3`

A `-revN` suffix is a **pre-release** in the only grammar that reads this field. `0.9.1-rev2`
sorts *before* `0.9.1`, so a version meant to say "implements revision 2" tells cargo "not yet
0.9.1". Carrying that forward would carry the confusion forward. Which revision is implemented is
stated in the readme, which is where prose belongs.

## Why the minor rather than the patch

This breaks compatibility: the wire version changed, `send` lost an argument, and `did:peer`
identifiers moved to numalgo 4. Before 1.0, that belongs in the minor.

## Reach

The version is read in exactly two places beyond publishing, both user-agent strings. It does not
touch the wire, which carries its own version — currently `(0, 1, 0)`, encoded `YTSP-ABA`.

`demo/Cargo.lock` still pins the old number. The demo is excluded from the workspace and is not
built, so it is left alone rather than maintained.