### PR TITLE
Prepare 0.10.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",
@@ -814,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead 0.6.1",
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "cipher 0.5.2",
  "poly1305 0.9.1",
 ]
@@ -1276,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3469,7 +3469,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -4629,7 +4629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/tsp_javascript/Cargo.toml
+++ b/tsp_javascript/Cargo.toml
@@ -9,7 +9,8 @@ readme.workspace = true
 description.workspace = true
 rust-version.workspace = true
 
-publish = true
+# Belongs on npm, not crates.io: nothing consumes this as a Rust dependency.
+publish = false
 
 [features]
 pq = ["tsp_sdk/pq"]

--- a/tsp_python/Cargo.toml
+++ b/tsp_python/Cargo.toml
@@ -4,7 +4,8 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-publish = true
+# Belongs on PyPI, not crates.io: nothing consumes this as a Rust dependency.
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
Two things found while checking whether 0.10.0 is ready to publish.

## A yanked dependency

The lock held `chacha20 0.10.1`, which has been withdrawn from the registry. `cargo publish`
warns about it. It arrives through the HPKE implementation, so it is in the encryption path rather
than off to one side. Updated to `0.10.2`; `cargo deny` reports advisories, bans, licenses and
sources all clean afterwards.

## The bindings were pointed at the wrong registry

Neither binding has ever been published — not to crates.io, not PyPI, not npm. Only `tsp_sdk` has
ever been released, and it is currently two versions behind this manifest.

`publish = true` on the bindings meant "release this to crates.io", which is not where either
belongs. The Python binding belongs on PyPI as wheels; the JavaScript binding on npm, which the
WebAssembly build already generates a package for. Nothing consumes either as a Rust dependency.

Publishing them is postponed deliberately. There is no release process for any of this — the
library is published by hand — and adding two registries to a manual process gives three things to
forget instead of one. The condition for revisiting is a workflow that releases all three from a
single tag.

## Readiness

`cargo publish --dry-run -p tsp_sdk` packages 74 files and compiles the crate standalone. Tests,
clippy and cargo-deny are clean.