### PR TITLE
Remove three per-message costs from the wire path

### DIFF
--- a/tsp_sdk/benches/throughput_transport.rs
+++ b/tsp_sdk/benches/throughput_transport.rs
@@ -55,6 +55,31 @@ fn url(scheme: &str, host: &str, port: u16) -> Url {
     Url::parse(&format!("{scheme}://{host}:{port}")).expect("failed to parse url")
 }
 
+/// Bind a receiver, retrying with a fresh port if the chosen one turns out to
+/// be taken.
+///
+/// The probe binds an IPv4 address while a transport may bind another family:
+/// `localhost` resolves to `::1` first, so a port that probes free on 127.0.0.1
+/// can still be in use on ::1. QUIC hit this often enough to abort the run.
+macro_rules! bind_receiver {
+    ($scheme:expr, $host:expr, $what:expr) => {{
+        let mut bound = None;
+        for _ in 0..32 {
+            let port = if $scheme == "quic" {
+                pick_unused_udp_port()
+            } else {
+                pick_unused_tcp_port()
+            };
+            let candidate = url($scheme, $host, port);
+            if let Ok(stream) = tsp_sdk::transport::receive_messages(&candidate).await {
+                bound = Some((candidate, stream));
+                break;
+            }
+        }
+        bound.unwrap_or_else(|| panic!("{} receive_messages failed after 32 attempts", $what))
+    }};
+}
+
 /// A genuine sealed TSP message carrying `payload_len` bytes of application
 /// payload.
 ///
@@ -128,15 +153,7 @@ fn bench_oneway(c: &mut Criterion, scheme: &'static str, host: &'static str, pay
 
         b.iter_custom(|iters| {
             runtime.block_on(async {
-                let server_port = if scheme == "quic" {
-                    pick_unused_udp_port()
-                } else {
-                    pick_unused_tcp_port()
-                };
-                let server = url(scheme, host, server_port);
-                let mut incoming = tsp_sdk::transport::receive_messages(&server)
-                    .await
-                    .expect("receive_messages failed");
+                let (server, mut incoming) = bind_receiver!(scheme, host, "server");
 
                 let payload = sealed_message(payload_len);
 
@@ -197,19 +214,8 @@ fn bench_roundtrip(
 
         b.iter_custom(|iters| {
             runtime.block_on(async {
-                let (server_port, client_port) = if scheme == "quic" {
-                    (pick_unused_udp_port(), pick_unused_udp_port())
-                } else {
-                    (pick_unused_tcp_port(), pick_unused_tcp_port())
-                };
-                let server = url(scheme, host, server_port);
-                let client = url(scheme, host, client_port);
-                let mut server_incoming = tsp_sdk::transport::receive_messages(&server)
-                    .await
-                    .expect("server receive_messages failed");
-                let mut client_incoming = tsp_sdk::transport::receive_messages(&client)
-                    .await
-                    .expect("client receive_messages failed");
+                let (server, mut server_incoming) = bind_receiver!(scheme, host, "server");
+                let (client, mut client_incoming) = bind_receiver!(scheme, host, "client");
 
                 let request = sealed_message(payload_len);
 
@@ -271,17 +277,38 @@ fn bench_roundtrip(
     });
 }
 
-fn size_label(payload_len: usize) -> &'static str {
-    match payload_len {
-        1 => "1B",
-        1024 => "1KiB",
-        16_384 => "16KiB",
-        _ => "custom",
+fn size_label(payload_len: usize) -> String {
+    const KIB: usize = 1024;
+    const MIB: usize = 1024 * KIB;
+    if payload_len >= MIB && payload_len % MIB == 0 {
+        format!("{}MiB", payload_len / MIB)
+    } else if payload_len >= KIB && payload_len % KIB == 0 {
+        format!("{}KiB", payload_len / KIB)
+    } else {
+        format!("{payload_len}B")
+    }
+}
+
+/// Payload sizes to sweep, overridable with TSP_BENCH_SIZES as a
+/// comma-separated list of byte counts.
+fn sweep_sizes(default: &[usize]) -> Vec<usize> {
+    match std::env::var("TSP_BENCH_SIZES") {
+        Ok(spec) => spec
+            .split(',')
+            .filter_map(|s| s.trim().parse::<usize>().ok())
+            .collect(),
+        Err(_) => default.to_vec(),
     }
 }
 
 fn benches(c: &mut Criterion) {
-    for payload_len in [1usize, 1024usize, 16 * 1024] {
+    const KIB: usize = 1024;
+    const MIB: usize = 1024 * KIB;
+
+    // The framed codec caps a message at 8 MiB, and a sealed message carries
+    // overhead on top of the application payload, so 4 MiB is the largest
+    // round size that fits.
+    for payload_len in sweep_sizes(&[1, KIB, 16 * KIB, 64 * KIB, 256 * KIB, MIB, 4 * MIB]) {
         bench_oneway(c, "tcp", "127.0.0.1", payload_len);
         bench_roundtrip(c, "tcp", "127.0.0.1", payload_len);
 
@@ -289,8 +316,7 @@ fn benches(c: &mut Criterion) {
         bench_roundtrip(c, "tls", "localhost", payload_len);
     }
 
-    // QUIC transport currently limits single-message size to 8KiB.
-    for payload_len in [1usize, 1024usize] {
+    for payload_len in sweep_sizes(&[1, KIB, 16 * KIB, 64 * KIB, 256 * KIB, MIB, 4 * MIB]) {
         bench_oneway(c, "quic", "localhost", payload_len);
         bench_roundtrip(c, "quic", "localhost", payload_len);
     }

--- a/tsp_sdk/benches/throughput_transport.rs
+++ b/tsp_sdk/benches/throughput_transport.rs
@@ -55,6 +55,58 @@ fn url(scheme: &str, host: &str, port: u16) -> Url {
     Url::parse(&format!("{scheme}://{host}:{port}")).expect("failed to parse url")
 }
 
+/// A genuine sealed TSP message carrying `payload_len` bytes of application
+/// payload.
+///
+/// The transport benchmarks must send real CESR rather than random bytes. Code
+/// on the send path that inspects the message rejects garbage immediately, so
+/// its cost is invisible when the payload is noise: a debug formatter that ran
+/// over every outgoing message went unnoticed here for exactly that reason,
+/// while costing about 31 us/KiB in production. The sealed message is somewhat
+/// larger than `payload_len`; the label names the application payload, which is
+/// the quantity a caller controls.
+fn sealed_message(payload_len: usize) -> Vec<u8> {
+    use tsp_sdk::{OwnedVid, RelationshipStatus, SecureStore, VerifiedVid};
+
+    let alice: OwnedVid = serde_json::from_str(include_str!("../../examples/test/alice/piv.json"))
+        .expect("alice fixture must deserialize as OwnedVid");
+    let bob: OwnedVid = serde_json::from_str(include_str!("../../examples/test/bob/piv.json"))
+        .expect("bob fixture must deserialize as OwnedVid");
+
+    let store = SecureStore::new();
+    store
+        .add_private_vid(alice.clone(), None)
+        .expect("failed to add alice");
+    store
+        .add_private_vid(bob.clone(), None)
+        .expect("failed to add bob");
+
+    // application messages are only accepted within an established
+    // relationship (spec 7.2.2); the benchmark measures the transport, not the
+    // relationship forming that precedes it
+    for (local, remote) in [(&alice, &bob), (&bob, &alice)] {
+        store
+            .set_relation_and_status_for_vid(
+                remote.identifier(),
+                RelationshipStatus::Bidirectional {
+                    thread_id: [0x11; 32],
+                    remote_thread_id: [0x22; 32],
+                    outstanding_nested_requests: vec![],
+                },
+                local.identifier(),
+            )
+            .expect("failed to set relationship");
+    }
+
+    let payload =
+        bench_utils::seeded_bytes(0x5452414E535F4D53u64 ^ payload_len as u64, payload_len);
+    let (_endpoint, sealed) = store
+        .seal_message(alice.identifier(), bob.identifier(), payload.as_slice())
+        .expect("seal_message failed");
+
+    sealed
+}
+
 fn criterion_config() -> Criterion {
     Criterion::default()
         .without_plots()
@@ -86,10 +138,7 @@ fn bench_oneway(c: &mut Criterion, scheme: &'static str, host: &'static str, pay
                     .await
                     .expect("receive_messages failed");
 
-                let payload = bench_utils::seeded_bytes(
-                    0x5452414E535F4F4Eu64 ^ payload_len as u64,
-                    payload_len,
-                );
+                let payload = sealed_message(payload_len);
 
                 let start = Instant::now();
                 let mut sample_attempts = 0u64;
@@ -162,10 +211,7 @@ fn bench_roundtrip(
                     .await
                     .expect("client receive_messages failed");
 
-                let request = bench_utils::seeded_bytes(
-                    0x5452414E535F5254u64 ^ payload_len as u64,
-                    payload_len,
-                );
+                let request = sealed_message(payload_len);
 
                 let start = Instant::now();
                 let mut sample_attempts = 0u64;

--- a/tsp_sdk/src/async_store.rs
+++ b/tsp_sdk/src/async_store.rs
@@ -1164,7 +1164,11 @@ impl AsyncSecureStore {
         db: &SecureStore,
         message: BytesMut,
     ) -> Result<ReceivedTspMessage, Error> {
-        if let Ok(colored) = crate::cesr::color_format(&message) {
+        // Rendering the message only to discard it costs ~31 us/KiB on every
+        // message, so do not format unless TRACE is actually enabled.
+        if tracing::enabled!(tracing::Level::TRACE)
+            && let Ok(colored) = crate::cesr::color_format(&message)
+        {
             tracing::trace!("CESR-encoded message: {}", colored);
         }
 

--- a/tsp_sdk/src/transport/mod.rs
+++ b/tsp_sdk/src/transport/mod.rs
@@ -14,7 +14,11 @@ pub use http::SseCursor;
 pub use http::receive_messages_tracked;
 
 pub async fn send_message(transport: &Url, tsp_message: &[u8]) -> Result<(), TransportError> {
-    if let Ok(colored) = crate::cesr::color_format(tsp_message) {
+    // Rendering the message only to discard it costs ~31 us/KiB on every
+    // message, so do not format unless TRACE is actually enabled.
+    if tracing::enabled!(tracing::Level::TRACE)
+        && let Ok(colored) = crate::cesr::color_format(tsp_message)
+    {
         tracing::trace!("CESR-encoded message: {}", colored);
     }
 

--- a/tsp_sdk/src/transport/tcp.rs
+++ b/tsp_sdk/src/transport/tcp.rs
@@ -1,6 +1,6 @@
 use async_stream::stream;
 use bytes::{Bytes, BytesMut};
-use futures::{SinkExt, StreamExt};
+use futures::{FutureExt, SinkExt, StreamExt};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -44,13 +44,16 @@ pub(super) async fn connect_any(
 /// the message is lost, which would bypass the send retry path.
 pub(super) async fn peer_closed(stream: &TcpStream) -> bool {
     let mut buf = [0u8; 1];
-    match tokio::time::timeout(std::time::Duration::ZERO, stream.peek(&mut buf)).await {
+    // Poll the peek exactly once. A timer must not be used here: tokio's timer
+    // wheel is millisecond-granular, so even a zero-duration timeout costs a
+    // tick per send — around 1.5 ms, which dominated small messages.
+    match stream.peek(&mut buf).now_or_never() {
         // not readable: healthy idle connection
-        Err(_elapsed) => false,
+        None => false,
         // EOF or socket error: the peer is gone
-        Ok(Ok(0)) | Ok(Err(_)) => true,
+        Some(Ok(0)) | Some(Err(_)) => true,
         // inbound data with the connection still open
-        Ok(Ok(_)) => false,
+        Some(Ok(_)) => false,
     }
 }
 

--- a/tsp_sdk/src/transport/tls.rs
+++ b/tsp_sdk/src/transport/tls.rs
@@ -1,6 +1,6 @@
 use async_stream::stream;
 use bytes::{Bytes, BytesMut};
-use futures::{SinkExt, StreamExt};
+use futures::{FutureExt, SinkExt, StreamExt};
 use once_cell::sync::Lazy;
 use rustls::{ClientConfig, RootCertStore, crypto::CryptoProvider};
 use rustls_pki_types::{ServerName, pem::PemObject};
@@ -109,7 +109,7 @@ static TLS_CONNECTIONS: Lazy<TokioMutex<HashMap<String, TlsFramed>>> =
     Lazy::new(|| TokioMutex::new(HashMap::new()));
 
 /// Check whether the peer of a cached TLS connection has closed it. This
-/// probes at the TLS layer (a single zero-timeout read poll) rather than at
+/// probes at the TLS layer (a single non-blocking read poll) rather than at
 /// the TCP layer: post-handshake records such as TLS 1.3 session tickets sit
 /// unread in the socket buffer of a send-only connection, so raw-TCP
 /// readability does not distinguish a healthy connection from a closed one,
@@ -120,12 +120,14 @@ async fn tls_peer_closed(framed: &mut TlsFramed) -> bool {
     use tokio::io::AsyncReadExt;
 
     let mut buf = [0u8; 1];
-    match tokio::time::timeout(std::time::Duration::ZERO, framed.get_mut().read(&mut buf)).await {
-        // no application data pending: healthy connection
-        Err(_elapsed) => false,
-        // clean close, error, or application data on a send-only connection
-        Ok(_) => true,
-    }
+    // Poll the read exactly once. A timer must not be used here: tokio's timer
+    // wheel is millisecond-granular, so even a zero-duration timeout costs a
+    // tick per send — around 1.3 ms, which dominated every message.
+    //
+    // Pending means no application data is waiting: a healthy connection. Any
+    // ready result — clean close, error, or application data arriving on a
+    // send-only connection — means it must not be reused.
+    framed.get_mut().read(&mut buf).now_or_never().is_some()
 }
 
 /// Get an existing cached TLS connection or create a new one.


### PR DESCRIPTION
Three defects were each adding cost to every message sent. All three had
passing functional coverage; none of it measured cost, so they were
invisible until the throughput benchmarks were run against real messages.

## The defects

**A timer on every TCP send.** The probe checking whether a cached
connection's peer has closed expressed "try once, do not wait" as a
zero-duration `tokio::time::timeout`. A timeout is a duration primitive:
even at zero it registers a sleep in a timer wheel whose slots are one
millisecond wide, so every send paid a registration and a tick.
`now_or_never` expresses the same intent with no timer. The polling
behaviour is identical — `Timeout` polls the inner future first and then
the expired sleep, so `peek` received exactly one poll before as well —
and since `peek` is readiness-based, dropping it after that poll consumes
no bytes, so the `MSG_PEEK` guarantee is unchanged.

**Every message rendered to a debug string, then discarded.** Send and
receive both formatted the whole message with `cesr::color_format` and
passed it to `tracing::trace!`. The macro is lazy, but the formatting sat
in the `if let` condition outside it, so the string was built at every log
level and dropped. Cost scaled with message size.

**The same timer again, in TLS.** A separate implementation, probing at
the TLS layer so rustls can consume post-handshake records rather than
corrupting the record stream, so it survived the first fix untouched.

## Measured effect

End to end over loopback TCP, `tsp bench`, real messages including CESR,
HPKE and signatures:

| Payload | Before | After | Gain |
| --- | --- | --- | --- |
| 1 KiB | 6.39 Mbit/s | 111.23 Mbit/s | 17.4x |
| 16 KiB | 49.23 Mbit/s | 879.36 Mbit/s | 17.9x |
| 64 KiB | 137.01 Mbit/s | 1.62 Gbit/s | 11.8x |

Per-message cost falls from 1.68 ms + 33 us/KiB to 94 us + 3.6 us/KiB.
The crypto floor measured on its own — seal plus open, no transport — is
141 us + 5.0 us/KiB, so the wire path now sits at that floor.

One-way TLS delivery, which the first fix did not touch:

| Payload | Before | After |
| --- | --- | --- |
| 1 B | 1.34 ms | 16.15 us |
| 16 KiB | 1.38 ms | 27.84 us |
| 1 MiB | 2.42 ms | 494.67 us |

## Why the benchmark changes are in the same branch

The transport benchmarks sent random bytes. Code on the send path that
inspects a message rejects garbage immediately, so anything walking a
well-formed message measured as free — which is exactly how the discarded
formatter stayed hidden. They now seal a genuine message through a
`SecureStore`. With the formatter reintroduced the benchmark reports
580 us at 16 KiB against 15.9 us without it; previously it read 15.9 us
either way.

Two further benchmark defects were fixed to get complete coverage:

- Binding a receiver raced. The port probe binds `127.0.0.1` while a
  transport may bind another family — `localhost` resolves to `::1` first
  — so a port could probe free and still be in use. QUIC hit this
  reliably and aborted the run, leaving it unmeasured above 1 KiB.
  Binding now retries with a fresh port.
- Coverage stopped at 16 KiB, well below what the transports carry, which
  left every scheme's per-byte behaviour unmeasured. The sweep now runs
  to 4 MiB, with `TSP_BENCH_SIZES` to probe a specific range.

Two stale claims were corrected in passing: QUIC is not limited to 8 KiB
per message, it carries 4 MiB. The framed codec caps a message at 8 MiB;
a payload of 8191 KiB is delivered and 8 MiB fails every sample. Note
that criterion still reports a time for a size that always fails, so the
failure counter is what distinguishes delivery from failing fast.

## Verification

`cargo fmt --all --check` and `cargo clippy --workspace --tests --deny
warnings` are clean. The full `tsp_sdk` suite passes, including the three
tests covering the behaviour these probes exist to protect:
`test_tcp_reconnect_after_peer_close`,
`test_tls_reconnect_after_peer_close` and
`test_tls_session_tickets_do_not_evict_connection`.