### PR TITLE
Tag the published containers as latest as well

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           push: true
 #          build-args: "FEATURE_FLAGS=pq"
-          tags: "ghcr.io/openwallet-foundation-labs/tsp/demo-intermediary:${{ env.tag }}"
+          tags: |
+            ghcr.io/openwallet-foundation-labs/tsp/demo-intermediary:${{ env.tag }}
+            ghcr.io/openwallet-foundation-labs/tsp/demo-intermediary:latest
           target: intermediary
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -43,7 +45,9 @@ jobs:
         with:
           push: true
 #          build-args: "FEATURE_FLAGS=pq"
-          tags: "ghcr.io/openwallet-foundation-labs/tsp/demo-server:${{ env.tag }}"
+          tags: |
+            ghcr.io/openwallet-foundation-labs/tsp/demo-server:${{ env.tag }}
+            ghcr.io/openwallet-foundation-labs/tsp/demo-server:latest
           target: server
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -52,7 +56,9 @@ jobs:
         with:
           push: true
 #          build-args: "FEATURE_FLAGS=pq"
-          tags: "ghcr.io/openwallet-foundation-labs/tsp/did-server:${{ env.tag }}"
+          tags: |
+            ghcr.io/openwallet-foundation-labs/tsp/did-server:${{ env.tag }}
+            ghcr.io/openwallet-foundation-labs/tsp/did-server:latest
           target: did-server
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The three images published by the deploy workflow are tagged only with a
Unix timestamp and a short commit hash:

```
ghcr.io/openwallet-foundation-labs/tsp/demo-intermediary:1788834691-753d09a
ghcr.io/openwallet-foundation-labs/tsp/demo-server:...
ghcr.io/openwallet-foundation-labs/tsp/did-server:...
```

That tag is immutable and the Cloud Run declarations should keep pinning
it. But it is the only tag any of these images carry, so `:latest`
currently 404s on all three, the packages listing is more than a hundred
indistinguishable tags per image, and pulling one by hand means first
working out which name is the newest.

This pushes `latest` alongside the existing tag. Nothing consumes it —
the deployment templates are unchanged and still pin the timestamped tag,
which is the right behaviour for a reproducible deploy. It exists so the
listing is readable and so a manual pull gets the current image.

Old tags are not pruned here; removing published versions is destructive
and is a separate decision.