### PR TITLE
Document the node binding build so the commands work

### DIFF
--- a/tsp_node/README.md
+++ b/tsp_node/README.md
@@ -4,14 +4,19 @@ Node.js module based on `tsp-javascript` that binds to a WebAssembly binary buil
 
 ## How to run
 
-First build `tsp-javascript` for Node.js in the tsp-javascript folder:
+First build `tsp-javascript` for Node.js. Run this from the repository root; the
+`RUSTFLAGS` are required, because the WebAssembly target needs an explicit
+`getrandom` backend:
 ```
-wasm-pack build --target nodejs
+RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build --target nodejs tsp_javascript/
 ```
+
+That writes the package to `tsp_javascript/pkg`, which this module depends on by
+path.
 
 Then install the dependencies in this folder:
 ```
-npm install --dev
+npm install
 ```
 
 Run the tests in test.js with Mocha:

--- a/tsp_node/package-lock.json
+++ b/tsp_node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../tsp_javascript/pkg": {
       "name": "tsp_javascript",
-      "version": "0.9.1-rev2",
+      "version": "0.10.0",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@isaacs/cliui": {


### PR DESCRIPTION
The build instructions for the Node.js binding did not work as written.

- The wasm build was missing `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`.
  Without it the WebAssembly target has no getrandom backend and the build
  fails. The `check` workflow has always passed it; the README never did.
- It referred to the `tsp-javascript` folder. The directory is
  `tsp_javascript`, so the `cd` fails.
- `npm install --dev` is a legacy spelling. Dev dependencies are installed
  by default.

The build command is now given the way the workflow runs it, from the
repository root with the crate path, and the README says where the package
lands, since this module depends on it by path.

Verified by running the three commands in order on a clean checkout:

```
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build --target nodejs tsp_javascript/
npm install
npm run test
```

The build writes `tsp_javascript/pkg`, and the suite passes — 5 passing,
1 pending.

The second commit updates `package-lock.json`, which still recorded the
dependency at 0.9.1-rev2, to 0.10.0.