### PR TITLE
Do not hold the connection map lock while sending

### DIFF
--- a/tsp_sdk/src/transport/tcp.rs
+++ b/tsp_sdk/src/transport/tcp.rs
@@ -4,6 +4,7 @@ use futures::{FutureExt, SinkExt, StreamExt};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex as TokioMutex, mpsc};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
@@ -13,8 +14,20 @@ use super::{TSPStream, TransportError};
 
 pub(crate) const SCHEME: &str = "tcp";
 
+type TcpFramed = Framed<TcpStream, LengthDelimitedCodec>;
+
+/// One peer's cached connection, with the lock that serialises writes to it.
+///
+/// The map below is locked only to find or insert this handle, never while
+/// sending. Holding a single global lock across the write serialised every
+/// send in the process against every other, so throughput fell as senders were
+/// added and one slow peer stalled traffic to every other peer. Writes to the
+/// same peer still serialise, which they must: a `Framed` cannot be written
+/// concurrently.
+type Connection = Arc<TokioMutex<Option<TcpFramed>>>;
+
 /// Cached TCP connections keyed by URL string.
-static TCP_CONNECTIONS: Lazy<TokioMutex<HashMap<String, Framed<TcpStream, LengthDelimitedCodec>>>> =
+static TCP_CONNECTIONS: Lazy<TokioMutex<HashMap<String, Connection>>> =
     Lazy::new(|| TokioMutex::new(HashMap::new()));
 
 /// Connect to the first address that accepts the connection.
@@ -57,74 +70,61 @@ pub(super) async fn peer_closed(stream: &TcpStream) -> bool {
     }
 }
 
-/// Get an existing cached connection or create a new one.
-async fn get_or_create_connection(
-    url: &Url,
-) -> Result<
-    &'static TokioMutex<HashMap<String, Framed<TcpStream, LengthDelimitedCodec>>>,
-    TransportError,
-> {
-    let key = url.to_string();
+/// The handle for a peer, empty if nothing is connected yet. Holds the map
+/// lock only long enough to look up or insert.
+async fn connection_for(url: &Url) -> Connection {
     let mut cache = TCP_CONNECTIONS.lock().await;
-
-    if let Some(framed) = cache.get(&key)
-        && peer_closed(framed.get_ref()).await
-    {
-        cache.remove(&key);
-    }
-
-    if let std::collections::hash_map::Entry::Vacant(entry) = cache.entry(key) {
-        let addresses = url
-            .socket_addrs(|| None)
-            .map_err(|_| TransportError::InvalidTransportAddress(url.to_string()))?;
-
-        let stream = connect_any(&addresses, url).await?;
-
-        let framed = Framed::new(stream, LengthDelimitedCodec::new());
-        entry.insert(framed);
-    }
-
-    Ok(&TCP_CONNECTIONS)
+    cache.entry(url.to_string()).or_default().clone()
 }
 
-/// Evict a cached connection so the next send will reconnect.
-async fn invalidate_connection(url: &Url) {
-    let key = url.to_string();
-    let mut cache = TCP_CONNECTIONS.lock().await;
-    cache.remove(&key);
+/// Open a fresh connection to `url`.
+async fn connect(url: &Url) -> Result<TcpFramed, TransportError> {
+    let addresses = url
+        .socket_addrs(|| None)
+        .map_err(|_| TransportError::InvalidTransportAddress(url.to_string()))?;
+    let stream = connect_any(&addresses, url).await?;
+
+    Ok(Framed::new(stream, LengthDelimitedCodec::new()))
 }
 
 /// Send a message over TCP.
 /// Reuses a cached connection with length-delimited framing.
 /// If the connection is stale, it reconnects automatically.
 pub(crate) async fn send_message(tsp_message: &[u8], url: &Url) -> Result<(), TransportError> {
-    let key = url.to_string();
+    let connection = connection_for(url).await;
+    let mut cached = connection.lock().await;
 
-    // First attempt
+    // Drop a connection whose peer has gone before writing to it: the kernel
+    // can accept a write shortly after the peer closed and report success even
+    // though the message is lost, which would bypass the retry below.
+    if let Some(framed) = cached.as_ref()
+        && peer_closed(framed.get_ref()).await
     {
-        let _ = get_or_create_connection(url).await?;
-        let mut cache = TCP_CONNECTIONS.lock().await;
-        if let Some(framed) = cache.get_mut(&key)
-            && framed
-                .send(Bytes::copy_from_slice(tsp_message))
-                .await
-                .is_ok()
-        {
-            return Ok(());
-        }
+        *cached = None;
     }
 
-    // Retry once on failure
-    invalidate_connection(url).await;
-    {
-        let _ = get_or_create_connection(url).await?;
-        let mut cache = TCP_CONNECTIONS.lock().await;
-        let framed = cache.get_mut(&key).ok_or(TransportError::Internal)?;
-        framed
-            .send(Bytes::copy_from_slice(tsp_message))
-            .await
-            .map_err(|e| TransportError::Connection(key, e))?;
+    if cached.is_none() {
+        *cached = Some(connect(url).await?);
     }
+
+    let framed = cached.as_mut().ok_or(TransportError::Internal)?;
+    if framed
+        .send(Bytes::copy_from_slice(tsp_message))
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    // Retry once on a fresh connection, leaving nothing cached if that fails
+    // too, so the next send starts over.
+    *cached = None;
+    let mut framed = connect(url).await?;
+    framed
+        .send(Bytes::copy_from_slice(tsp_message))
+        .await
+        .map_err(|e| TransportError::Connection(url.to_string(), e))?;
+    *cached = Some(framed);
 
     Ok(())
 }
@@ -244,6 +244,72 @@ mod test {
             .expect("message was lost on the stale cached connection")
             .unwrap();
         assert_eq!(received, b"second message");
+    }
+
+    /// Regression test: a peer that stops reading must not block sends to
+    /// other peers. The connection cache is global, so an implementation that
+    /// holds the map lock across the write serialises every send in the
+    /// process: one unresponsive peer then stalls traffic to all of them.
+    /// Measured at 4.7 seconds before the per-connection lock was introduced.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial_test::serial(tcp)]
+    async fn test_tcp_stalled_peer_does_not_block_other_peers() {
+        let allocator = TestPortAllocator::new();
+
+        // A peer that accepts the connection and then never reads a byte.
+        let deaf_port = allocator.allocate();
+        let deaf_url = Url::parse(&format!("tcp://127.0.0.1:{deaf_port}")).unwrap();
+        let deaf = TcpListener::bind(("127.0.0.1", deaf_port)).await.unwrap();
+        tokio::spawn(async move {
+            let _accepted = deaf.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        // A healthy peer that drains what it is sent.
+        let live_url = Url::parse(&format!("tcp://127.0.0.1:{}", allocator.allocate())).unwrap();
+        let mut incoming = receive_messages(&live_url).await.unwrap();
+        tokio::spawn(async move { while incoming.next().await.is_some() {} });
+
+        // Fill the deaf peer's socket buffer so that its next send blocks.
+        let big = vec![0x5Au8; 512 * 1024];
+        let stalled = tokio::spawn({
+            let url = deaf_url.clone();
+            async move {
+                for _ in 0..40 {
+                    if tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        send_message(&big, &url),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // Sends to the healthy peer must still complete promptly.
+        let small = vec![0x41u8; 256];
+        let mut worst = std::time::Duration::ZERO;
+        for _ in 0..10 {
+            let started = std::time::Instant::now();
+            tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                send_message(&small, &live_url),
+            )
+            .await
+            .expect("send to the healthy peer never returned")
+            .expect("send to the healthy peer failed");
+            worst = worst.max(started.elapsed());
+        }
+        stalled.abort();
+
+        assert!(
+            worst < std::time::Duration::from_millis(500),
+            "a stalled peer blocked sends to an unrelated peer for {worst:?}"
+        );
     }
 
     /// Regression test: `localhost` resolves to both IPv6 and IPv4 addresses

--- a/tsp_sdk/src/transport/tls.rs
+++ b/tsp_sdk/src/transport/tls.rs
@@ -104,8 +104,13 @@ pub(super) static TLS_CONFIG: Lazy<Arc<ClientConfig>> = Lazy::new(|| Arc::new(cr
 
 type TlsFramed = Framed<TlsStream<tokio::net::TcpStream>, LengthDelimitedCodec>;
 
+/// One peer's cached connection, with the lock that serialises writes to it.
+/// The map is locked only to find or insert this handle, never while sending;
+/// see the equivalent type in the TCP transport for why.
+type Connection = Arc<TokioMutex<Option<TlsFramed>>>;
+
 /// Cached TLS connections keyed by URL string.
-static TLS_CONNECTIONS: Lazy<TokioMutex<HashMap<String, TlsFramed>>> =
+static TLS_CONNECTIONS: Lazy<TokioMutex<HashMap<String, Connection>>> =
     Lazy::new(|| TokioMutex::new(HashMap::new()));
 
 /// Check whether the peer of a cached TLS connection has closed it. This
@@ -130,93 +135,81 @@ async fn tls_peer_closed(framed: &mut TlsFramed) -> bool {
     framed.get_mut().read(&mut buf).now_or_never().is_some()
 }
 
-/// Get an existing cached TLS connection or create a new one.
-async fn get_or_create_connection(url: &Url) -> Result<(), TransportError> {
-    let key = url.to_string();
+/// The handle for a peer, empty if nothing is connected yet. Holds the map
+/// lock only long enough to look up or insert.
+async fn connection_for(url: &Url) -> Connection {
     let mut cache = TLS_CONNECTIONS.lock().await;
-
-    if let Some(framed) = cache.get_mut(&key)
-        && tls_peer_closed(framed).await
-    {
-        cache.remove(&key);
-    }
-
-    if let std::collections::hash_map::Entry::Vacant(entry) = cache.entry(key) {
-        let addresses = url
-            .socket_addrs(|| None)
-            .map_err(|_| TransportError::InvalidTransportAddress(url.to_string()))?;
-
-        let tcp_stream = super::tcp::connect_any(&addresses, url).await?;
-
-        let address = tcp_stream
-            .peer_addr()
-            .map_err(|e| TransportError::Connection(url.to_string(), e))?;
-
-        let domain = url
-            .domain()
-            .ok_or(TransportError::InvalidTransportAddress(format!(
-                "could not resolve {url} to a domain"
-            )))?
-            .to_owned();
-
-        let dns_name = ServerName::try_from(domain).map_err(|_| {
-            TransportError::InvalidTransportAddress(format!(
-                "could not resolve {url} to a server name"
-            ))
-        })?;
-
-        let connector = TlsConnector::from(TLS_CONFIG.clone());
-
-        let tls_stream = connector
-            .connect(dns_name, tcp_stream)
-            .await
-            .map_err(|e| TransportError::Connection(address.to_string(), e))?;
-
-        let framed = Framed::new(tls_stream, LengthDelimitedCodec::new());
-        entry.insert(framed);
-    }
-
-    Ok(())
+    cache.entry(url.to_string()).or_default().clone()
 }
 
-/// Evict a cached connection so the next send will reconnect.
-async fn invalidate_connection(url: &Url) {
-    let key = url.to_string();
-    let mut cache = TLS_CONNECTIONS.lock().await;
-    cache.remove(&key);
+/// Open a fresh TLS connection to `url`.
+async fn connect(url: &Url) -> Result<TlsFramed, TransportError> {
+    let addresses = url
+        .socket_addrs(|| None)
+        .map_err(|_| TransportError::InvalidTransportAddress(url.to_string()))?;
+
+    let tcp_stream = super::tcp::connect_any(&addresses, url).await?;
+
+    let address = tcp_stream
+        .peer_addr()
+        .map_err(|e| TransportError::Connection(url.to_string(), e))?;
+
+    let domain = url
+        .domain()
+        .ok_or(TransportError::InvalidTransportAddress(format!(
+            "could not resolve {url} to a domain"
+        )))?
+        .to_owned();
+
+    let dns_name = ServerName::try_from(domain).map_err(|_| {
+        TransportError::InvalidTransportAddress(format!("could not resolve {url} to a server name"))
+    })?;
+
+    let connector = TlsConnector::from(TLS_CONFIG.clone());
+
+    let tls_stream = connector
+        .connect(dns_name, tcp_stream)
+        .await
+        .map_err(|e| TransportError::Connection(address.to_string(), e))?;
+    Ok(Framed::new(tls_stream, LengthDelimitedCodec::new()))
 }
 
 /// Send a message over TLS.
 /// Reuses a cached connection with length-delimited framing.
 /// If the connection is stale, it reconnects automatically.
 pub(crate) async fn send_message(tsp_message: &[u8], url: &Url) -> Result<(), TransportError> {
-    let key = url.to_string();
+    let connection = connection_for(url).await;
+    let mut cached = connection.lock().await;
 
-    // First attempt
+    // Drop a connection whose peer has gone before writing to it.
+    if let Some(framed) = cached.as_mut()
+        && tls_peer_closed(framed).await
     {
-        get_or_create_connection(url).await?;
-        let mut cache = TLS_CONNECTIONS.lock().await;
-        if let Some(framed) = cache.get_mut(&key)
-            && framed
-                .send(Bytes::copy_from_slice(tsp_message))
-                .await
-                .is_ok()
-        {
-            return Ok(());
-        }
+        *cached = None;
     }
 
-    // Retry once on failure
-    invalidate_connection(url).await;
-    {
-        get_or_create_connection(url).await?;
-        let mut cache = TLS_CONNECTIONS.lock().await;
-        let framed = cache.get_mut(&key).ok_or(TransportError::Internal)?;
-        framed
-            .send(Bytes::copy_from_slice(tsp_message))
-            .await
-            .map_err(|e| TransportError::Connection(key, e))?;
+    if cached.is_none() {
+        *cached = Some(connect(url).await?);
     }
+
+    let framed = cached.as_mut().ok_or(TransportError::Internal)?;
+    if framed
+        .send(Bytes::copy_from_slice(tsp_message))
+        .await
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    // Retry once on a fresh connection, leaving nothing cached if that fails
+    // too, so the next send starts over.
+    *cached = None;
+    let mut framed = connect(url).await?;
+    framed
+        .send(Bytes::copy_from_slice(tsp_message))
+        .await
+        .map_err(|e| TransportError::Connection(url.to_string(), e))?;
+    *cached = Some(framed);
 
     Ok(())
 }


### PR DESCRIPTION
Cached connections for TCP and TLS live in one global map behind one
mutex, and the send path held that mutex across the write:

```rust
let mut cache = TCP_CONNECTIONS.lock().await;   // global, all peers
if let Some(framed) = cache.get_mut(&key)
    && framed.send(...).await.is_ok()           // I/O awaited while held
```

Every send in the process therefore serialised against every other. Worse,
because the lock spanned the I/O wait, a peer that stopped reading blocked
sends to every unrelated peer for as long as it stayed stuck. That matters
most for an intermediary, which is the component that sends to many peers
at once.

## Measured

A peer that accepts a connection and then never reads a byte, with its
socket buffer filled. Sends to a *different*, healthy peer:

| | worst send |
| --- | --- |
| before | 4.70 s |
| after | 723 µs |

## The change

Each connection gets its own lock; the map lock is held only for lookup
and insertion. Writes to one peer still serialise — they must, a `Framed`
cannot be written concurrently — while writes to different peers no longer
wait on one another. The slot holds an `Option` so two senders racing to
reach a new peer share one handle and only one of them connects.

## What this is not

Throughput is not the motivation, and barely moves. With each sender on
its own runtime, eight concurrent senders scaled 7.67x before and 7.95x
after; per-send latency under that load fell from 7 µs to 3 µs. The
serialisation mattered for isolation between peers, not for aggregate rate.

A regression test is included; it fails on the previous code with the 4.7 s
figure above. `cargo fmt --check`, `clippy --workspace --tests --deny
warnings` and the full `tsp_sdk` suite (179 tests) pass.