### PR TITLE
Benchmark the HTTP transport on loopback

### DIFF
--- a/tsp_sdk/benches/common/sse_endpoint.rs
+++ b/tsp_sdk/benches/common/sse_endpoint.rs
@@ -1,0 +1,106 @@
+//! A minimal HTTP endpoint implementing the two things the SDK's HTTP
+//! transport needs, so that HTTP can be benchmarked on loopback.
+//!
+//! The SDK's HTTP transport is a client only: `receive_messages` subscribes to
+//! a remote server's event stream and `send_message` posts to it. The other
+//! transports bind both ends inside the benchmark; HTTP cannot, so without
+//! something like this it is the one transport that goes unmeasured.
+//!
+//! The contract is small. `GET` returns an event stream whose events carry the
+//! message base64url-encoded, matching what the transport decodes. `POST`
+//! carries the raw message bytes and answers 200. Written on tokio directly
+//! rather than a web framework, to keep this out of the dependency graph.
+use base64ct::{Base64UrlUnpadded, Encoding as _};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+
+/// Serve on an unused port, returning the URL to give the transport and a
+/// count of connected event-stream subscribers.
+///
+/// The count matters: a broadcast drops messages sent before anyone is
+/// subscribed, and the transport's GET connects asynchronously after
+/// `receive_messages` returns. Posting before then would lose the message and
+/// the benchmark would wait for something that never arrives.
+pub async fn spawn() -> (url::Url, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let address = listener.local_addr().expect("local_addr");
+    let (tx, _) = broadcast::channel::<Vec<u8>>(1024);
+    let subscribers = Arc::new(AtomicUsize::new(0));
+    let subscribers_for_server = Arc::clone(&subscribers);
+
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let tx = tx.clone();
+            let subscribers = Arc::clone(&subscribers_for_server);
+            tokio::spawn(async move {
+                let mut head = Vec::new();
+                let mut byte = [0u8; 1];
+                // Read the request head one byte at a time: any buffered read
+                // could swallow part of a POST body.
+                while !head.ends_with(b"\r\n\r\n") {
+                    match stream.read(&mut byte).await {
+                        Ok(1) => head.push(byte[0]),
+                        _ => return,
+                    }
+                }
+                let head = String::from_utf8_lossy(&head).to_string();
+
+                if head.starts_with("GET") {
+                    let mut rx = tx.subscribe();
+                    if stream
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                              Cache-Control: no-cache\r\nConnection: keep-alive\r\n\r\n",
+                        )
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    subscribers.fetch_add(1, Ordering::SeqCst);
+                    let mut id = 0u64;
+                    while let Ok(message) = rx.recv().await {
+                        id += 1;
+                        let event = format!(
+                            "id: {id}\ndata: {}\n\n",
+                            Base64UrlUnpadded::encode_string(&message)
+                        );
+                        if stream.write_all(event.as_bytes()).await.is_err() {
+                            return;
+                        }
+                    }
+                } else if head.starts_with("POST") {
+                    let length = head
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())?
+                        })
+                        .unwrap_or(0);
+                    let mut body = vec![0u8; length];
+                    if stream.read_exact(&mut body).await.is_err() {
+                        return;
+                    }
+                    let _ = tx.send(body);
+                    let _ = stream
+                        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                        .await;
+                }
+            });
+        }
+    });
+
+    (
+        url::Url::parse(&format!("http://{address}")).expect("url"),
+        subscribers,
+    )
+}
+
+/// Whether the transport's event stream has connected yet.
+pub fn is_ready(subscribers: &AtomicUsize) -> bool {
+    subscribers.load(Ordering::SeqCst) > 0
+}

--- a/tsp_sdk/benches/throughput_transport.rs
+++ b/tsp_sdk/benches/throughput_transport.rs
@@ -310,9 +310,9 @@ fn bench_roundtrip(
 fn size_label(payload_len: usize) -> String {
     const KIB: usize = 1024;
     const MIB: usize = 1024 * KIB;
-    if payload_len >= MIB && payload_len % MIB == 0 {
+    if payload_len >= MIB && payload_len.is_multiple_of(MIB) {
         format!("{}MiB", payload_len / MIB)
-    } else if payload_len >= KIB && payload_len % KIB == 0 {
+    } else if payload_len >= KIB && payload_len.is_multiple_of(KIB) {
         format!("{}KiB", payload_len / KIB)
     } else {
         format!("{payload_len}B")

--- a/tsp_sdk/benches/throughput_transport.rs
+++ b/tsp_sdk/benches/throughput_transport.rs
@@ -10,6 +10,8 @@ use url::Url;
 mod bench_utils;
 #[path = "common/failure.rs"]
 mod failure_common;
+#[path = "common/sse_endpoint.rs"]
+mod sse_endpoint;
 #[path = "common/tokio_rt.rs"]
 mod tokio_rt;
 
@@ -63,20 +65,48 @@ fn url(scheme: &str, host: &str, port: u16) -> Url {
 /// can still be in use on ::1. QUIC hit this often enough to abort the run.
 macro_rules! bind_receiver {
     ($scheme:expr, $host:expr, $what:expr) => {{
-        let mut bound = None;
-        for _ in 0..32 {
-            let port = if $scheme == "quic" {
-                pick_unused_udp_port()
-            } else {
-                pick_unused_tcp_port()
-            };
-            let candidate = url($scheme, $host, port);
-            if let Ok(stream) = tsp_sdk::transport::receive_messages(&candidate).await {
-                bound = Some((candidate, stream));
-                break;
+        // HTTP is a client-only transport: it subscribes to a server rather
+        // than binding, so the benchmark serves the endpoint itself.
+        if $scheme == "http" {
+            let (candidate, subscribers) = sse_endpoint::spawn().await;
+            let mut stream = tsp_sdk::transport::receive_messages(&candidate)
+                .await
+                .expect("http receive_messages failed");
+            // The event source connects on first poll, not when it is built, so
+            // the stream has to be driven before the server sees a subscriber.
+            // Until it does, a send would be broadcast to nobody and the
+            // benchmark would wait for a message that was already dropped.
+            for _ in 0..2000 {
+                if sse_endpoint::is_ready(&subscribers) {
+                    break;
+                }
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_millis(1),
+                    futures::StreamExt::next(&mut stream),
+                )
+                .await;
             }
+            assert!(
+                sse_endpoint::is_ready(&subscribers),
+                "the event stream never connected"
+            );
+            (candidate, stream)
+        } else {
+            let mut bound = None;
+            for _ in 0..32 {
+                let port = if $scheme == "quic" {
+                    pick_unused_udp_port()
+                } else {
+                    pick_unused_tcp_port()
+                };
+                let candidate = url($scheme, $host, port);
+                if let Ok(stream) = tsp_sdk::transport::receive_messages(&candidate).await {
+                    bound = Some((candidate, stream));
+                    break;
+                }
+            }
+            bound.unwrap_or_else(|| panic!("{} receive_messages failed after 32 attempts", $what))
         }
-        bound.unwrap_or_else(|| panic!("{} receive_messages failed after 32 attempts", $what))
     }};
 }
 
@@ -314,6 +344,8 @@ fn benches(c: &mut Criterion) {
 
         bench_oneway(c, "tls", "localhost", payload_len);
         bench_roundtrip(c, "tls", "localhost", payload_len);
+
+        bench_oneway(c, "http", "127.0.0.1", payload_len);
     }
 
     for payload_len in sweep_sizes(&[1, KIB, 16 * KIB, 64 * KIB, 256 * KIB, MIB, 4 * MIB]) {


### PR DESCRIPTION
HTTP was the one transport the benchmarks could not measure. The others
bind both ends inside the harness, but the SDK's HTTP transport is a
**client only**: `receive_messages` subscribes to a server's event stream,
`send_message` posts to it, and `http.rs` has no listener. Measuring it
meant a separate server process, so it was never measured — and its cost
could not be told apart from network latency.

The harness now serves the endpoint itself. The contract is small: `GET`
returns an event stream whose events carry the message base64url-encoded,
`POST` carries the raw bytes and answers 200. Written on tokio directly
rather than a web framework, so nothing is added to the dependency graph.

## Result, against the transport it should be compared with

Both run over TCP, and HTTPS is what the deployed intermediaries use.
Measured in one run, so the columns are comparable.

| payload | TLS | HTTP |
| --- | --- | --- |
| 1 B | 16.04 µs | 104.77 µs |
| 1 KiB | 16.25 µs | 107.52 µs |
| 16 KiB | 28.07 µs | 198.87 µs |
| 64 KiB | 56.69 µs | 937.38 µs |

That is **6.5× the fixed cost and 20× the per-byte cost**, with different
causes. The fixed part is the request and response round trip, where a
stream transport only writes. The per-byte part is the base64 expansion
and line framing an event stream requires — the transport decodes
base64url, so any conforming server must encode it. Both follow from
carrying messages over HTTP rather than from this implementation, though
the absolute per-byte figure includes the harness's own encoding and
should be read as indicative.

## Two details the transport forces

- Its event source connects on **first poll**, not when it is built, so the
  stream must be driven before the server sees a subscriber. A send before
  that is broadcast to nobody, and the benchmark then waits for a message
  that was already dropped.
- The request head is read a byte at a time, since a buffered read could
  swallow part of a POST body.

## Not disturbed

TCP, TLS and QUIC share the binding helper this adds a branch to. Measured
after the change at 14.27, 16.04 and 23.56 µs at 1 B — matching their
values before it.

The second commit fixes two clippy errors in the size label from the
earlier size sweep. CI runs `clippy --workspace --tests`, which does not
include benchmarks, so they never failed anything. `--all-targets` is clean
today if you want CI to cover them.