### PR TITLE
Encode the version as MAJOR and MINOR, not MAJOR.MINOR.PATCH

### DIFF
--- a/tsp_sdk/examples/generate_test_vectors.rs
+++ b/tsp_sdk/examples/generate_test_vectors.rs
@@ -763,7 +763,7 @@ fn main() {
     );
 
     let doc = json!({
-        "tsp_version": "0.1.0",
+        "tsp_version": "0.2",
         "generated_by": "cargo run -p tsp_sdk --example generate_test_vectors",
         "note": "Every value a message depends on is recorded here: the identifiers with their \
                  private keys, the seed each random value was drawn from, and the nonce where one \

--- a/tsp_sdk/src/cesr/packet.rs
+++ b/tsp_sdk/src/cesr/packet.rs
@@ -1,14 +1,17 @@
 use super::consts::{cesr, cesr_data};
 
-/// The TSP version supported by this spec.
+/// The TSP version supported by this spec: MAJOR and MINOR, no patch level.
 ///
-/// Rev 3 is 0.1.0, not 0.0.1: implementations of Rev 2 emit 0.0.1, and the two
-/// revisions are not interoperable — the wire changed throughout. Leaving the
-/// version alone would have made a Rev 3 message indistinguishable from a Rev 2
-/// one until it failed to decode, which is exactly what a version field exists
-/// to prevent. Encoded `YTSP-ABA`, where MAJOR is the count code's identifier
-/// and MINOR and PATCH are six bits each of its count.
-const TSP_VERSION: (u16, u8, u8) = (0, 1, 0);
+/// Rev 3 is 0.2 where Rev 2 is 0.1, and the two are not interoperable — the
+/// wire changed throughout. Leaving the version alone would have made a Rev 3
+/// message indistinguishable from a Rev 2 one until it failed to decode, which
+/// is exactly what a version field exists to prevent.
+///
+/// Encoded `YTSP-AAC`: MAJOR is the count code's identifier, and MINOR is the
+/// whole of its two-character count (spec 9.2.1). An earlier draft split that
+/// count into two six-bit halves for a patch level, which made Rev 3 read as
+/// 0.64 rather than 0.2.
+const TSP_VERSION: (u16, u16) = (0, 2);
 
 /// The CESR code table this implementation follows: genus `AAA`, version 2.00,
 /// identified by the genus/version code `-_AAACAA` (not emitted per message).
@@ -719,7 +722,7 @@ pub fn decode_payload(stream: &mut [u8]) -> Result<DecodedPayload<'_>, DecodeErr
 }
 
 const fn encoded_version() -> u16 {
-    (TSP_VERSION.1 as u16) << 6 | (TSP_VERSION.2 as u16)
+    TSP_VERSION.1
 }
 
 /// Encode a TSP version marker
@@ -741,9 +744,9 @@ fn decode_version(stream: &mut &[u8]) -> Result<(), DecodeError> {
     *stream = new_stream;
 
     // the count identifier is the MAJOR version: a different MAJOR fails to decode,
-    // and per semver a message with a different MAJOR cannot be assumed processable.
-    // The count value carries MINOR and PATCH, which do not affect processability.
-    let _minor_patch = decode_count(TSP_VERSION.0, stream).ok_or(DecodeError::VersionMismatch)?;
+    // since a message with a different MAJOR cannot be assumed processable. The
+    // count value carries MINOR, which does not affect processability.
+    let _minor = decode_count(TSP_VERSION.0, stream).ok_or(DecodeError::VersionMismatch)?;
 
     Ok(())
 }

--- a/tsp_sdk/src/cesr/segments.rs
+++ b/tsp_sdk/src/cesr/segments.rs
@@ -189,14 +189,14 @@ fn walk(text: &str) -> Vec<Segment> {
             continue;
         }
 
-        // the TSP genus, then a count code carrying MAJOR, MINOR and PATCH
+        // the TSP genus, then a count code carrying MAJOR and MINOR
         if h4 == "YTSP" {
             let version = at(i + 4, 4);
             let value = match (
                 version.as_bytes().get(1).copied().and_then(b64_index),
                 count(at(i + 6, 2)),
             ) {
-                (Some(major), Some(mp)) => Some(format!("{major}.{}.{}", mp >> 6, mp & 0x3F)),
+                (Some(major), Some(minor)) => Some(format!("{major}.{minor}")),
                 _ => None,
             };
             out.push(seg(
@@ -210,7 +210,7 @@ fn walk(text: &str) -> Vec<Segment> {
                 SegmentKind::Data,
                 "TSP_Version",
                 version,
-                "MAJOR in the count code's identifier, then MINOR and PATCH",
+                "MAJOR in the count code's identifier, MINOR in its count",
                 value,
             ));
             i += 8;
@@ -444,7 +444,7 @@ mod test {
         let labelled = |name: &str| segments.iter().find(|s| s.label == name).cloned();
         assert_eq!(
             labelled("TSP_Version").and_then(|s| s.value).as_deref(),
-            Some("0.1.0")
+            Some("0.2")
         );
         assert_eq!(
             labelled("VID_sndr").and_then(|s| s.value).as_deref(),

--- a/tsp_sdk/test_vectors/rev3.json
+++ b/tsp_sdk/test_vectors/rev3.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "cargo run -p tsp_sdk --example generate_test_vectors",
   "note": "Every value a message depends on is recorded here: the identifiers with their private keys, the seed each random value was drawn from, and the nonce where one applies. A verifier can therefore regenerate the exact bytes of a vector, not only decrypt them. Regenerate with the command in generated_by; the output is byte-for-byte identical.",
-  "tsp_version": "0.1.0",
+  "tsp_version": "0.2",
   "vectors": [
     {
       "description": "A confidential application message under the libsodium anonymous sealed box. The sender's static keys play no part in the encryption, so sender authenticity rests on the ESSR sender VID inside the payload, which this suite requires, together with the outer signature.",
@@ -26,7 +26,7 @@
         "-A##",
         "Bytes"
       ],
-      "message": "-EBYYTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4CAtwfprioKR4GMkMcd24cr7B7sM1_iy88nTHbvkED2YVysWC_6GFqzGqxjBQhW05P2nlttvJtG8bu8WM2kZJiLlOeT7b2Wg0URDRYhOFeb4EtB8XpEUW6KqjqW_zwj79vMTAdrf8vq4u27MbDCQpI8qzeiGLN8B-tak3SI1vKAADx68VHVg5TQM-CAX-KAWBAAEBcQdynkYZuKDtCFr96nFQYAYqzFkccyYPS0gtlTpebinrsiEvafy7BI8mzfW-GrzH3zWIVclfElXBm8aB1oP",
+      "message": "-EBYYTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4CAtwfprioKR4GMkMcd24cr7B7sM1_iy88nTHbvkED2YVysWC_6GFqzGqxjBQhW05P2nlttvJtG8bu8WM2kZJiLlOeT7b2Wg0URDRYhOFeb4EtB8XpEUW6KqjqW_zwj79vMTAdrf8vq4u27MbDCQpI8qzeiGLN8B-tak3SI1vKAADx68VHVg5TQM-CAX-KAWBADatiGf0keq_Yh5pDYzDpKoicsevHubnS9RNd5rRX8Sn21puLukElsJxroPtCRXFYTcwkJqazpoWpCZAv95sW4M",
       "name": "direct-sealed-box",
       "nonce": null,
       "payload_plaintext": "-ZAcXSCS4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BAA-AAF5BAEAGhlbGxvIHdvcmxk",
@@ -119,9 +119,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -200,8 +200,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "AEBcQdynkYZuKDtCFr96nFQYAYqzFkccyYPS0gtlTpebinrsiEvafy7BI8mzfW-GrzH3zWIVclfElXBm8aB1oP",
-          "value": "0405c41dca791866e283b4216bf7a9c5418018ab316471cc983d2d20b654e979b8a7aec884bda7f2ec123c9b37d6f86af31f7cd62157257c4957066f1a075a0f"
+          "text": "DatiGf0keq_Yh5pDYzDpKoicsevHubnS9RNd5rRX8Sn21puLukElsJxroPtCRXFYTcwkJqazpoWpCZAv95sW4M",
+          "value": "dab6219fd247aafd8879a436330e92a889cb1ebc7b9b9d2f5135de6b457f129f6d69b8bba4125b09c6ba0fb424571584dcc2426a6b3a685a909902ff79b16e0c"
         }
       ],
       "sender": "alice",
@@ -230,7 +230,7 @@
         "-A##",
         "Bytes"
       ],
-      "message": "-EBFYTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FAa1T4oA1pSbehBiIwnoXFGA24kgHowT34VdE95wF9qjStBsok4fIkbu8IKODF2nsZMUAmS5BqxDbbYrvl_TNGpz2omwJgYX4bSYoTeKse4-CAX-KAWBADHuTmj_7jyUCkkalySPOFiy5pTbNtjEODiwwJZlI5DqMk5Wutx4LIOWkAAa3uee2b_0Kh5SXaFq65MedyO5VYJ",
+      "message": "-EBFYTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FAa1T4oA1pSbehBiIwnoXFGA24kgHowT34VdE95wF9qjStBsok4fIkbu8IKODF2nsZMUAmS5BqxDbbYrvl_TNFj6rHuLymWkvlrkt54-cOq-CAX-KAWBADw48mquyWI0O40nsbcI7jRugSJko0JMZR-4S07YFJq3Mzy6jvAkEsDGAecW9jCUVDdwZScckWUaAzSSGbNunMN",
       "name": "direct-hpke-base",
       "nonce": null,
       "payload_plaintext": "-ZAJXSCS4BAA4BAA-AAF5BAEAGhlbGxvIHdvcmxk",
@@ -315,9 +315,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -364,8 +364,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "78 bytes, shown as hex",
-          "text": "1T4oA1pSbehBiIwnoXFGA24kgHowT34VdE95wF9qjStBsok4fIkbu8IKODF2nsZMUAmS5BqxDbbYrvl_TNGpz2omwJgYX4bSYoTeKse4",
-          "value": "d53e28035a526de841888c27a17146036e24807a304f7e15744f79c05f6a8d2b41b289387c891bbbc20a3831769ec64c500992e41ab10db6d8aef97f4cd1a9cf6a26c098185f86d26284de2ac7b8"
+          "text": "1T4oA1pSbehBiIwnoXFGA24kgHowT34VdE95wF9qjStBsok4fIkbu8IKODF2nsZMUAmS5BqxDbbYrvl_TNFj6rHuLymWkvlrkt54-cOq",
+          "value": "d53e28035a526de841888c27a17146036e24807a304f7e15744f79c05f6a8d2b41b289387c891bbbc20a3831769ec64c500992e41ab10db6d8aef97f4cd163eab1ee2f299692f96b92de78f9c3aa"
         },
         {
           "chars": 4,
@@ -396,8 +396,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "DHuTmj_7jyUCkkalySPOFiy5pTbNtjEODiwwJZlI5DqMk5Wutx4LIOWkAAa3uee2b_0Kh5SXaFq65MedyO5VYJ",
-          "value": "c7b939a3ffb8f25029246a5c923ce162cb9a536cdb6310e0e2c30259948e43a8c9395aeb71e0b20e5a40006b7b9e7b66ffd0a879497685abae4c79dc8ee55609"
+          "text": "Dw48mquyWI0O40nsbcI7jRugSJko0JMZR-4S07YFJq3Mzy6jvAkEsDGAecW9jCUVDdwZScckWUaAzSSGbNunMN",
+          "value": "f0e3c9aabb2588d0ee349ec6dc23b8d1ba0489928d0931947ee12d3b60526adcccf2ea3bc0904b0318079c5bd8c25150ddc1949c724594680cd24866cdba730d"
         }
       ],
       "sender": "alice",
@@ -422,7 +422,7 @@
         "-A##",
         "Bytes"
       ],
-      "message": "-EA3YTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB-ZAMXSCS4BAA4BAA-AAI5BAHAHB1YmxpYyBhbm5vdW5jZW1lbnQh-CAX-KAWBAD-jhE5h1oMTf-JsSEMVdJ2ntTahc3PFi25mQ6kPvbnPqfuhIQzTKxuTvfYauG95msg_yb2eryo3wvg1YoX7xAP",
+      "message": "-EA3YTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB-ZAMXSCS4BAA4BAA-AAI5BAHAHB1YmxpYyBhbm5vdW5jZW1lbnQh-CAX-KAWBACLj6MsdBES31rSLHtwvsl399JiRr8guUU--hauBWZ9zftvcY7LWzfK5JyEOcqb2l1F5c32MNtpDsQjmQgn1m8F",
       "name": "direct-signed-only",
       "nonce": null,
       "payload_plaintext": "-ZAMXSCS4BAA4BAA-AAI5BAHAHB1YmxpYyBhbm5vdW5jZW1lbnQh",
@@ -507,9 +507,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -628,8 +628,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "D-jhE5h1oMTf-JsSEMVdJ2ntTahc3PFi25mQ6kPvbnPqfuhIQzTKxuTvfYauG95msg_yb2eryo3wvg1YoX7xAP",
-          "value": "fe8e1139875a0c4dff89b1210c55d2769ed4da85cdcf162db9990ea43ef6e73ea7ee8484334cac6e4ef7d86ae1bde66b20ff26f67abca8df0be0d58a17ef100f"
+          "text": "CLj6MsdBES31rSLHtwvsl399JiRr8guUU--hauBWZ9zftvcY7LWzfK5JyEOcqb2l1F5c32MNtpDsQjmQgn1m8F",
+          "value": "8b8fa32c741112df5ad22c7b70bec977f7d26246bf20b9453efa16ae05667dcdfb6f718ecb5b37cae49c8439ca9bda5d45e5cdf630db690ec423990827d66f05"
         }
       ],
       "sender": "alice",
@@ -648,7 +648,7 @@
           "request_relationship": {
             "referral": null,
             "reply_path": [],
-            "thread_id": "W_x7mnpnWLYU-6e40XbqZKvYAdTnM8kZvucG5Ug-vp4"
+            "thread_id": "bocqFgaJ5buvtwAMaPqAnRowHSs0V_ojIOAr-72MUTo"
           }
         }
       },
@@ -663,10 +663,10 @@
         "Referral_Field",
         "Padding_Field"
       ],
-      "message": "-EBSYTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FAnU9I24IIKCz-mPGP1IZcfMZohp_eBlv-BBlfLm7vbUWlcL29m6RzNgGaA3yIiD3pFzZJXgoeCU1eij4KirnEhlzPGETY8c46grFfA0oxKauyhQSKfn8OxuivWKEaP0_r0j9JfxngveOHpa0A7mCV8dm3taohU-CAX-KAWBAA_tgpqb5e4Vfz2bXZ9ZMrk0K_pw4tSD7xd9PfHv6uPYLhaVLNap-E4pVf2GGLw0qKeadFPDV2WT4gGX2Nww_AF",
+      "message": "-EBSYTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FAnU9I24IIKCz-mPGP1IZcfMZohp_eBlv-BBlfLm7vbUWlcL29m6RzNgGaA6llzgwarcJ_sziA26tvIdjNKso7y8wD8jzERbXsSQ_PA0oxKauyhQSKfn8OxuivWKEaP0_r0j9Jfxnh2oanEUeLFG7wJ97xLQfnY-CAX-KAWBACNFhexhFZuxtMYcR0SnzKbkofePpeJJlPsgTyHPUT2YcG2GR5ELoNtquUeu5ltysJtqfDBwXgi2UvPhsSOJrkJ",
       "name": "control-rfi-direct",
       "nonce": "EREREREREREREREREREREQ",
-      "payload_plaintext": "-ZAWXRFI4BAAIFv8e5p6Z1i2FPunuNF26mSr2AHU5zPJGb7nBuVIPr6e0AARERERERERERERERERERER-JAA-JAA4BAA",
+      "payload_plaintext": "-ZAWXRFI4BAAIG6HKhYGieW7r7cADGj6gJ0aMB0rNFf6IyDgK_u9jFE60AARERERERERERERERERERER-JAA-JAA4BAA",
       "payload_segments": [
         {
           "chars": 4,
@@ -705,8 +705,8 @@
           "field": "Digest",
           "kind": "data",
           "note": "43 characters",
-          "text": "Fv8e5p6Z1i2FPunuNF26mSr2AHU5zPJGb7nBuVIPr6e",
-          "value": "5bfc7b9a7a6758b614fba7b8d176ea64abd801d4e733c919bee706e5483ebe9e"
+          "text": "G6HKhYGieW7r7cADGj6gJ0aMB0rNFf6IyDgK_u9jFE6",
+          "value": "6e872a160689e5bbafb7000c68fa809d1a301d2b3457fa2320e02bfbbd8c513a"
         },
         {
           "chars": 2,
@@ -772,9 +772,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -821,8 +821,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "117 bytes, shown as hex",
-          "text": "U9I24IIKCz-mPGP1IZcfMZohp_eBlv-BBlfLm7vbUWlcL29m6RzNgGaA3yIiD3pFzZJXgoeCU1eij4KirnEhlzPGETY8c46grFfA0oxKauyhQSKfn8OxuivWKEaP0_r0j9JfxngveOHpa0A7mCV8dm3taohU",
-          "value": "53d236e0820a0b3fa63c63f521971f319a21a7f78196ff810657cb9bbbdb51695c2f6f66e91ccd806680df22220f7a45cd92578287825357a28f82a2ae71219733c611363c738ea0ac57c0d28c4a6aeca141229f9fc3b1ba2bd628468fd3faf48fd25fc6782f78e1e96b403b98257c766ded6a8854"
+          "text": "U9I24IIKCz-mPGP1IZcfMZohp_eBlv-BBlfLm7vbUWlcL29m6RzNgGaA6llzgwarcJ_sziA26tvIdjNKso7y8wD8jzERbXsSQ_PA0oxKauyhQSKfn8OxuivWKEaP0_r0j9Jfxnh2oanEUeLFG7wJ97xLQfnY",
+          "value": "53d236e0820a0b3fa63c63f521971f319a21a7f78196ff810657cb9bbbdb51695c2f6f66e91ccd806680ea59738306ab709fecce2036eadbc876334ab28ef2f300fc8f31116d7b1243f3c0d28c4a6aeca141229f9fc3b1ba2bd628468fd3faf48fd25fc67876a1a9c451e2c51bbc09f7bc4b41f9d8"
         },
         {
           "chars": 4,
@@ -853,8 +853,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "A_tgpqb5e4Vfz2bXZ9ZMrk0K_pw4tSD7xd9PfHv6uPYLhaVLNap-E4pVf2GGLw0qKeadFPDV2WT4gGX2Nww_AF",
-          "value": "3fb60a6a6f97b855fcf66d767d64cae4d0afe9c38b520fbc5df4f7c7bfab8f60b85a54b35aa7e138a557f61862f0d2a29e69d14f0d5d964f88065f6370c3f005"
+          "text": "CNFhexhFZuxtMYcR0SnzKbkofePpeJJlPsgTyHPUT2YcG2GR5ELoNtquUeu5ltysJtqfDBwXgi2UvPhsSOJrkJ",
+          "value": "8d1617b184566ec6d318711d129f329b9287de3e97892653ec813c873d44f661c1b6191e442e836daae51ebb996dcac26da9f0c1c17822d94bcf86c48e26b909"
         }
       ],
       "sender": "alice",
@@ -871,8 +871,8 @@
         "crypto": "HpkeBase",
         "payload": {
           "accept_relationship": {
-            "reply_thread_id": "HeIlAV1Wqbl8f1GhJyeoGzl8ih-D1RQM-PwKb8uQZhI",
-            "thread_id": "W_x7mnpnWLYU-6e40XbqZKvYAdTnM8kZvucG5Ug-vp4"
+            "reply_thread_id": "VUPQxC2Cuq6cXHkAu3JG3hFdHxHi6YtUoRMfaK7lniE",
+            "thread_id": "bocqFgaJ5buvtwAMaPqAnRowHSs0V_ojIOAr-72MUTo"
           }
         }
       },
@@ -885,10 +885,10 @@
         "Reply_Digest",
         "Padding_Field"
       ],
-      "message": "-EBVYTSP-ABA4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4FAqqVZSTmoBq-jrBX8d1pa40Yk5J28FT14vIHOh8-GN6VXzL1VMQNnLb62gQT0KXkUQj74Jikwx7vUJlxbrJdtnskeHwsE-0heOyQ9hbgVIPjbvbro4DiNE-jSYkdv-xhIF8v7UTyc7OLTwd9ay2_hd6kaXfsa8Ecxv3_3deNYe-CAX-KAWBAB_2tB6-CHdYpaTYbgbvYgRNzQGL_LUn-sy_sga4tWPdHcnH2cUeqvF6r4k9EivaZLLem7S2YfZI2kAsWWTVXYJ",
+      "message": "-EBVYTSP-AAC4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4FAqqVZSTmoBq-jrBX8d1pa40Yk5J28FT14vIHOh8-GN6VXzL1VMQNnLb62gdEZb0jn-MrOyxuuFV3ljbqcDOSS01nS9XMYTzOI8JqthJqS9-0Y7fa3YLQvlZmF2VPPfUxxkzmGMFsguP9GFj-Wy2_jbXRvbLGRyd9n5Iu0x6fZY-CAX-KAWBADOiTPO66uSeX7v1x8LVcVGkiJvoRaLemx6g7torYTWAC2fXuVzBxTpBBWUxqHq-feLHLlPF04nQtVvKjwBY88D",
       "name": "control-rfa-direct",
       "nonce": "EREREREREREREREREREREQ",
-      "payload_plaintext": "-ZAZXRFA4BAAIFv8e5p6Z1i2FPunuNF26mSr2AHU5zPJGb7nBuVIPr6eIB3iJQFdVqm5fH9RoScnqBs5fIofg9UUDPj8Cm_LkGYS4BAA",
+      "payload_plaintext": "-ZAZXRFA4BAAIG6HKhYGieW7r7cADGj6gJ0aMB0rNFf6IyDgK_u9jFE6IFVD0MQtgrqunFx5ALtyRt4RXR8R4umLVKETH2iu5Z4h4BAA",
       "payload_segments": [
         {
           "chars": 4,
@@ -927,8 +927,8 @@
           "field": "Digest",
           "kind": "data",
           "note": "43 characters",
-          "text": "Fv8e5p6Z1i2FPunuNF26mSr2AHU5zPJGb7nBuVIPr6e",
-          "value": "5bfc7b9a7a6758b614fba7b8d176ea64abd801d4e733c919bee706e5483ebe9e"
+          "text": "G6HKhYGieW7r7cADGj6gJ0aMB0rNFf6IyDgK_u9jFE6",
+          "value": "6e872a160689e5bbafb7000c68fa809d1a301d2b3457fa2320e02bfbbd8c513a"
         },
         {
           "chars": 1,
@@ -943,8 +943,8 @@
           "field": "Digest",
           "kind": "data",
           "note": "43 characters",
-          "text": "B3iJQFdVqm5fH9RoScnqBs5fIofg9UUDPj8Cm_LkGYS",
-          "value": "1de225015d56a9b97c7f51a12727a81b397c8a1f83d5140cf8fc0a6fcb906612"
+          "text": "FVD0MQtgrqunFx5ALtyRt4RXR8R4umLVKETH2iu5Z4h",
+          "value": "5543d0c42d82baae9c5c7900bb7246de115d1f11e2e98b54a1131f68aee59e21"
         },
         {
           "chars": 4,
@@ -978,9 +978,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -1027,8 +1027,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "126 bytes, shown as hex",
-          "text": "qVZSTmoBq-jrBX8d1pa40Yk5J28FT14vIHOh8-GN6VXzL1VMQNnLb62gQT0KXkUQj74Jikwx7vUJlxbrJdtnskeHwsE-0heOyQ9hbgVIPjbvbro4DiNE-jSYkdv-xhIF8v7UTyc7OLTwd9ay2_hd6kaXfsa8Ecxv3_3deNYe",
-          "value": "a956524e6a01abe8eb057f1dd696b8d18939276f054f5e2f2073a1f3e18de955f32f554c40d9cb6fada0413d0a5e45108fbe098a4c31eef5099716eb25db67b24787c2c13ed2178ec90f616e05483e36ef6eba380e2344fa349891dbfec61205f2fed44f273b38b4f077d6b2dbf85dea46977ec6bc11cc6fdffddd78d61e"
+          "text": "qVZSTmoBq-jrBX8d1pa40Yk5J28FT14vIHOh8-GN6VXzL1VMQNnLb62gdEZb0jn-MrOyxuuFV3ljbqcDOSS01nS9XMYTzOI8JqthJqS9-0Y7fa3YLQvlZmF2VPPfUxxkzmGMFsguP9GFj-Wy2_jbXRvbLGRyd9n5Iu0x6fZY",
+          "value": "a956524e6a01abe8eb057f1dd696b8d18939276f054f5e2f2073a1f3e18de955f32f554c40d9cb6fada074465bd239fe32b3b2c6eb855779636ea7033924b4d674bd5cc613cce23c26ab6126a4bdfb463b7dadd82d0be566617654f3df531c64ce618c16c82e3fd1858fe5b2dbf8db5d1bdb2c647277d9f922ed31e9f658"
         },
         {
           "chars": 4,
@@ -1059,8 +1059,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "B_2tB6-CHdYpaTYbgbvYgRNzQGL_LUn-sy_sga4tWPdHcnH2cUeqvF6r4k9EivaZLLem7S2YfZI2kAsWWTVXYJ",
-          "value": "7fdad07af821dd62969361b81bbd88113734062ff2d49feb32fec81ae2d58f7477271f67147aabc5eabe24f448af6992cb7a6ed2d987d9236900b16593557609"
+          "text": "DOiTPO66uSeX7v1x8LVcVGkiJvoRaLemx6g7torYTWAC2fXuVzBxTpBBWUxqHq-feLHLlPF04nQtVvKjwBY88D",
+          "value": "ce8933ceebab92797eefd71f0b55c54692226fa1168b7a6c7a83bb68ad84d6002d9f5ee5730714e9041594c6a1eaf9f78b1cb94f174e2742d56f2a3c0163cf03"
         }
       ],
       "sender": "bob",
@@ -1077,7 +1077,7 @@
         "crypto": "HpkeBase",
         "payload": {
           "cancel_relationship": {
-            "thread_id": "W_x7mnpnWLYU-6e40XbqZKvYAdTnM8kZvucG5Ug-vp4"
+            "thread_id": "bocqFgaJ5buvtwAMaPqAnRowHSs0V_ojIOAr-72MUTo"
           }
         }
       },
@@ -1089,10 +1089,10 @@
         "Digest",
         "Padding_Field"
       ],
-      "message": "-EBKYTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FAfOLoHxJkegv3Q68EgUa1HPL_ELnoSkq5XE30aiOOC606B3B1YEcvuD4SDsz6TJiaJavy3u83tzf2rlJFV1NsV3QJqO3GwG2gHxOBeTblt_9yZcAaBs9-hgEO9nm-5-CAX-KAWBACH2iTSkMLf5JsDKTu9JUmptveFad52vuynvG5FUwMqSSvDUpAG9QphNBY2CmwZNVQStTjwNWG-NzaiQt_hJw0F",
+      "message": "-EBKYTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FAfOLoHxJkegv3Q68EgUa1HPL_ELnoSkq5XE30aiOOC606B3B1YEcvuD4SDhkXCqlpn1_EM92pZdHHBbSC9yCTGuTFQpXadBZ21K0ReTbkUqjyX4lDkzJyHnFRHC20C-CAX-KAWBAAP0xHZu9aQ3ipUAO_IlZ25t-YZycYCnzDoep-n707EY-MQNqkRqA00M3KvMwBAV_iV9_jzDJ8TXrKiirrrahwK",
       "name": "control-rfd",
       "nonce": null,
-      "payload_plaintext": "-ZAOXRFD4BAAIFv8e5p6Z1i2FPunuNF26mSr2AHU5zPJGb7nBuVIPr6e4BAA",
+      "payload_plaintext": "-ZAOXRFD4BAAIG6HKhYGieW7r7cADGj6gJ0aMB0rNFf6IyDgK_u9jFE64BAA",
       "payload_segments": [
         {
           "chars": 4,
@@ -1131,8 +1131,8 @@
           "field": "Digest",
           "kind": "data",
           "note": "43 characters",
-          "text": "Fv8e5p6Z1i2FPunuNF26mSr2AHU5zPJGb7nBuVIPr6e",
-          "value": "5bfc7b9a7a6758b614fba7b8d176ea64abd801d4e733c919bee706e5483ebe9e"
+          "text": "G6HKhYGieW7r7cADGj6gJ0aMB0rNFf6IyDgK_u9jFE6",
+          "value": "6e872a160689e5bbafb7000c68fa809d1a301d2b3457fa2320e02bfbbd8c513a"
         },
         {
           "chars": 4,
@@ -1166,9 +1166,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -1215,8 +1215,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "93 bytes, shown as hex",
-          "text": "OLoHxJkegv3Q68EgUa1HPL_ELnoSkq5XE30aiOOC606B3B1YEcvuD4SDsz6TJiaJavy3u83tzf2rlJFV1NsV3QJqO3GwG2gHxOBeTblt_9yZcAaBs9-hgEO9nm-5",
-          "value": "38ba07c4991e82fdd0ebc12051ad473cbfc42e7a1292ae57137d1a88e382eb4e81dc1d5811cbee0f8483b33e932626896afcb7bbcdedcdfdab949155d4db15dd026a3b71b01b6807c4e05e4db96dffdc99700681b3dfa18043bd9e6fb9"
+          "text": "OLoHxJkegv3Q68EgUa1HPL_ELnoSkq5XE30aiOOC606B3B1YEcvuD4SDhkXCqlpn1_EM92pZdHHBbSC9yCTGuTFQpXadBZ21K0ReTbkUqjyX4lDkzJyHnFRHC20C",
+          "value": "38ba07c4991e82fdd0ebc12051ad473cbfc42e7a1292ae57137d1a88e382eb4e81dc1d5811cbee0f84838645c2aa5a67d7f10cf76a597471c16d20bdc824c6b93150a5769d059db52b445e4db914aa3c97e250e4cc9c879c54470b6d02"
         },
         {
           "chars": 4,
@@ -1247,8 +1247,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "CH2iTSkMLf5JsDKTu9JUmptveFad52vuynvG5FUwMqSSvDUpAG9QphNBY2CmwZNVQStTjwNWG-NzaiQt_hJw0F",
-          "value": "87da24d290c2dfe49b03293bbd2549a9b6f78569de76beeca7bc6e4553032a492bc3529006f50a613416360a6c19355412b538f03561be3736a242dfe1270d05"
+          "text": "AP0xHZu9aQ3ipUAO_IlZ25t-YZycYCnzDoep-n707EY-MQNqkRqA00M3KvMwBAV_iV9_jzDJ8TXrKiirrrahwK",
+          "value": "0fd311d9bbd690de2a5400efc8959db9b7e619c9c6029f30e87a9fa7ef4ec463e31036a911a80d343372af33004057f895f7f8f30c9f135eb2a28abaeb6a1c0a"
         }
       ],
       "sender": "alice",
@@ -1267,7 +1267,7 @@
           "request_relationship": {
             "referral": null,
             "reply_path": [],
-            "thread_id": "BD__deIYNMmhETcPR1fq8v2YgoKoa16vLJJe7nI2C9Y"
+            "thread_id": "ICbb6sCz0B7h0lhEagDMSFAy9gM0Op2p-NlbsIPxyME"
           }
         }
       },
@@ -1282,10 +1282,10 @@
         "Referral_Field",
         "Padding_Field"
       ],
-      "message": "-EBlYTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4CA6DvRIPYQKw_paPzePKdSbkGiRcRNmjYHhx0gYr0S543IUTpqE3k4s9HkuJRqrD8LXaYNucbfQLrI9Q_TfieiYffgOvSAPhO5cAisip55K2b2AbuPDV4Zk5EnAMy7-470OWR2mI3ouzQl4meT26JPSyg_rg7X_evwr8ZJy5MbImIzNsXyhokDa-xx64NI2P9EtoAp7jAt2L_c9YW-tI0x9gtg3b53hlA0RJj1GWRop-CAX-KAWBADpDxx2j-GxAdAbAMV57_2ieRHgJniYg9zwHZXVAVS3JLfRDe2y4iEN2rQkFUe2i_iam6ucCwHRUELVXLEOddYG",
+      "message": "-EBlYTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4CA6DvRIPYQKw_paPzePKdSbkGiRcRNmjYHhx0gYr0S543LPuthiS9TykYKBa5GgjpzVaYNucbfQLrI9Q_TfieiYffgOvSAPhO5cAisip55K2b2AbuPDV4Zk5EnAMy7-470OWR2mI3ouzQl4meT26JPSyg_rg5HmXmMJWnalpAWn06Gal8YMCDRbZ0255gZ9Oo_cZ8lsjAt2L_c9YW-tI0x9gtg3b53hlA0RJj1GWRop-CAX-KAWBACZ_SWKSrGs0IJizGHSPHgDFXfwoB4xQFHecjUVbYA8d8jPfVge-5Lj3FW2E9gY1xx4to73eQgj7fc_jiCVuNAA",
       "name": "control-rfi-sealed-box",
       "nonce": "EREREREREREREREREREREQ",
-      "payload_plaintext": "-ZApXRFI4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBxFAQ__3XiGDTJoRE3D0dX6vL9mIKCqGteryySXu5yNgvW0AARERERERERERERERERERER-JAA-JAA4BAA",
+      "payload_plaintext": "-ZApXRFI4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBxFCAm2-rAs9Ae4dJYRGoAzEhQMvYDNDqdqfjZW7CD8cjB0AARERERERERERERERERERER-JAA-JAA4BAA",
       "payload_segments": [
         {
           "chars": 4,
@@ -1332,8 +1332,8 @@
           "field": "Digest",
           "kind": "data",
           "note": "43 characters",
-          "text": "AQ__3XiGDTJoRE3D0dX6vL9mIKCqGteryySXu5yNgvW",
-          "value": "043fff75e21834c9a111370f4757eaf2fd988282a86b5eaf2c925eee72360bd6"
+          "text": "CAm2-rAs9Ae4dJYRGoAzEhQMvYDNDqdqfjZW7CD8cjB",
+          "value": "2026dbeac0b3d01ee1d258446a00cc485032f603343a9da9f8d95bb083f1c8c1"
         },
         {
           "chars": 2,
@@ -1399,9 +1399,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -1448,8 +1448,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "174 bytes, shown as hex",
-          "text": "DvRIPYQKw_paPzePKdSbkGiRcRNmjYHhx0gYr0S543IUTpqE3k4s9HkuJRqrD8LXaYNucbfQLrI9Q_TfieiYffgOvSAPhO5cAisip55K2b2AbuPDV4Zk5EnAMy7-470OWR2mI3ouzQl4meT26JPSyg_rg7X_evwr8ZJy5MbImIzNsXyhokDa-xx64NI2P9EtoAp7jAt2L_c9YW-tI0x9gtg3b53hlA0RJj1GWRop",
-          "value": "0ef4483d840ac3fa5a3f378f29d49b9068917113668d81e1c74818af44b9e372144e9a84de4e2cf4792e251aab0fc2d769836e71b7d02eb23d43f4df89e8987df80ebd200f84ee5c022b22a79e4ad9bd806ee3c3578664e449c0332efee3bd0e591da6237a2ecd097899e4f6e893d2ca0feb83b5ff7afc2bf19272e4c6c8988ccdb17ca1a240dafb1c7ae0d2363fd12da00a7b8c0b762ff73d616fad234c7d82d8376f9de1940d11263d46591a29"
+          "text": "DvRIPYQKw_paPzePKdSbkGiRcRNmjYHhx0gYr0S543LPuthiS9TykYKBa5GgjpzVaYNucbfQLrI9Q_TfieiYffgOvSAPhO5cAisip55K2b2AbuPDV4Zk5EnAMy7-470OWR2mI3ouzQl4meT26JPSyg_rg5HmXmMJWnalpAWn06Gal8YMCDRbZ0255gZ9Oo_cZ8lsjAt2L_c9YW-tI0x9gtg3b53hlA0RJj1GWRop",
+          "value": "0ef4483d840ac3fa5a3f378f29d49b9068917113668d81e1c74818af44b9e372cfbad8624bd4f29182816b91a08e9cd569836e71b7d02eb23d43f4df89e8987df80ebd200f84ee5c022b22a79e4ad9bd806ee3c3578664e449c0332efee3bd0e591da6237a2ecd097899e4f6e893d2ca0feb8391e65e63095a76a5a405a7d3a19a97c60c08345b674db9e6067d3a8fdc67c96c8c0b762ff73d616fad234c7d82d8376f9de1940d11263d46591a29"
         },
         {
           "chars": 4,
@@ -1480,8 +1480,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "DpDxx2j-GxAdAbAMV57_2ieRHgJniYg9zwHZXVAVS3JLfRDe2y4iEN2rQkFUe2i_iam6ucCwHRUELVXLEOddYG",
-          "value": "e90f1c768fe1b101d01b00c579effda27911e026789883dcf01d95d50154b724b7d10dedb2e2210ddab4241547b68bf89a9bab9c0b01d15042d55cb10e75d606"
+          "text": "CZ_SWKSrGs0IJizGHSPHgDFXfwoB4xQFHecjUVbYA8d8jPfVge-5Lj3FW2E9gY1xx4to73eQgj7fc_jiCVuNAA",
+          "value": "99fd258a4ab1acd08262cc61d23c78031577f0a01e314051de7235156d803c77c8cf7d581efb92e3dc55b613d818d71c78b68ef7790823edf73f8e2095b8d000"
         }
       ],
       "sender": "alice",
@@ -1573,10 +1573,10 @@
         "Padding_Field",
         "Encoded_TSP_Message"
       ],
-      "message": "-ECeYTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FBz2lwtszl6nTuyUHQPcfgHqTOLcllbgMpL5_tD3myO5kqpyGOhlgwX9CKraR5Zqsd5gQo7pmzcqtklHmtpSe0VUGRKNk7lkfZ20A6iBtCP1VqpCenjGyAJ53mdytJaBU4yQlfk6_h_qkKkr8jSQoN13rtqJFnFKtSekDzdd8MtUk82fdLHrNnmk8228jNhzbL2mewQhT_V3x1-FikjdZELf5LksMYsRVdiTbIqnVk0Co_EAAO_fNEtKS-g8X2RFjJ4RHAqC-HmTC9rQg-YRasfnB2d9HuK9nLecMZspuUHPEV7Tw6UDpjSHAqwyxLkQ7Lxxgmjc4_5WRW40q8smgcd2coX_MBnjRKhY-7T4Gbo4wQ1g-6KdFgfRPbxU8mK9tN2Ch3HAEgajunFklLWpwyRRJjTYTteYXy4Z8_fYvksFnulwaI14fXVSZw-H5wT4Tiua76wgDGaWUrR-CAX-KAWBAAkhxeb5pP-zAgzjEdQkHMcjb3_U6C5KH-Nan-SU1Mhrog7UzKu1EWq8wqEU_JByX0RbDz_wXMke_SbjOG9JcsC",
+      "message": "-ECeYTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVptQ0FzRzdqMWV3VGpYanRkZHd1amlrMzNDRTJjTWJZU1BhZ3BNaVludDFB4FBz2lwtszl6nTuyUHQPcfgHqTOLcllbgMpL5_tD3myO5kqpyGOhlgwX9CKraR5Zqsd5gQo7pmzcqpslHmtpSe0VUGRKNk7lkfZ20A6iBtCP1VqpCenjGyAJ53mdytJaBU4yQlfk6_h_qkKkr8jSQoN13rtqJFnFKtSekDzdd8MtUk82fdLHrNnmk8228jNhzbL2mewQhT_V3x1-FikjdZELf5LksMYsRVdiTbIqnVk0Co_EAAO_fNEtKS-g8X2RFjJ4RHAqC-HmTC9rQg-YRasfnB2d9HuK9nLecMZspuUHPEV7Tw6UDpjSHAqwyxLkQ7LxxmW98egYKdSiaRxh6Js6BBoX_MBnjRKhY6-kPFnkWJgUA2NhQyzZ4QpYOZwiRT6qkzqB1SWU_hgQ_WLLxr1bMoaVuflEN9Dv2tKRmXJx1LMtWUkeP6Z_e5y0Cnl3d0m10M-GJnvVBBtp-CAX-KAWBAAf8fKbSjXyszjAzBQMtY580wZ_F-rhMqGMYbEGBs4te68JmWebtqW0r4cO_jyf4EQxMSV2wDmc00e0XoUo1N4M",
       "name": "nested-direct",
       "nonce": null,
-      "payload_plaintext": "-ZBiXHOP4BAA-JAA4BAA-EBFYTSP-ABA4BATZGlkOnBlZXI6NHpRbWVoc2pNdVBrUGp6ZzdXRjJ0SDVYMVNHdUZNeGFjSkI5UkVUTEZ3amdNRHFY4BATZGlkOnBlZXI6NHpRbVNNdzQxM2tlS2hncFRwWW0xcThqem1wcU5Zd2RkVkdQdWJrSE5ncDNxUWVp4FAa18xMvIf8fW5FF3cOHHKPlmJY7CNOU4gMdUw06e03UW_1PVt1O92_IkwQWqsgqb--yVFkjJd6aYMUklWFZRedb-1Dges-0k1J6Ci_CRjw-CAX-KAWBADMVJ3ENHk7SRgzuBbzonXVQ2vu4uVtLAu4Icbg1s69jW9RYPw4TaZKFvVR27mf32fuxj1YhrGBaf9hyEfFAJoJ",
+      "payload_plaintext": "-ZBiXHOP4BAA-JAA4BAA-EBFYTSP-AAC4BATZGlkOnBlZXI6NHpRbWVoc2pNdVBrUGp6ZzdXRjJ0SDVYMVNHdUZNeGFjSkI5UkVUTEZ3amdNRHFY4BATZGlkOnBlZXI6NHpRbVNNdzQxM2tlS2hncFRwWW0xcThqem1wcU5Zd2RkVkdQdWJrSE5ncDNxUWVp4FAa18xMvIf8fW5FF3cOHHKPlmJY7CNOU4gMdUw06e03UW_1PVt1O92_IkwQWqsgqb--yVFkjJd6aYMUklWFZRfxcW8kYJv_yPb6pVojLsUg-CAX-KAWBACNI0H7OMKnaJi-UyGHZNAp6gG7SlaA8JKfZxONWL5MWABhfZ2Jh9BUUC2Twe8ziNrziMbT23NJ4WeK45mWqqgJ",
       "payload_segments": [
         {
           "chars": 4,
@@ -1638,9 +1638,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -1687,8 +1687,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "78 bytes, shown as hex",
-          "text": "18xMvIf8fW5FF3cOHHKPlmJY7CNOU4gMdUw06e03UW_1PVt1O92_IkwQWqsgqb--yVFkjJd6aYMUklWFZRedb-1Dges-0k1J6Ci_CRjw",
-          "value": "d7cc4cbc87fc7d6e4517770e1c728f966258ec234e53880c754c34e9ed37516ff53d5b753bddbf224c105aab20a9bfbec951648c977a69831492558565179d6fed4381eb3ed24d49e828bf0918f0"
+          "text": "18xMvIf8fW5FF3cOHHKPlmJY7CNOU4gMdUw06e03UW_1PVt1O92_IkwQWqsgqb--yVFkjJd6aYMUklWFZRfxcW8kYJv_yPb6pVojLsUg",
+          "value": "d7cc4cbc87fc7d6e4517770e1c728f966258ec234e53880c754c34e9ed37516ff53d5b753bddbf224c105aab20a9bfbec951648c977a6983149255856517f1716f24609bffc8f6faa55a232ec520"
         },
         {
           "chars": 4,
@@ -1719,8 +1719,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "DMVJ3ENHk7SRgzuBbzonXVQ2vu4uVtLAu4Icbg1s69jW9RYPw4TaZKFvVR27mf32fuxj1YhrGBaf9hyEfFAJoJ",
-          "value": "cc549dc434793b491833b816f3a275d5436beee2e56d2c0bb821c6e0d6cebd8d6f5160fc384da64a16f551dbb99fdf67eec63d5886b18169ff61c847c5009a09"
+          "text": "CNI0H7OMKnaJi-UyGHZNAp6gG7SlaA8JKfZxONWL5MWABhfZ2Jh9BUUC2Twe8ziNrziMbT23NJ4WeK45mWqqgJ",
+          "value": "8d2341fb38c2a76898be53218764d029ea01bb4a5680f0929f67138d58be4c5800617d9d8987d054502d93c1ef3388daf388c6d3db7349e1678ae39996aaa809"
         }
       ],
       "receiver": "bob",
@@ -1746,9 +1746,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -1795,8 +1795,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "345 bytes, shown as hex",
-          "text": "2lwtszl6nTuyUHQPcfgHqTOLcllbgMpL5_tD3myO5kqpyGOhlgwX9CKraR5Zqsd5gQo7pmzcqtklHmtpSe0VUGRKNk7lkfZ20A6iBtCP1VqpCenjGyAJ53mdytJaBU4yQlfk6_h_qkKkr8jSQoN13rtqJFnFKtSekDzdd8MtUk82fdLHrNnmk8228jNhzbL2mewQhT_V3x1-FikjdZELf5LksMYsRVdiTbIqnVk0Co_EAAO_fNEtKS-g8X2RFjJ4RHAqC-HmTC9rQg-YRasfnB2d9HuK9nLecMZspuUHPEV7Tw6UDpjSHAqwyxLkQ7Lxxgmjc4_5WRW40q8smgcd2coX_MBnjRKhY-7T4Gbo4wQ1g-6KdFgfRPbxU8mK9tN2Ch3HAEgajunFklLWpwyRRJjTYTteYXy4Z8_fYvksFnulwaI14fXVSZw-H5wT4Tiua76wgDGaWUrR",
-          "value": "da5c2db3397a9d3bb250740f71f807a9338b72595b80ca4be7fb43de6c8ee64aa9c863a1960c17f422ab691e59aac779810a3ba66cdcaad9251e6b6949ed1550644a364ee591f676d00ea206d08fd55aa909e9e31b2009e7799dcad25a054e324257e4ebf87faa42a4afc8d2428375debb6a2459c52ad49e903cdd77c32d524f367dd2c7acd9e693cdb6f23361cdb2f699ec10853fd5df1d7e16292375910b7f92e4b0c62c4557624db22a9d59340a8fc40003bf7cd12d292fa0f17d9116327844702a0be1e64c2f6b420f9845ab1f9c1d9df47b8af672de70c66ca6e5073c457b4f0e940e98d21c0ab0cb12e443b2f1c609a3738ff95915b8d2af2c9a071dd9ca17fcc0678d12a163eed3e066e8e3043583ee8a74581f44f6f153c98af6d3760a1dc700481a8ee9c59252d6a70c914498d3613b5e617cb867cfdf62f92c167ba5c1a235e1f5d5499c3e1f9c13e138ae6bbeb080319a594ad1"
+          "text": "2lwtszl6nTuyUHQPcfgHqTOLcllbgMpL5_tD3myO5kqpyGOhlgwX9CKraR5Zqsd5gQo7pmzcqpslHmtpSe0VUGRKNk7lkfZ20A6iBtCP1VqpCenjGyAJ53mdytJaBU4yQlfk6_h_qkKkr8jSQoN13rtqJFnFKtSekDzdd8MtUk82fdLHrNnmk8228jNhzbL2mewQhT_V3x1-FikjdZELf5LksMYsRVdiTbIqnVk0Co_EAAO_fNEtKS-g8X2RFjJ4RHAqC-HmTC9rQg-YRasfnB2d9HuK9nLecMZspuUHPEV7Tw6UDpjSHAqwyxLkQ7LxxmW98egYKdSiaRxh6Js6BBoX_MBnjRKhY6-kPFnkWJgUA2NhQyzZ4QpYOZwiRT6qkzqB1SWU_hgQ_WLLxr1bMoaVuflEN9Dv2tKRmXJx1LMtWUkeP6Z_e5y0Cnl3d0m10M-GJnvVBBtp",
+          "value": "da5c2db3397a9d3bb250740f71f807a9338b72595b80ca4be7fb43de6c8ee64aa9c863a1960c17f422ab691e59aac779810a3ba66cdcaa9b251e6b6949ed1550644a364ee591f676d00ea206d08fd55aa909e9e31b2009e7799dcad25a054e324257e4ebf87faa42a4afc8d2428375debb6a2459c52ad49e903cdd77c32d524f367dd2c7acd9e693cdb6f23361cdb2f699ec10853fd5df1d7e16292375910b7f92e4b0c62c4557624db22a9d59340a8fc40003bf7cd12d292fa0f17d9116327844702a0be1e64c2f6b420f9845ab1f9c1d9df47b8af672de70c66ca6e5073c457b4f0e940e98d21c0ab0cb12e443b2f1c665bdf1e81829d4a2691c61e89b3a041a17fcc0678d12a163afa43c59e4589814036361432cd9e10a58399c22453eaa933a81d52594fe1810fd62cbc6bd5b328695b9f94437d0efdad291997271d4b32d59491e3fa67f7b9cb40a79777749b5d0cf86267bd5041b69"
         },
         {
           "chars": 4,
@@ -1827,8 +1827,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "Akhxeb5pP-zAgzjEdQkHMcjb3_U6C5KH-Nan-SU1Mhrog7UzKu1EWq8wqEU_JByX0RbDz_wXMke_SbjOG9JcsC",
-          "value": "2487179be693fecc08338c475090731c8dbdff53a0b9287f8d6a7f92535321ae883b5332aed445aaf30a8453f241c97d116c3cffc173247bf49b8ce1bd25cb02"
+          "text": "Af8fKbSjXyszjAzBQMtY580wZ_F-rhMqGMYbEGBs4te68JmWebtqW0r4cO_jyf4EQxMSV2wDmc00e0XoUo1N4M",
+          "value": "1ff1f29b4a35f2b338c0cc140cb58e7cd3067f17eae132a18c61b10606ce2d7baf0999679bb6a5b4af870efe3c9fe04431312576c0399cd347b45e8528d4de0c"
         }
       ],
       "sender": "alice",
@@ -1926,10 +1926,10 @@
         "Padding_Field",
         "Encoded_TSP_Message"
       ],
-      "message": "-EDGYTSP-ABA4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVh1WXg1cXVOcEFZdnUxc3lhb0hwSld4SGNlQk04UG5BUzFKODRtakVvMTE44FCbu3jQxhX4ryavA7_XLCdatfNVJssymR8KjHMqFhCjl1fHhCX_UWAqrxNVo7bN-T0MGRTxtZbXHohFBpJBtj56fuw7UmON9OGL5WewM8NS0pCOIVlwvkg3zFasindp0QF9RtKf60Y5ZewPVLKJE6zrYGM2B6fCupmO_qBmBJjXuHWh01-rGzvpFO_-Lldld7PmcFCcTrJDwLb39GhO_MQ8anZkjGz3AOAArmiwDhfVo5PNWj-7OnZ5fsKE5hBbf_2ZGN059sGqofoBGzM3KV9eCcZccBL0gmUCp5pqy_VTzsB19HhzED39WmMiFK67ZwFMmME9yBfMk9hRjyiq7UTulmS6E4X-TJSOhoMq7a3jrDKLzLeFyh6v_Jbu5_aYnz_dohJstsSkhwqCSuQxudCHC9pumoAaO4rE9pg8N1_yMg3bHL7i_SwHELoRSb9zMJy_BDGNeNPqYE7UdwnDanzHVqJ3UHzfkt9mwK4TSkS5YVmYsO2yhFRbK7_PR_J5qlizbUX8oJpm8B7JOrnBT9cUZTCVG2ykcJHrsqNrAlJCHtCl8g9LGpQXjo2PuVqpqF08fFYat_qR3HlZbOPOF13DE9-IoatO88XmFIPoLXd07MA9-CAX-KAWBACFpYywiBN-4IGmaNbJjoMGzmmLRFPtFdZ9Lo6Zhy-skvljp5e3qLMi-5rGYJO0D93U0A_V1O5gTC9LDSUlvjAG",
+      "message": "-EDGYTSP-AAC4BATZGlkOnBlZXI6NHpRbVVMNjFOYzFGN2lvaUt4SE5xd25KWFg0c3JoRnNLS1BvNlRyQ21oTTNkZnBx4BATZGlkOnBlZXI6NHpRbVh1WXg1cXVOcEFZdnUxc3lhb0hwSld4SGNlQk04UG5BUzFKODRtakVvMTE44FCbu3jQxhX4ryavA7_XLCdatfNVJssymR8KjHMqFhCjl1fHhCX_UWAqrxNVo7bN-T0MGRTxtZbXHohFBpJBtj56fuw7UmON9OGL5WewM8NS0pCOIVlwvkg3zFasindp0QF9RtKf60Y5ZewPVLKJE6zrYGM2B6fCupmO_qBmBJjXuHWh01-rGzvpFO_-Lldld7PmcFCcTrJDwLb39GhO_MQ8anZkjGz3AOAArmiwDhfVo9HNWj-7OnZ5fsKE5hBbf_2ZGN059sGqofoBGzM3KV9eCcZccBL0gmUCp5pqy_VTzsB19HhzED39WmMiFK67ZwFMmME9yBfMk9hRjyiq7UTulmS6E4X-TJSOhoMq7a3jrDKLzLeFyh6v_Jbu5_aYnz_dohJstsSkhwqCSuQxudCHC9pumoAaO4rE9pg8N1_yMg3bHL7i_SwHELoRSb9zMJy_BDGNeNPqYE7UdwnDanzHVqJ3UHzfkt9mwF1MM_QZdKOvgvfBxE9dxEHPR_J5qlizbf5nGw-4-Nbqt0y1YspyqoHUM7RS8CNS49ihzipCXyaTJQKe8iAamp_Ifkpya_Ufh2-9B0rfUcgRguVt6plFzt_cfp7d8p7yHAIaRGlVeVEi-CAX-KAWBADXtOMgFILitn6czr6D3zzczLT8uAfUBn8x0pBiFu92B-gyI5V8KaYiOvtCqiKVplPFx--C4YAVoNb7mnR2PR4P",
       "name": "routed",
       "nonce": null,
-      "payload_plaintext": "-ZCKXHOP4BAA-JAo4BATZGlkOnBlZXI6NHpRbVRLYVNSZXhuelgyZWN1MWVZUnVzRk5lV2JyVDVqYmpyM1lqdGZnY2laYzFR4BATZGlkOnBlZXI6NHpRbVNNdzQxM2tlS2hncFRwWW0xcThqem1wcU5Zd2RkVkdQdWJrSE5ncDNxUWVp4BAA-EBFYTSP-ABA4BATZGlkOnBlZXI6NHpRbWVoc2pNdVBrUGp6ZzdXRjJ0SDVYMVNHdUZNeGFjSkI5UkVUTEZ3amdNRHFY4BATZGlkOnBlZXI6NHpRbVNNdzQxM2tlS2hncFRwWW0xcThqem1wcU5Zd2RkVkdQdWJrSE5ncDNxUWVp4FAa_Gblg2mbPRmyh5lhWb0A-hzL-Neyd0LKd1gGhh-ILyOsKH7KHRVUqhRWKUcoR8U9j2EogB7xFwucVDU959TAd9Q2QqSjB-jE9i6eegLP-CAX-KAWBADtlMyQTv0kh9azrwhi4zZBRWSjYytoDK1DSDI3ipa5yqU7_YYADFl32dyFqvSZdh_YxLD5EcpCK0Me6sA8aA4J",
+      "payload_plaintext": "-ZCKXHOP4BAA-JAo4BATZGlkOnBlZXI6NHpRbVRLYVNSZXhuelgyZWN1MWVZUnVzRk5lV2JyVDVqYmpyM1lqdGZnY2laYzFR4BATZGlkOnBlZXI6NHpRbVNNdzQxM2tlS2hncFRwWW0xcThqem1wcU5Zd2RkVkdQdWJrSE5ncDNxUWVp4BAA-EBFYTSP-AAC4BATZGlkOnBlZXI6NHpRbWVoc2pNdVBrUGp6ZzdXRjJ0SDVYMVNHdUZNeGFjSkI5UkVUTEZ3amdNRHFY4BATZGlkOnBlZXI6NHpRbVNNdzQxM2tlS2hncFRwWW0xcThqem1wcU5Zd2RkVkdQdWJrSE5ncDNxUWVp4FAa_Gblg2mbPRmyh5lhWb0A-hzL-Neyd0LKd1gGhh-ILyOsKH7KHRVUqhRWKUcoR8U9j2EogB7xFwucVDU959QzKK2G4rFZMNrehW6FfO0x-CAX-KAWBABWD3cFkPXspFtG2yV_hfnwBEx7lavatfw4gv5PitdP_HI2KG60AU1lnhuVcTcxVeThYwBJX0fzY60YST347tMJ",
       "payload_segments": [
         {
           "chars": 4,
@@ -2023,9 +2023,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -2072,8 +2072,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "78 bytes, shown as hex",
-          "text": "_Gblg2mbPRmyh5lhWb0A-hzL-Neyd0LKd1gGhh-ILyOsKH7KHRVUqhRWKUcoR8U9j2EogB7xFwucVDU959TAd9Q2QqSjB-jE9i6eegLP",
-          "value": "fc66e583699b3d19b287996159bd00fa1ccbf8d7b27742ca775806861f882f23ac287eca1d1554aa145629472847c53d8f6128801ef1170b9c54353de7d4c077d43642a4a307e8c4f62e9e7a02cf"
+          "text": "_Gblg2mbPRmyh5lhWb0A-hzL-Neyd0LKd1gGhh-ILyOsKH7KHRVUqhRWKUcoR8U9j2EogB7xFwucVDU959QzKK2G4rFZMNrehW6FfO0x",
+          "value": "fc66e583699b3d19b287996159bd00fa1ccbf8d7b27742ca775806861f882f23ac287eca1d1554aa145629472847c53d8f6128801ef1170b9c54353de7d43328ad86e2b15930dade856e857ced31"
         },
         {
           "chars": 4,
@@ -2104,8 +2104,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "DtlMyQTv0kh9azrwhi4zZBRWSjYytoDK1DSDI3ipa5yqU7_YYADFl32dyFqvSZdh_YxLD5EcpCK0Me6sA8aA4J",
-          "value": "ed94cc904efd2487d6b3af0862e336414564a3632b680cad434832378a96b9caa53bfd86000c5977d9dc85aaf499761fd8c4b0f911ca422b431eeac03c680e09"
+          "text": "BWD3cFkPXspFtG2yV_hfnwBEx7lavatfw4gv5PitdP_HI2KG60AU1lnhuVcTcxVeThYwBJX0fzY60YST347tMJ",
+          "value": "560f770590f5eca45b46db257f85f9f0044c7b95abdab5fc3882fe4f8ad74ffc7236286eb4014d659e1b9571373155e4e16300495f47f363ad18493df8eed309"
         }
       ],
       "receiver": "p",
@@ -2131,9 +2131,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -2180,8 +2180,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "465 bytes, shown as hex",
-          "text": "u3jQxhX4ryavA7_XLCdatfNVJssymR8KjHMqFhCjl1fHhCX_UWAqrxNVo7bN-T0MGRTxtZbXHohFBpJBtj56fuw7UmON9OGL5WewM8NS0pCOIVlwvkg3zFasindp0QF9RtKf60Y5ZewPVLKJE6zrYGM2B6fCupmO_qBmBJjXuHWh01-rGzvpFO_-Lldld7PmcFCcTrJDwLb39GhO_MQ8anZkjGz3AOAArmiwDhfVo5PNWj-7OnZ5fsKE5hBbf_2ZGN059sGqofoBGzM3KV9eCcZccBL0gmUCp5pqy_VTzsB19HhzED39WmMiFK67ZwFMmME9yBfMk9hRjyiq7UTulmS6E4X-TJSOhoMq7a3jrDKLzLeFyh6v_Jbu5_aYnz_dohJstsSkhwqCSuQxudCHC9pumoAaO4rE9pg8N1_yMg3bHL7i_SwHELoRSb9zMJy_BDGNeNPqYE7UdwnDanzHVqJ3UHzfkt9mwK4TSkS5YVmYsO2yhFRbK7_PR_J5qlizbUX8oJpm8B7JOrnBT9cUZTCVG2ykcJHrsqNrAlJCHtCl8g9LGpQXjo2PuVqpqF08fFYat_qR3HlZbOPOF13DE9-IoatO88XmFIPoLXd07MA9",
-          "value": "bb78d0c615f8af26af03bfd72c275ab5f35526cb32991f0a8c732a1610a39757c78425ff51602aaf1355a3b6cdf93d0c1914f1b596d71e8845069241b63e7a7eec3b52638df4e18be567b033c352d2908e215970be4837cc56ac8a7769d1017d46d29feb463965ec0f54b28913aceb60633607a7c2ba998efea0660498d7b875a1d35fab1b3be914effe2e576577b3e670509c4eb243c0b6f7f4684efcc43c6a76648c6cf700e000ae68b00e17d5a393cd5a3fbb3a76797ec284e6105b7ffd9918dd39f6c1aaa1fa011b3337295f5e09c65c7012f4826502a79a6acbf553cec075f47873103dfd5a632214aebb67014c98c13dc817cc93d8518f28aaed44ee9664ba1385fe4c948e86832aedade3ac328bccb785ca1eaffc96eee7f6989f3fdda2126cb6c4a4870a824ae431b9d0870bda6e9a801a3b8ac4f6983c375ff2320ddb1cbee2fd2c0710ba1149bf73309cbf04318d78d3ea604ed47709c36a7cc756a277507cdf92df66c0ae134a44b9615998b0edb284545b2bbfcf47f279aa58b36d45fca09a66f01ec93ab9c14fd7146530951b6ca47091ebb2a36b0252421ed0a5f20f4b1a94178e8d8fb95aa9a85d3c7c561ab7fa91dc79596ce3ce175dc313df88a1ab4ef3c5e61483e82d7774ecc03d"
+          "text": "u3jQxhX4ryavA7_XLCdatfNVJssymR8KjHMqFhCjl1fHhCX_UWAqrxNVo7bN-T0MGRTxtZbXHohFBpJBtj56fuw7UmON9OGL5WewM8NS0pCOIVlwvkg3zFasindp0QF9RtKf60Y5ZewPVLKJE6zrYGM2B6fCupmO_qBmBJjXuHWh01-rGzvpFO_-Lldld7PmcFCcTrJDwLb39GhO_MQ8anZkjGz3AOAArmiwDhfVo9HNWj-7OnZ5fsKE5hBbf_2ZGN059sGqofoBGzM3KV9eCcZccBL0gmUCp5pqy_VTzsB19HhzED39WmMiFK67ZwFMmME9yBfMk9hRjyiq7UTulmS6E4X-TJSOhoMq7a3jrDKLzLeFyh6v_Jbu5_aYnz_dohJstsSkhwqCSuQxudCHC9pumoAaO4rE9pg8N1_yMg3bHL7i_SwHELoRSb9zMJy_BDGNeNPqYE7UdwnDanzHVqJ3UHzfkt9mwF1MM_QZdKOvgvfBxE9dxEHPR_J5qlizbf5nGw-4-Nbqt0y1YspyqoHUM7RS8CNS49ihzipCXyaTJQKe8iAamp_Ifkpya_Ufh2-9B0rfUcgRguVt6plFzt_cfp7d8p7yHAIaRGlVeVEi",
+          "value": "bb78d0c615f8af26af03bfd72c275ab5f35526cb32991f0a8c732a1610a39757c78425ff51602aaf1355a3b6cdf93d0c1914f1b596d71e8845069241b63e7a7eec3b52638df4e18be567b033c352d2908e215970be4837cc56ac8a7769d1017d46d29feb463965ec0f54b28913aceb60633607a7c2ba998efea0660498d7b875a1d35fab1b3be914effe2e576577b3e670509c4eb243c0b6f7f4684efcc43c6a76648c6cf700e000ae68b00e17d5a3d1cd5a3fbb3a76797ec284e6105b7ffd9918dd39f6c1aaa1fa011b3337295f5e09c65c7012f4826502a79a6acbf553cec075f47873103dfd5a632214aebb67014c98c13dc817cc93d8518f28aaed44ee9664ba1385fe4c948e86832aedade3ac328bccb785ca1eaffc96eee7f6989f3fdda2126cb6c4a4870a824ae431b9d0870bda6e9a801a3b8ac4f6983c375ff2320ddb1cbee2fd2c0710ba1149bf73309cbf04318d78d3ea604ed47709c36a7cc756a277507cdf92df66c05d4c33f41974a3af82f7c1c44f5dc441cf47f279aa58b36dfe671b0fb8f8d6eab74cb562ca72aa81d433b452f02352e3d8a1ce2a425f269325029ef2201a9a9fc87e4a726bf51f876fbd074adf51c81182e56dea9945cedfdc7e9eddf29ef21c021a446955795122"
         },
         {
           "chars": 4,
@@ -2212,8 +2212,8 @@
           "field": "signature",
           "kind": "data",
           "note": "64 bytes",
-          "text": "CFpYywiBN-4IGmaNbJjoMGzmmLRFPtFdZ9Lo6Zhy-skvljp5e3qLMi-5rGYJO0D93U0A_V1O5gTC9LDSUlvjAG",
-          "value": "85a58cb088137ee081a668d6c98e8306ce698b4453ed15d67d2e8e99872fac92f963a797b7a8b322fb9ac66093b40fddd4d00fd5d4ee604c2f4b0d2525be3006"
+          "text": "DXtOMgFILitn6czr6D3zzczLT8uAfUBn8x0pBiFu92B-gyI5V8KaYiOvtCqiKVplPFx--C4YAVoNb7mnR2PR4P",
+          "value": "d7b4e3201482e2b67e9ccebe83df3cdcccb4fcb807d4067f31d2906216ef7607e83223957c29a6223afb42aa2295a653c5c7ef82e18015a0d6fb9a74763d1e0f"
         }
       ],
       "sender": "alice",
@@ -2238,7 +2238,7 @@
         "-A##",
         "Bytes"
       ],
-      "message": "-EGwYTSP-ABA4BATZGlkOnBlZXI6NHpRbWJMcXUzd2VadHNuTmVzQnplY0NabTVGQTZ1YUdrZ0NXWVI1V25kcjZHenpk4BATZGlkOnBlZXI6NHpRbVpzS21mZm53WVZiR0xiNlptWjhna2d5VHM4RDc2WVFSQnQ1WW5GTks0U25v5FGFAG_gn35RNoXWKshZoo7uJpjoK4rcKk2jfCWOYB5delcb_W29HoRlEL0dSVeU4hgMITPH3cryDD1lyXErM9gmApU_t3X2VMWTbHMN8i8YqhdzaUnPWWDqRNtFjChapB_euEuUWFXJYvlz7tyudeTDJxbbXFn5s_fzwvfKwPMsvzF0asVGhxKC77xe3cMht126-gHc0xx908WrHrMVUtfLXWQiQmIsnXcbHqPwbHnxDWamgaWPkbwjebDDnJGHwkAg1jBz9_Wo6RYymhGpBGqc2L9IsGfYSzy9PaSb22sg5BtTLO1vf3o_d3KoAks7uHG7RYDQgarMl4pWZUaICod3MK7yZlTR9LOsnXqkn2UXMyNg5Tr0bX6iEIw4bM77HXu2Ic84eF-2DfgXbK2I6DdH-KcH2b2EMmv95kC4WED-jPGoQA2Wd7kBNYlbYouQU4nDmmdVjOVvo2AeD0_aDu3cN2nQyINx34ryTcGjG6sfg6H6FYWT6yET7vpfPpZlx_cs_qq9QC9d5yjZOSzyEmgQE4a0QVGtxdk8a_Bd2O8gGutWbM5fFNLoPEwreECPHIuhuMBXMmIqRS1igha8yN_dvapSle1WrHVy9EADQww4KzR8DHvPVuqbCEKtm5_zA0jYiLtiiCGkfUJnBI5k07acUjSSmWz3idGItf-SmY4latHXAeWF6i18cJZkJjV2MA3s1ufE0xB2QgRMs_zwpDAB94ICwBUcMBuce40rVhamBx4_RPvr-FsX_IUMBOCRf-p_Av3RKqE2KQa83IgWUbgUnvXHsmNOtArVpTD5wtIDB-Pcwq_jvOgyKYupgddkTwo9jY50q4R3u2Nvm47NjurQKJ1jvmVsv-ouSfIYGeUrqWOkbwjfkgenLJHv7ZnXE2bPI-KkkM4n5f2OjCfHuirtQnstKEd4gCbhUSx5BSpjoNLT77emBWb_NjiKdCZ8dugvuu48R9uaAc3PtBQyf1xkyHpUoge7FLHRDC_Kc4mITunie4eC4SjaBpyVwL2PwW-pPr8J1RHOX0KNqxFq_7ZocLPdzAtgaYkLO7kaIBRKH4gGPRsoO4eyk0DrUzIaZBqp4VJRE7EcE48FjtneHHvjPc0eA4v35CWpdPtvEHgeAwsXgfF64Bn_PIMgyMt29Ja-s7Ob4j4TGOBXxxdMUhf67z9nnUARnLej12ARzaz9Wa00fQjfvJQVaxbjeZ9kFDM69vjW997615Oxute1YenKcZqACx9EoghOqj_xwJphXfBIQcy27pYcOPDm5Q1vjLryDv5kyyp0bIni5sIqUQnrJ9InUy2VBtSB0wE_drnoiwQu2_rMb_M0jgnuNZ-N3Y9haW4AMX7a-5uttqK-eyQO0OogmCBr8pLN0ZC7aQz2KbPl_TDxQQgrCn2ra_1VsYn8hl0x_D1FQUeB4y6bA3LnfUuVkYYYoUFQQGy5oCdT-AjqCSqfOoGRjRRBfsOpm67DykdVa1BXIEgfXNPCzfHzPHvAkYdH1aar1fOZINtK9jKJZjz-5RtiE2yvMWqj628njag-IiDxyVRM1-5WD2VR-CRR-KRQ1AAQ7lG6KIMGuSHrKLzGbLDrkCKa1exarWA7Go0792shiM2psZaZuqyfY7fO0V0vY4B4uCOlCWiRxbAR3JzslRQnRzE34f7CseSlcO_Xv-yR1USl0Ad3i9dkdjsqrp8boBA4unSl8IEi5b6syuIORGnQCQZvO1xbHTra_xwdNe9H-yvnaeZe-e9JrvI6wTEXKpwfzj6JhUliPiQiZffpC9aFiaMz4b8s6i37tWRygHFrlCS97tV2fCL9XkGms5vjLzNVBmhBw-NvcgLSrtfXLpvBOmNIphE3kzFAi0vZUa2phQKuFmlviyFrPHPlVAN9Q5WGbst425cS2bIE9meRNnD2i7Y5F74aSPwbow5KDpQQc3Rch3OWWDRjspuxx9zYTkMRIatosRJtXc2dNnGrRoUHKF2-5DKrJ5Gx9J9sFm4f1OQ4IokxmGj-YkjRPiPukYFvUFrobfRx3kyhHzxoHpMgmkN98dh24tlVbVpcsWXwhXkfoGy2fvTMQE3EE7ItA3deCXumiFwHeCFpNOjyEaLj_s9zBI6NF3lvtR0Ex17w-YehP7_zyufpwguCnyxxbHFAbZDOXGc5jMntG2QvosPYirxVoEQUaQg4nZFCikoWbh7KgjXtzLnctKBIRn6DSeNYNdIweq2M3YUJOkk-Au9tTFSO8UvmPiww5oDBT927QrpeyOLVBuHYBC8HFFe7_XbmBC2T-_qCs68f4OqhLbMdK2SM3O36hIXK81QbWR-2_3Zy7qgLRVRiHNIsycmWibYsD_MmSzM7s__J-jzDTISOuj-ZtoKtAcmYndpLZLzkpWoKfxHSfX_PUH1T0My5nhGypx5zSQ2NxOur_PoYERR0bijcAAmzqRm2xtBaGqI6YbPm_88y3hlzU4N1wcFlyoc8R68rHZk25UR5oVi4veVi4_s1itJ1tNVUojKvbYpLOUnVa_A3-G4B6uYBrIW7svDbBzV8cp-ptNGkBrIyh3xNSftImjH641Y49wSfds2RS7K4_QJyJpeRyhLTD3xabL1QkKO2hqNFD0aEtLtCPdpaUvFxrCgL7vXdR86-KnJOP5bedbWNiYGRbUU7JdOQt2pFOqMlW0TWfl7-313tavijKuy4DoSCA_cjlWsc7XWT8zPk0gTSFrN8QH5EF2rAZNt1F7HjZibEDlzC5fb559Y9TB3Kud_LGKfOjqcFQDrRKGpaJTFnBbgBZdk2Mt96QVMUUYJTvHjeUlbFi7MtNrSuGjTItrf2SZWq_c0MJN1T6KX6ZPEVvqTZ31shLhwXW1MysbGdavuF_-Z9ZXwUYeWdmi9mWAfio10dfEKhpjnnxHVaPk7mpKH2883L3GnkzV1GQSJbeykEv-bEgmSEmVNo1QwFcAEBTfndi_vUmSxTtNWUct7Nv7nfvUTmyy6FECGTYaLoT8VfZRPn0hwi5axZM--6lC9qLEWk8PGWQk6FEFoj6jcJS0s69IzasBXE-JyZaKKOORagAjOxYoAv3K0h8N7wSxupoukUwRrYn-4WxAddpfFLTuFGwoqfp4Va0VZXsMZtuXXUkqlPSCfBrvs7m56GDRVCmLGJlI7QlMMjNgde2dxgKo8sqL8mYjZDHAJG732BaGAmGNI31KFy2lCe0ot7JOF5vy8UMBAfHGEprgQpCvRAfzHeJSSRg8ZqfQTCOjKIuGQeKRxYhEXv74-ZaCVNF2qE02ldQ3ugkt642VQXvo-rGSmH17L7P6T3JkU7zUvnO3HMrgI0xSzY1RHRgICCeFi35s7cqliW0jHbuHhQ3VkzY8ZXO8LBLM2nwbor6BetQYmgrhWefqg_QOXyKnnuuwT8sZneNDKpfxPLD_3CKSib56PoRdmZIjM8f1xKcje4ceJktg32XunXWUlDM1ptOLPb7vzniVZycycC_0tqsNk0V_NSbR_wnVsE80t7d0y8uKV7i2-nISibVd6MuQoIVq3dNJ8ebJZkvTNIApOPlPe3KpyZn73C-oROuGINs7I7QDfkrHzsVm-2V7pRYfpdtGNJnXacAdT29Jz20PQBQh11laHcRh-o3JSmzQHRbsHVYi6oBUIi_NUnyLe5lfWXB3BPafxPCVbTBw_WtwEYUBEzpbvNIx_9kaGP068S4Co-qwCRFIS6dsR6d7O_TGsPfddpgESp0XmeWqtsu4x3nTipUVwlDlf9yL4iaOknwejxzdG-CvTlPUCTjXfuE1mv35tptCWjP-64IHPANUHQVfok9otzwWS5Y-y4Ih3yEX9Sriq7WOWp0SVgZNZ7J1r4f3ghHl2zo6W_ec8M5mOLAFJjZQNQzSInA2ZrmtuJ8lXhYht0ydTblDhi1Woprz-hBsmoSVxe2pvjlJSmHgEQUsH__NR-83AP2atgi1MdUqOQWQDCpW6DjYgbOhP4xZiu6jdFqp6AAyUpb6w7NrTqsObzZrwFD72ibmGA3baV1v-z8XSFhYi6FKBf-QLRO_AFzyc0w_vRquM6E_h2X271_SkYSp5A1YtdepapEU6O_e2ivK2lP6ctlv_F2QVFfF-8Lsw-aS9iIJsvrRBXqFct6KkF9XSW7nBcVmKXL-RMZNf2XTtBMta2O2vohS6R1M04g5Ls1w-4dk1jG1XVABNF9o_ECf2ARKMKICbJsQppnJd00Gb5yKpbOwt0D51YOOKF5aPmCl0kX0eB70EHBYa0MIcZuRs5SZooDOVe1sLLrTphX1uHY0TapWKX0_42-434qVgMiSCc7KxJEVDSHHoEof_DVVX9zKdXCbfK5Nykyj8qfDOX21vZP_yNB171nFSpu7kxqrN7q3mC4YMxzPZzFzfgPmWqSDTXBYFxzFmt_wSJSVCjJATRlw8mg1Ay-8xQHWT5K5zikRuNoIgS_cy7kUC8t1EvGN99SHCAvDqN6GMemIv8Av_rCRhlnpVR1XbhutWjrPqoVh4XV7iCBfewlJYIOtocv20tLlbplxC_3WA7goKoKLn1QDrlRuk0lslueye6vIOMNBZv_brPkAilqAkbUVYtiMmnGXOvB3U-rzJ54D9kQkI_zJarhT-wSaMCnoBd2KHyR4rfGnBXCs6xGwvWycET9E8q5ApDjYVAZoOBOl6KwKzCtPz8H2cKmeezVkL3IvTVZsWZEr55WWwioQhPnXpCAgZI0HqEwCfITKh_d_0-Nt3PJdXQygL9Z6EKKxe6fGfs1rx33U86fOiWVftpRWY9WnpreUZQSov3OgtFSeFQbgK2C3WZOgOl6rfzKu9pQjXWHmk-xxWMCIKKSTBmfv2eHzzp8UnBoKSUALNNSMXxA5vUwGDh6iGziC8O0QGex5prNNspjLd99B0TO-NqJVeNd0fwQ5iHWiswfr1Ak3jzYqAyq6mRlUG5mIHNAiDLQb_EizjMQapBSM_QvvZabVHf8EiBNJwvTp0N4ag_XNlf3eOnplLWWRQShRE2nwpZverwNg4AWe7KpvgaHjMNJaj3RzJ5jvYjGdWxd0EreuUE0L_RBDrkXEJVtXo47sys0ykg0i9bJ2GkPyx_TNi8TcrPsKPl4YDbpFG6GZbX0rEJhPwe-MeLAqOriUAPQGblT5RFFTf3Yt5sovMPGkeFy9yybB430UuNm_DcbbrP5_HZqnQ7gp7E5Fws1uBz03IXEUkGlTonBGuRV8s3_FsRpTr3fM7UFr3eK1OYuMNkCbja5tTVXLLTFmGx2F-5EbapDDSFNrVgfr5QQ29qxFc6h9KqN5cKReBQBMMA_LdL74iR2RLMLBltlI8e4PVztX-tXmsvMe6LMFHVAeCcGIHugx48Aaiun-XrAPLG80iRaMBeXNYTYXsnTM7nPk7APJ8FKrbpxKTVKM7fMtddVoYghVpGIPIBo1eGaPRpf1HK1O2XIzR61PoRBGJjRTQlMd4iGlQ6vKA9ss9-3DioRtSrnqws5eoTxN3keYBn-d_jZJws9r4YE3hYyfx-an9jafBQIIwYJ9c1Xi4wd_6KonPhIQig0NLpn4Y_phs4s0Oy8QLGPkTTKHUc3jClCKjoesBbp4WVqb3ffLiZ2rgyYaSKWK2e6Dt57ajcOZuUuGQhTo_CbYTiycGWXNfc_aa7hmA0zM3Aiy1QYN0R4vk0BRGmwJsRuU0uVMRdKD7TbjCNxeKWVnp87Xs4YUyrcCWaj9eW6Vr_e22tPdS32o1sE53D6np0TjdBJHujiUqkaxZQmYRzie92eLlHFqNkuIX5PNGGQUYit0pDJCwx7HQHcVYxcmzhe4CuoEYDGAqt7w7TjI1l8buOk81ZNVHq_IlYf_Q1z8vj9R8qjynQY_CY_ldgMhgq64-F7KvMPrGMWUQJTifjgHEDYeZ97ktz3oIeOUEAxQTfS6ciJmwhyIQ9hJvj9RAWJV1lc57F-i9SWYq5N-R4ecsaQVl8mMoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQ4TFRge",
+      "message": "-EGwYTSP-AAC4BATZGlkOnBlZXI6NHpRbWJMcXUzd2VadHNuTmVzQnplY0NabTVGQTZ1YUdrZ0NXWVI1V25kcjZHenpk4BATZGlkOnBlZXI6NHpRbVpzS21mZm53WVZiR0xiNlptWjhna2d5VHM4RDc2WVFSQnQ1WW5GTks0U25v5FGFAG_gn35RNoXWKshZoo7uJpjoK4rcKk2jfCWOYB5delcb_W29HoRlEL0dSVeU4hgMITPH3cryDD1lyXErM9gmApU_t3X2VMWTbHMN8i8YqhdzaUnPWWDqRNtFjChapB_euEuUWFXJYvlz7tyudeTDJxbbXFn5s_fzwvfKwPMsvzF0asVGhxKC77xe3cMht126-gHc0xx908WrHrMVUtfLXWQiQmIsnXcbHqPwbHnxDWamgaWPkbwjebDDnJGHwkAg1jBz9_Wo6RYymhGpBGqc2L9IsGfYSzy9PaSb22sg5BtTLO1vf3o_d3KoAks7uHG7RYDQgarMl4pWZUaICod3MK7yZlTR9LOsnXqkn2UXMyNg5Tr0bX6iEIw4bM77HXu2Ic84eF-2DfgXbK2I6DdH-KcH2b2EMmv95kC4WED-jPGoQA2Wd7kBNYlbYouQU4nDmmdVjOVvo2AeD0_aDu3cN2nQyINx34ryTcGjG6sfg6H6FYWT6yET7vpfPpZlx_cs_qq9QC9d5yjZOSzyEmgQE4a0QVGtxdk8a_Bd2O8gGutWbM5fFNLoPEwreECPHIuhuMBXMmIqRS1igha8yN_dvapSle1WrHVy9EADQww4KzR8DHvPVuqbCEKtm5_zA0jYiLtiiCGkfUJnBI5k07acUjSSmWz3idGItf-SmY4latHXAeWF6i18cJZkJjV2MA3s1ufE0xB2QgRMs_zwpDAB94ICwBUcMBuce40rVhamBx4_RPvr-FsX_IUMBOCRf-p_Av3RKqE2KQa83IgWUbgUnvXHsmNOtArVpTD5wtIDB-Pcwq_jvOgyKYupgddkTwo9jY50q4R3u2Nvm47NjurQKJ1jvmVsv-ouSfIYGeUrqWOkbwjfkgenLJHv7ZnXE2bPI-KkkM4n5f2OjCfHuirtQnstKEd4gCbhUSx5BSpjoNLT77emBWb_NjiKdCZ8dugvuu48R9uaAc3PtBQyf1xkyHpUoge7FLHRDC_Kc4mITunie4eC4SjaBpyVwL2PwW-pPr8J1RHOX0KNqxFq_7ZocLPdzAtgaYkLO7kaIBRKH4gGPRsoO4eyk0DrUzIaZBqp4VJRE7EcE48FjtneHHvjPc0eA4v35CWpdPtvEHgeAwsXgfF64Bn_PIMgyMt29Ja-s7Ob4j4TGOBXxxdMUhf67z9nnUARnLej12ARzaz9Wa00fQjfvJQVaxbjeZ9kFDM69vjW997615Oxute1YenKcZqACx9EoghOqj_xwJphXfBIQcy27pYcOPDm5Q1vjLryDv5kyyp0bIni5sIqUQnrJ9InUy2VBtSB0wE_drnoiwQu2_rMb_M0jgnuNZ-N3Y9haW4AMX7a-5uttqK-eyQO0OogmCBr8pLN0ZC7aQz2KbPl_TDxQQgrCn2ra_1VsYn8hl0x_D1FQUeB4y6bA3LnfUuVkYYYoUFQQGy5oCdT-AjqCSqfOoGRjRRBfsOpm67DykdVa1BXIEgfXNPCzfHzPHvAkYdH1aar1fOZINtK9jKJZjz-5RtiE2yvMWqj629LAtbbXg63OW_A6SJ7Y_4N-CRR-KRQ1AAQB4RkRy_co2t-SiuKfXPHlU5es2uIAfVB_WJ8artzk1efysbPS2uf5bdHL7krPJXl1ZV31V-rdxoXv1ESppt27vrwNAd2NnxWkjH9Dnif3SyV8ZY2fxe0X-_hDFVfdst75PK69kAbhCDPaMjczGLVKCFh34fGQVScKIlfsswAuzYPQaTNmt6Zg98lGlWG7oZJ1dXR89NBTYEHk2vJBWS_-qDu28hGUiGpgjK60GNxo0m9JAHvGC_SkURCtRlIydqr1o1sI_ZOIgU43EFYhYrafPrWtx6by6wRSdlRKjKSIDHkuobUsVYruanR6aPdbpjFf31Ez3sFBmn3c1VjqBOl4vBUOBapAVbbj3lnwd6eJC1psRYLgcgqPkLe2sq2i6FhlxDeBX9h9T7qI1hiWmTAwdt3W9CeR00IXIQNE_0OH_THREAv2RE-pBFtg447EwfVpvK1T-3oiPsqrgRq-zoOc5jWqfzY-CLl9lOLE5pO_bAbzzglRNs8oDbfoxSKbhl09GTFbLr5mQ3PGfReVlzL9s-wO4DTYX7zmuVPCEQY5NldKhXHXsPtNrrgedWnpsdIeHsMJ-M_z6gOmhmzctMcf1c8fPluVYmYa6-h5pEIuvmWpkWOVLVZoI7aADx5v1sDXNPokBSo6TY4g8SB2_gcxERbmSp8_BXumw-9RAtwNx0fWkqmJAzZJOLgX-cYOwQyVQvuZv_HhMFtUhhSFEzg6cHQJmbhaTLqVa7iiiJMXU-vPmpro0kf5eKw2nkbrEZ6lnH2-eniGRpycY1PsyRThIkosGwv-9SlMvieR1qMsHxr_p3SfAAvtRupWrFIUZfCECTYx5l9IuV7PEQPxvUiYjAE41NKJ2SX5d_AiX62TYfZDmuRRG5cg7cA6IhD8Uf0sm3_eLErf3dify4uEy7ftvqqQqUHdm-rVaHPp9UdK_7knXvSqXBnfch1ZORlo9e5_nG9KT0zF2Gp6AhcoDYjtXVLVjF_3mmc7SmY6gCNQuqhyrLZLzXOtMmNXM-g_Wg-Wy9KISyfHtOp86HA_mjzGNxOO470A5iQuI-nF_L4kLmhQv1PsVrusUDRNx7dyqBqhIBTetL9uU8a-2dXuBIn-5Qe01XxcnZcmDazq1BPQoeUSgYD30sBAaqEgOZ89nOB7u9nmyB5iirWH9-ejdnx9wkR2wIoB4y9ohwEG3-Gs776uNrTUI73vEHTYrcZNBod432Fnr-iibMsTMa8B_G-EZ4PXIqxzyi7j-SkGK4uVRfsPxhLsC8EvcbtHzyhRczCEhVUFHlikoFUdEoNMze09wq_d8st6OsEobm0WZr6nPlqiJ-gPJWsY0WA7Q_w1Ql5W1M-x0ThkeGxw_RMo_IScHchZ36OodPGm_n0Zjbdh-S_pnlKr8l8YUb6AtIEkOtyhl0ZBHdHTIeJZbSCNNtSaFjKmHwvDdK79CaR4vgN7y2X7aZkVlMwrCmMTydhK_8mvryyhkr6eSQb2A4faz-yzhac09e0abg6_-dXZKr7QWxD3f_3-V42y1AcmemYwKti_RFgE3koDZGY0ghZu851hvRgNzJx0iI6Yz4sdxlzD2GQ_xGKdoZjZLPXeO_Z4PKd6Gb77i-ekutyKDzy3l9g2gaKB8L5T2O9NPWPju3IqFaVzAiwH0qSzxtO6wTk99jVfX6qOBNkgcoJYp1DgQXheDGj5AS7AYWFIrI29uA7PYCEAL_DWT1-nEQFJGZ3vUlsMWRevEg4BnB_64Xw1SvKDpC9dlrot2AWe9Y6K1bcpU2ZObp2kUD7S1hgRGjpjz31Lon4iSdCdhEhXmFU9FQ9zf3K7X_oV8NFYmaUgUk8rFP2jBFG3OmCuMY2lgWN39kh5Vp6KSvvZ4GAcgds5FzUIO3sVfmEWECxnzFPvnJtWaloj2rarXLF50F6FWIJeaJsPks-4D9SB5RiLRE9OT7P-jg9F1asn7D3oE0VfOa1mW1erVL6eHbVV4l_IQCZlRMXzg7V8naaSXXE4mcRC7IA3aq7nHGmTqr2RdzJNpHXebDqL37k7myswdHyX1bHUb--Ku45s9WZwECCXfSfFzKmnGRl_2tOSix5ypPLtJZj4e11usS391NVr7lgUgQBfRAUqrBkx0yhkDc4_ChvfXGdyacRkzmu7kkDZx7PnHGQsvrtSGimxYx9Fa13dRZcW4tH4sFBhc0oUM10yGsjEXhfK0o4zAz94N_Glw5kH-kFtGPkFLTwUEECISWD7xpHVIiNSfM4YtJsNkWXbBtj0UYM57MuGDzbPqDkCnrhHBl2AhHJ5eKz4byR8ouf6i5xQQIG8NU-4cGyiGErUze1QUYQx-10xi1Q8p9Ibz3ejHpSIXmJxUyUMToqTgOA-eQqn073VyLZrc9_AYmSdT9BT1UE56jl7tITcEq0ix_Th0A5zdSoVw5lp_iXrv5V1cy-2Z_rvbjoc6Bw6NikjsKQrX5we9n8hQ-R8ugYW1eIUP-B91inNBWLp8UtY98LE5c8-CulvVJavFjQZXdpC1_Gy8s-GB1QdYfZdoLlbjrojhN-p_HG2L67eakv4hNrgNHJjMs2VvDKuGNZTOF_AFg8QBUWnD5onGwDKt1LhkzCpSgH-qjM79a5AhZPlNrk99jum_TcdKxsBZgjoU3kbs5Nvgb-MHx0tyr35A1r6O18jyBHBH61-KsVu1b3CH6sUVlZ3Vpbl5rGHi02Kv3gf2Z76Oe7rjDmgEtCwp9otovvpBrJxadkdoIOexK45Nw9ZjlArqDxfBAuIeY0VQySHyUQvRJiLC3_1SF8a4d8qnHNlmBEdYnH2bXtnvlBiaF0ZknjCy6IRynUWGYN3kEnE9MjwLWsx1DHdstewkMhq_U5qtxvh6RUmrANXB97GK17vj9E6uCfndQfq_AzSB3WEmWxXHwLDwII7cyN90FwthhxbRM-HfL0Mzj61ljk1fZXtbB9-uRw1S4KqqxJqMxe5giSzZ8A4yhL91ILt5Z6_gvxwCbZEP_BAJut2tCdSu6X6rcCiO0eIyM8MsvXGlBOsY0M_7jvbHJVA86NF8dV6k0uxsN-r1B-0Mg1AOEGt_8gC2YzhN0a6-4PDycJFHsaWFbgoSJZbM_Uy4OEg6QTG4WYaLcjbXES-UzTF1BHsjSO8BEKDHexDlJN_wY2EXJaAoUiPu1JPVjWemHBSNy-HvZGIpdXZ7XSOnBYtCbCVf3khiNNoY6NlhoZtDx5Y92xJlDcVupuq8CBsVZY8ruHd5XVlgFD8QfDKWjzyVqjKQ2yitWOtX6FY443axjZOykFWS_fBwehTV7NVX_yvYiVLFjeJ0XG_9DZqofn8cVg71FBC4AuY1_CdjPnHPlUPPUeEY9NdSyUMDqGDiLTHSWNvhFUbi4La5loNjugGEyvvHmlx6_YFKSJ747WH64AdLSnvNsQ7jgPQtD5rlxUDfdGS_0rE10jfvZGJo_sABL7DIAzi79ecyVCyG0PG3fCfNWHa7iTT6rk8KYRBC4mFhrLmdM3mIe57xu5rMdg1axkXsPOn8heZ-QZyxlSQXXTFEf70S9bgfFT86xs83Cp1k2KaEzlCYnoPxOJOUNdthWv5Skp-OszV5cwUMq5u4Wlei5V1SRzN1ydS27r60I2_JdWg5ymLRlvj5wL1eeaeB7LZF4ROd6uxDmbErX1zPPuSaHMopqEBJOWc-wjFfKF2Hdz4riu6_tYvmbYdrbQVh8ciGOlY4oQX_7EwrCD1fBzDXVtAk59DeyVL6uiFwWRuXTlmYb0yHk4YAnv3pN4BZGX0d6hacYQIbVZFyfRHKE3BmGWamgiLH1-q1OIcpAVfALQcKEjrR666EstrZN_wk2Ydwruu_-Lgj9TPE2eRc-AVYVb-2p29KE1rBkpIkLTHtUqjvIt3YeMv-N2gfVWsPVhr7VtR7vUhzkIASUDBQ3udRiWEQRI2TsFQjgBoNyDCmtBSEJY8eEHd9lA1Jyh2ZLXMVpLNxskklrAz7Xse51jjcbtlHWlHw26pmPHpXfpYxxEQE2JXTbBAvTsa5ei3A7ObX9Cg22ghgv6eMq2zX3-eHurDyZhsSuqd6WSdETenn8HmuEVWybbize-m9AfKQaH5YZN7jUL-nUgbBiOz217AbduaOY9dcnn6-sQPGoik6RxWfHN6r94ox62zRXHxLPwn8A9ycZVAX31Yvi42j435NB5gtwVK3PvykKS0iht2tWkBacQP9R5sFPGgy-mDQ2y8QeRa6rA3Ezyr36wk6OJec9oVd7AqBfXvnI9IiQ3HyeDswRGzukXMncJ0zao4l6hvXP2uE_n6Yhbc1wr_hM2OdQodTirJPaqeS8igmjIeMGhw2RqO1lxI7YII0RswgIDC2SYpsvq-JvP4voJDkFJcXd6kbjd_CcqQFiLEyCS2wAAAAAAAAAAAAAAAAAAAAAABQ4SHSIm",
       "name": "direct-hpke-base-pq",
       "nonce": null,
       "payload_plaintext": "-ZAJXSCS4BAA4BAA-AAF5BAEAGhlbGxvIHdvcmxk",
@@ -2323,9 +2323,9 @@
           "chars": 4,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, then MINOR and PATCH",
-          "text": "-ABA",
-          "value": "0.1.0"
+          "note": "MAJOR in the count code's identifier, MINOR in its count",
+          "text": "-AAC",
+          "value": "0.2"
         },
         {
           "chars": 4,
@@ -2372,8 +2372,8 @@
           "field": "ciphertext",
           "kind": "data",
           "note": "1166 bytes, shown as hex",
-          "text": "AG_gn35RNoXWKshZoo7uJpjoK4rcKk2jfCWOYB5delcb_W29HoRlEL0dSVeU4hgMITPH3cryDD1lyXErM9gmApU_t3X2VMWTbHMN8i8YqhdzaUnPWWDqRNtFjChapB_euEuUWFXJYvlz7tyudeTDJxbbXFn5s_fzwvfKwPMsvzF0asVGhxKC77xe3cMht126-gHc0xx908WrHrMVUtfLXWQiQmIsnXcbHqPwbHnxDWamgaWPkbwjebDDnJGHwkAg1jBz9_Wo6RYymhGpBGqc2L9IsGfYSzy9PaSb22sg5BtTLO1vf3o_d3KoAks7uHG7RYDQgarMl4pWZUaICod3MK7yZlTR9LOsnXqkn2UXMyNg5Tr0bX6iEIw4bM77HXu2Ic84eF-2DfgXbK2I6DdH-KcH2b2EMmv95kC4WED-jPGoQA2Wd7kBNYlbYouQU4nDmmdVjOVvo2AeD0_aDu3cN2nQyINx34ryTcGjG6sfg6H6FYWT6yET7vpfPpZlx_cs_qq9QC9d5yjZOSzyEmgQE4a0QVGtxdk8a_Bd2O8gGutWbM5fFNLoPEwreECPHIuhuMBXMmIqRS1igha8yN_dvapSle1WrHVy9EADQww4KzR8DHvPVuqbCEKtm5_zA0jYiLtiiCGkfUJnBI5k07acUjSSmWz3idGItf-SmY4latHXAeWF6i18cJZkJjV2MA3s1ufE0xB2QgRMs_zwpDAB94ICwBUcMBuce40rVhamBx4_RPvr-FsX_IUMBOCRf-p_Av3RKqE2KQa83IgWUbgUnvXHsmNOtArVpTD5wtIDB-Pcwq_jvOgyKYupgddkTwo9jY50q4R3u2Nvm47NjurQKJ1jvmVsv-ouSfIYGeUrqWOkbwjfkgenLJHv7ZnXE2bPI-KkkM4n5f2OjCfHuirtQnstKEd4gCbhUSx5BSpjoNLT77emBWb_NjiKdCZ8dugvuu48R9uaAc3PtBQyf1xkyHpUoge7FLHRDC_Kc4mITunie4eC4SjaBpyVwL2PwW-pPr8J1RHOX0KNqxFq_7ZocLPdzAtgaYkLO7kaIBRKH4gGPRsoO4eyk0DrUzIaZBqp4VJRE7EcE48FjtneHHvjPc0eA4v35CWpdPtvEHgeAwsXgfF64Bn_PIMgyMt29Ja-s7Ob4j4TGOBXxxdMUhf67z9nnUARnLej12ARzaz9Wa00fQjfvJQVaxbjeZ9kFDM69vjW997615Oxute1YenKcZqACx9EoghOqj_xwJphXfBIQcy27pYcOPDm5Q1vjLryDv5kyyp0bIni5sIqUQnrJ9InUy2VBtSB0wE_drnoiwQu2_rMb_M0jgnuNZ-N3Y9haW4AMX7a-5uttqK-eyQO0OogmCBr8pLN0ZC7aQz2KbPl_TDxQQgrCn2ra_1VsYn8hl0x_D1FQUeB4y6bA3LnfUuVkYYYoUFQQGy5oCdT-AjqCSqfOoGRjRRBfsOpm67DykdVa1BXIEgfXNPCzfHzPHvAkYdH1aar1fOZINtK9jKJZjz-5RtiE2yvMWqj628njag-IiDxyVRM1-5WD2VR",
-          "value": "6fe09f7e513685d62ac859a28eee2698e82b8adc2a4da37c258e601e5d7a571bfd6dbd1e846510bd1d495794e2180c2133c7ddcaf20c3d65c9712b33d82602953fb775f654c5936c730df22f18aa17736949cf5960ea44db458c285aa41fdeb84b945855c962f973eedcae75e4c32716db5c59f9b3f7f3c2f7cac0f32cbf31746ac546871282efbc5eddc321b75dbafa01dcd31c7dd3c5ab1eb31552d7cb5d642242622c9d771b1ea3f06c79f10d66a681a58f91bc2379b0c39c9187c24020d63073f7f5a8e916329a11a9046a9cd8bf48b067d84b3cbd3da49bdb6b20e41b532ced6f7f7a3f7772a8024b3bb871bb4580d081aacc978a566546880a877730aef26654d1f4b3ac9d7aa49f6517332360e53af46d7ea2108c386ccefb1d7bb621cf38785fb60df8176cad88e83747f8a707d9bd84326bfde640b85840fe8cf1a8400d9677b90135895b628b905389c39a67558ce56fa3601e0f4fda0eeddc3769d0c88371df8af24dc1a31bab1f83a1fa158593eb2113eefa5f3e9665c7f72cfeaabd402f5de728d9392cf21268101386b44151adc5d93c6bf05dd8ef201aeb566cce5f14d2e83c4c2b78408f1c8ba1b8c05732622a452d628216bcc8dfddbdaa5295ed56ac7572f44003430c382b347c0c7bcf56ea9b0842ad9b9ff30348d888bb628821a47d4267048e64d3b69c523492996cf789d188b5ff92998e256ad1d701e585ea2d7c709664263576300decd6e7c4d3107642044cb3fcf0a43001f78202c0151c301b9c7b8d2b5616a6071e3f44fbebf85b17fc850c04e0917fea7f02fdd12aa1362906bcdc881651b8149ef5c7b2634eb40ad5a530f9c2d20307e3dcc2afe3bce832298ba981d7644f0a3d8d8e74ab8477bb636f9b8ecd8eead0289d63be656cbfea2e49f21819e52ba963a46f08df9207a72c91efed99d71366cf23e2a490ce27e5fd8e8c27c7ba2aed427b2d2847788026e1512c79052a63a0d2d3efb7a60566ff36388a74267c76e82fbaee3c47db9a01cdcfb414327f5c64c87a54a207bb14b1d10c2fca7389884ee9e27b8782e128da069c95c0bd8fc16fa93ebf09d511ce5f428dab116affb66870b3ddcc0b6069890b3bb91a20144a1f88063d1b283b87b29340eb53321a641aa9e1525113b11c138f058ed9de1c7be33dcd1e038bf7e425a974fb6f10781e030b1781f17ae019ff3c8320c8cb76f496beb3b39be23e1318e057c7174c5217faef3f679d40119cb7a3d76011cdacfd59ad347d08dfbc94156b16e3799f6414333af6f8d6f7defad793b1bad7b561e9ca719a800b1f44a2084eaa3ff1c09a615df04841ccb6ee961c38f0e6e50d6f8cbaf20efe64cb2a746c89e2e6c22a5109eb27d227532d9506d481d3013f76b9e88b042edbfacc6ff3348e09ee359f8ddd8f61696e00317edafb9badb6a2be7b240ed0ea2098206bf292cdd190bb690cf629b3e5fd30f141082b0a7dab6bfd55b189fc865d31fc3d45414781e32e9b0372e77d4b95918618a14150406cb9a02753f808ea092a9f3a81918d14417ec3a99baec3ca47556b505720481f5cd3c2cdf1f33c7bc0918747d5a6abd5f39920db4af63289663cfee51b62136caf316aa3eb6f278da83e2220f1c9544cd7ee560f6551"
+          "text": "AG_gn35RNoXWKshZoo7uJpjoK4rcKk2jfCWOYB5delcb_W29HoRlEL0dSVeU4hgMITPH3cryDD1lyXErM9gmApU_t3X2VMWTbHMN8i8YqhdzaUnPWWDqRNtFjChapB_euEuUWFXJYvlz7tyudeTDJxbbXFn5s_fzwvfKwPMsvzF0asVGhxKC77xe3cMht126-gHc0xx908WrHrMVUtfLXWQiQmIsnXcbHqPwbHnxDWamgaWPkbwjebDDnJGHwkAg1jBz9_Wo6RYymhGpBGqc2L9IsGfYSzy9PaSb22sg5BtTLO1vf3o_d3KoAks7uHG7RYDQgarMl4pWZUaICod3MK7yZlTR9LOsnXqkn2UXMyNg5Tr0bX6iEIw4bM77HXu2Ic84eF-2DfgXbK2I6DdH-KcH2b2EMmv95kC4WED-jPGoQA2Wd7kBNYlbYouQU4nDmmdVjOVvo2AeD0_aDu3cN2nQyINx34ryTcGjG6sfg6H6FYWT6yET7vpfPpZlx_cs_qq9QC9d5yjZOSzyEmgQE4a0QVGtxdk8a_Bd2O8gGutWbM5fFNLoPEwreECPHIuhuMBXMmIqRS1igha8yN_dvapSle1WrHVy9EADQww4KzR8DHvPVuqbCEKtm5_zA0jYiLtiiCGkfUJnBI5k07acUjSSmWz3idGItf-SmY4latHXAeWF6i18cJZkJjV2MA3s1ufE0xB2QgRMs_zwpDAB94ICwBUcMBuce40rVhamBx4_RPvr-FsX_IUMBOCRf-p_Av3RKqE2KQa83IgWUbgUnvXHsmNOtArVpTD5wtIDB-Pcwq_jvOgyKYupgddkTwo9jY50q4R3u2Nvm47NjurQKJ1jvmVsv-ouSfIYGeUrqWOkbwjfkgenLJHv7ZnXE2bPI-KkkM4n5f2OjCfHuirtQnstKEd4gCbhUSx5BSpjoNLT77emBWb_NjiKdCZ8dugvuu48R9uaAc3PtBQyf1xkyHpUoge7FLHRDC_Kc4mITunie4eC4SjaBpyVwL2PwW-pPr8J1RHOX0KNqxFq_7ZocLPdzAtgaYkLO7kaIBRKH4gGPRsoO4eyk0DrUzIaZBqp4VJRE7EcE48FjtneHHvjPc0eA4v35CWpdPtvEHgeAwsXgfF64Bn_PIMgyMt29Ja-s7Ob4j4TGOBXxxdMUhf67z9nnUARnLej12ARzaz9Wa00fQjfvJQVaxbjeZ9kFDM69vjW997615Oxute1YenKcZqACx9EoghOqj_xwJphXfBIQcy27pYcOPDm5Q1vjLryDv5kyyp0bIni5sIqUQnrJ9InUy2VBtSB0wE_drnoiwQu2_rMb_M0jgnuNZ-N3Y9haW4AMX7a-5uttqK-eyQO0OogmCBr8pLN0ZC7aQz2KbPl_TDxQQgrCn2ra_1VsYn8hl0x_D1FQUeB4y6bA3LnfUuVkYYYoUFQQGy5oCdT-AjqCSqfOoGRjRRBfsOpm67DykdVa1BXIEgfXNPCzfHzPHvAkYdH1aar1fOZINtK9jKJZjz-5RtiE2yvMWqj629LAtbbXg63OW_A6SJ7Y_4N",
+          "value": "6fe09f7e513685d62ac859a28eee2698e82b8adc2a4da37c258e601e5d7a571bfd6dbd1e846510bd1d495794e2180c2133c7ddcaf20c3d65c9712b33d82602953fb775f654c5936c730df22f18aa17736949cf5960ea44db458c285aa41fdeb84b945855c962f973eedcae75e4c32716db5c59f9b3f7f3c2f7cac0f32cbf31746ac546871282efbc5eddc321b75dbafa01dcd31c7dd3c5ab1eb31552d7cb5d642242622c9d771b1ea3f06c79f10d66a681a58f91bc2379b0c39c9187c24020d63073f7f5a8e916329a11a9046a9cd8bf48b067d84b3cbd3da49bdb6b20e41b532ced6f7f7a3f7772a8024b3bb871bb4580d081aacc978a566546880a877730aef26654d1f4b3ac9d7aa49f6517332360e53af46d7ea2108c386ccefb1d7bb621cf38785fb60df8176cad88e83747f8a707d9bd84326bfde640b85840fe8cf1a8400d9677b90135895b628b905389c39a67558ce56fa3601e0f4fda0eeddc3769d0c88371df8af24dc1a31bab1f83a1fa158593eb2113eefa5f3e9665c7f72cfeaabd402f5de728d9392cf21268101386b44151adc5d93c6bf05dd8ef201aeb566cce5f14d2e83c4c2b78408f1c8ba1b8c05732622a452d628216bcc8dfddbdaa5295ed56ac7572f44003430c382b347c0c7bcf56ea9b0842ad9b9ff30348d888bb628821a47d4267048e64d3b69c523492996cf789d188b5ff92998e256ad1d701e585ea2d7c709664263576300decd6e7c4d3107642044cb3fcf0a43001f78202c0151c301b9c7b8d2b5616a6071e3f44fbebf85b17fc850c04e0917fea7f02fdd12aa1362906bcdc881651b8149ef5c7b2634eb40ad5a530f9c2d20307e3dcc2afe3bce832298ba981d7644f0a3d8d8e74ab8477bb636f9b8ecd8eead0289d63be656cbfea2e49f21819e52ba963a46f08df9207a72c91efed99d71366cf23e2a490ce27e5fd8e8c27c7ba2aed427b2d2847788026e1512c79052a63a0d2d3efb7a60566ff36388a74267c76e82fbaee3c47db9a01cdcfb414327f5c64c87a54a207bb14b1d10c2fca7389884ee9e27b8782e128da069c95c0bd8fc16fa93ebf09d511ce5f428dab116affb66870b3ddcc0b6069890b3bb91a20144a1f88063d1b283b87b29340eb53321a641aa9e1525113b11c138f058ed9de1c7be33dcd1e038bf7e425a974fb6f10781e030b1781f17ae019ff3c8320c8cb76f496beb3b39be23e1318e057c7174c5217faef3f679d40119cb7a3d76011cdacfd59ad347d08dfbc94156b16e3799f6414333af6f8d6f7defad793b1bad7b561e9ca719a800b1f44a2084eaa3ff1c09a615df04841ccb6ee961c38f0e6e50d6f8cbaf20efe64cb2a746c89e2e6c22a5109eb27d227532d9506d481d3013f76b9e88b042edbfacc6ff3348e09ee359f8ddd8f61696e00317edafb9badb6a2be7b240ed0ea2098206bf292cdd190bb690cf629b3e5fd30f141082b0a7dab6bfd55b189fc865d31fc3d45414781e32e9b0372e77d4b95918618a14150406cb9a02753f808ea092a9f3a81918d14417ec3a99baec3ca47556b505720481f5cd3c2cdf1f33c7bc0918747d5a6abd5f39920db4af63289663cfee51b62136caf316aa3eb6f4b02d6db5e0eb7396fc0e9227b63fe0d"
         },
         {
           "chars": 4,
@@ -2404,8 +2404,8 @@
           "field": "signature",
           "kind": "data",
           "note": "3309 bytes",
-          "text": "7lG6KIMGuSHrKLzGbLDrkCKa1exarWA7Go0792shiM2psZaZuqyfY7fO0V0vY4B4uCOlCWiRxbAR3JzslRQnRzE34f7CseSlcO_Xv-yR1USl0Ad3i9dkdjsqrp8boBA4unSl8IEi5b6syuIORGnQCQZvO1xbHTra_xwdNe9H-yvnaeZe-e9JrvI6wTEXKpwfzj6JhUliPiQiZffpC9aFiaMz4b8s6i37tWRygHFrlCS97tV2fCL9XkGms5vjLzNVBmhBw-NvcgLSrtfXLpvBOmNIphE3kzFAi0vZUa2phQKuFmlviyFrPHPlVAN9Q5WGbst425cS2bIE9meRNnD2i7Y5F74aSPwbow5KDpQQc3Rch3OWWDRjspuxx9zYTkMRIatosRJtXc2dNnGrRoUHKF2-5DKrJ5Gx9J9sFm4f1OQ4IokxmGj-YkjRPiPukYFvUFrobfRx3kyhHzxoHpMgmkN98dh24tlVbVpcsWXwhXkfoGy2fvTMQE3EE7ItA3deCXumiFwHeCFpNOjyEaLj_s9zBI6NF3lvtR0Ex17w-YehP7_zyufpwguCnyxxbHFAbZDOXGc5jMntG2QvosPYirxVoEQUaQg4nZFCikoWbh7KgjXtzLnctKBIRn6DSeNYNdIweq2M3YUJOkk-Au9tTFSO8UvmPiww5oDBT927QrpeyOLVBuHYBC8HFFe7_XbmBC2T-_qCs68f4OqhLbMdK2SM3O36hIXK81QbWR-2_3Zy7qgLRVRiHNIsycmWibYsD_MmSzM7s__J-jzDTISOuj-ZtoKtAcmYndpLZLzkpWoKfxHSfX_PUH1T0My5nhGypx5zSQ2NxOur_PoYERR0bijcAAmzqRm2xtBaGqI6YbPm_88y3hlzU4N1wcFlyoc8R68rHZk25UR5oVi4veVi4_s1itJ1tNVUojKvbYpLOUnVa_A3-G4B6uYBrIW7svDbBzV8cp-ptNGkBrIyh3xNSftImjH641Y49wSfds2RS7K4_QJyJpeRyhLTD3xabL1QkKO2hqNFD0aEtLtCPdpaUvFxrCgL7vXdR86-KnJOP5bedbWNiYGRbUU7JdOQt2pFOqMlW0TWfl7-313tavijKuy4DoSCA_cjlWsc7XWT8zPk0gTSFrN8QH5EF2rAZNt1F7HjZibEDlzC5fb559Y9TB3Kud_LGKfOjqcFQDrRKGpaJTFnBbgBZdk2Mt96QVMUUYJTvHjeUlbFi7MtNrSuGjTItrf2SZWq_c0MJN1T6KX6ZPEVvqTZ31shLhwXW1MysbGdavuF_-Z9ZXwUYeWdmi9mWAfio10dfEKhpjnnxHVaPk7mpKH2883L3GnkzV1GQSJbeykEv-bEgmSEmVNo1QwFcAEBTfndi_vUmSxTtNWUct7Nv7nfvUTmyy6FECGTYaLoT8VfZRPn0hwi5axZM--6lC9qLEWk8PGWQk6FEFoj6jcJS0s69IzasBXE-JyZaKKOORagAjOxYoAv3K0h8N7wSxupoukUwRrYn-4WxAddpfFLTuFGwoqfp4Va0VZXsMZtuXXUkqlPSCfBrvs7m56GDRVCmLGJlI7QlMMjNgde2dxgKo8sqL8mYjZDHAJG732BaGAmGNI31KFy2lCe0ot7JOF5vy8UMBAfHGEprgQpCvRAfzHeJSSRg8ZqfQTCOjKIuGQeKRxYhEXv74-ZaCVNF2qE02ldQ3ugkt642VQXvo-rGSmH17L7P6T3JkU7zUvnO3HMrgI0xSzY1RHRgICCeFi35s7cqliW0jHbuHhQ3VkzY8ZXO8LBLM2nwbor6BetQYmgrhWefqg_QOXyKnnuuwT8sZneNDKpfxPLD_3CKSib56PoRdmZIjM8f1xKcje4ceJktg32XunXWUlDM1ptOLPb7vzniVZycycC_0tqsNk0V_NSbR_wnVsE80t7d0y8uKV7i2-nISibVd6MuQoIVq3dNJ8ebJZkvTNIApOPlPe3KpyZn73C-oROuGINs7I7QDfkrHzsVm-2V7pRYfpdtGNJnXacAdT29Jz20PQBQh11laHcRh-o3JSmzQHRbsHVYi6oBUIi_NUnyLe5lfWXB3BPafxPCVbTBw_WtwEYUBEzpbvNIx_9kaGP068S4Co-qwCRFIS6dsR6d7O_TGsPfddpgESp0XmeWqtsu4x3nTipUVwlDlf9yL4iaOknwejxzdG-CvTlPUCTjXfuE1mv35tptCWjP-64IHPANUHQVfok9otzwWS5Y-y4Ih3yEX9Sriq7WOWp0SVgZNZ7J1r4f3ghHl2zo6W_ec8M5mOLAFJjZQNQzSInA2ZrmtuJ8lXhYht0ydTblDhi1Woprz-hBsmoSVxe2pvjlJSmHgEQUsH__NR-83AP2atgi1MdUqOQWQDCpW6DjYgbOhP4xZiu6jdFqp6AAyUpb6w7NrTqsObzZrwFD72ibmGA3baV1v-z8XSFhYi6FKBf-QLRO_AFzyc0w_vRquM6E_h2X271_SkYSp5A1YtdepapEU6O_e2ivK2lP6ctlv_F2QVFfF-8Lsw-aS9iIJsvrRBXqFct6KkF9XSW7nBcVmKXL-RMZNf2XTtBMta2O2vohS6R1M04g5Ls1w-4dk1jG1XVABNF9o_ECf2ARKMKICbJsQppnJd00Gb5yKpbOwt0D51YOOKF5aPmCl0kX0eB70EHBYa0MIcZuRs5SZooDOVe1sLLrTphX1uHY0TapWKX0_42-434qVgMiSCc7KxJEVDSHHoEof_DVVX9zKdXCbfK5Nykyj8qfDOX21vZP_yNB171nFSpu7kxqrN7q3mC4YMxzPZzFzfgPmWqSDTXBYFxzFmt_wSJSVCjJATRlw8mg1Ay-8xQHWT5K5zikRuNoIgS_cy7kUC8t1EvGN99SHCAvDqN6GMemIv8Av_rCRhlnpVR1XbhutWjrPqoVh4XV7iCBfewlJYIOtocv20tLlbplxC_3WA7goKoKLn1QDrlRuk0lslueye6vIOMNBZv_brPkAilqAkbUVYtiMmnGXOvB3U-rzJ54D9kQkI_zJarhT-wSaMCnoBd2KHyR4rfGnBXCs6xGwvWycET9E8q5ApDjYVAZoOBOl6KwKzCtPz8H2cKmeezVkL3IvTVZsWZEr55WWwioQhPnXpCAgZI0HqEwCfITKh_d_0-Nt3PJdXQygL9Z6EKKxe6fGfs1rx33U86fOiWVftpRWY9WnpreUZQSov3OgtFSeFQbgK2C3WZOgOl6rfzKu9pQjXWHmk-xxWMCIKKSTBmfv2eHzzp8UnBoKSUALNNSMXxA5vUwGDh6iGziC8O0QGex5prNNspjLd99B0TO-NqJVeNd0fwQ5iHWiswfr1Ak3jzYqAyq6mRlUG5mIHNAiDLQb_EizjMQapBSM_QvvZabVHf8EiBNJwvTp0N4ag_XNlf3eOnplLWWRQShRE2nwpZverwNg4AWe7KpvgaHjMNJaj3RzJ5jvYjGdWxd0EreuUE0L_RBDrkXEJVtXo47sys0ykg0i9bJ2GkPyx_TNi8TcrPsKPl4YDbpFG6GZbX0rEJhPwe-MeLAqOriUAPQGblT5RFFTf3Yt5sovMPGkeFy9yybB430UuNm_DcbbrP5_HZqnQ7gp7E5Fws1uBz03IXEUkGlTonBGuRV8s3_FsRpTr3fM7UFr3eK1OYuMNkCbja5tTVXLLTFmGx2F-5EbapDDSFNrVgfr5QQ29qxFc6h9KqN5cKReBQBMMA_LdL74iR2RLMLBltlI8e4PVztX-tXmsvMe6LMFHVAeCcGIHugx48Aaiun-XrAPLG80iRaMBeXNYTYXsnTM7nPk7APJ8FKrbpxKTVKM7fMtddVoYghVpGIPIBo1eGaPRpf1HK1O2XIzR61PoRBGJjRTQlMd4iGlQ6vKA9ss9-3DioRtSrnqws5eoTxN3keYBn-d_jZJws9r4YE3hYyfx-an9jafBQIIwYJ9c1Xi4wd_6KonPhIQig0NLpn4Y_phs4s0Oy8QLGPkTTKHUc3jClCKjoesBbp4WVqb3ffLiZ2rgyYaSKWK2e6Dt57ajcOZuUuGQhTo_CbYTiycGWXNfc_aa7hmA0zM3Aiy1QYN0R4vk0BRGmwJsRuU0uVMRdKD7TbjCNxeKWVnp87Xs4YUyrcCWaj9eW6Vr_e22tPdS32o1sE53D6np0TjdBJHujiUqkaxZQmYRzie92eLlHFqNkuIX5PNGGQUYit0pDJCwx7HQHcVYxcmzhe4CuoEYDGAqt7w7TjI1l8buOk81ZNVHq_IlYf_Q1z8vj9R8qjynQY_CY_ldgMhgq64-F7KvMPrGMWUQJTifjgHEDYeZ97ktz3oIeOUEAxQTfS6ciJmwhyIQ9hJvj9RAWJV1lc57F-i9SWYq5N-R4ecsaQVl8mMoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQ4TFRge",
-          "value": "ee51ba288306b921eb28bcc66cb0eb90229ad5ec5aad603b1a8d3bf76b2188cda9b19699baac9f63b7ced15d2f638078b823a5096891c5b011dc9cec951427473137e1fec2b1e4a570efd7bfec91d544a5d007778bd764763b2aae9f1ba01038ba74a5f08122e5beaccae20e4469d009066f3b5c5b1d3adaff1c1d35ef47fb2be769e65ef9ef49aef23ac131172a9c1fce3e898549623e242265f7e90bd68589a333e1bf2cea2dfbb5647280716b9424bdeed5767c22fd5e41a6b39be32f3355066841c3e36f7202d2aed7d72e9bc13a6348a611379331408b4bd951ada98502ae16696f8b216b3c73e554037d4395866ecb78db9712d9b204f667913670f68bb63917be1a48fc1ba30e4a0e941073745c877396583463b29bb1c7dcd84e431121ab68b1126d5dcd9d3671ab468507285dbee432ab2791b1f49f6c166e1fd4e4382289319868fe6248d13e23ee91816f505ae86df471de4ca11f3c681e93209a437df1d876e2d9556d5a5cb165f085791fa06cb67ef4cc404dc413b22d03775e097ba6885c0778216934e8f211a2e3fecf73048e8d17796fb51d04c75ef0f987a13fbff3cae7e9c20b829f2c716c71406d90ce5c67398cc9ed1b642fa2c3d88abc55a044146908389d91428a4a166e1eca8235edccb9dcb4a048467e8349e35835d2307aad8cdd85093a493e02ef6d4c548ef14be63e2c30e680c14fddbb42ba5ec8e2d506e1d8042f071457bbfd76e6042d93fbfa82b3af1fe0eaa12db31d2b648cdcedfa8485caf3541b591fb6ff7672eea80b4554621cd22cc9c99689b62c0ff3264b333bb3ffc9fa3cc34c848eba3f99b682ad01c9989dda4b64bce4a56a0a7f11d27d7fcf507d53d0ccb99e11b2a71e73490d8dc4ebabfcfa181114746e28dc0009b3a919b6c6d05a1aa23a61b3e6ffcf32de1973538375c1c165ca873c47af2b1d9936e54479a158b8bde562e3fb358ad275b4d554a232af6d8a4b3949d56bf037f86e01eae601ac85bbb2f0db07357c729fa9b4d1a406b232877c4d49fb489a31fae35638f7049f76cd914bb2b8fd0272269791ca12d30f7c5a6cbd5090a3b686a3450f4684b4bb423dda5a52f171ac280beef5dd47cebe2a724e3f96de75b58d8981916d453b25d390b76a453aa3255b44d67e5efedf5ded6af8a32aecb80e848203f723956b1ced7593f333e4d204d216b37c407e44176ac064db7517b1e36626c40e5cc2e5f6f9e7d63d4c1dcab9dfcb18a7ce8ea705403ad1286a5a25316705b80165d93632df7a415314518253bc78de5256c58bb32d36b4ae1a34c8b6b7f64995aafdcd0c24dd53e8a5fa64f115bea4d9df5b212e1c175b5332b1b19d6afb85ffe67d657c1461e59d9a2f665807e2a35d1d7c42a1a639e7c4755a3e4ee6a4a1f6f3cdcbdc69e4cd5d4641225b7b2904bfe6c4826484995368d50c057001014df9dd8bfbd4992c53b4d59472decdbfb9dfbd44e6cb2e8510219361a2e84fc55f6513e7d21c22e5ac5933efba942f6a2c45a4f0f196424e85105a23ea37094b4b3af48cdab015c4f89c9968a28e3916a00233b162802fdcad21f0def04b1ba9a2e914c11ad89fee16c4075da5f14b4ee146c28a9fa7855ad15657b0c66db975d492a94f4827c1aefb3b9b9e860d154298b189948ed094c32336075ed9dc602a8f2ca8bf266236431c0246ef7d8168602618d237d4a172da509ed28b7b24e179bf2f1430101f1c6129ae04290af4407f31de25249183c66a7d04c23a3288b8641e291c588445efef8f9968254d176a84d3695d437ba092deb8d95417be8fab192987d7b2fb3fa4f726453bcd4be73b71ccae0234c52cd8d511d18080827858b7e6cedcaa5896d231dbb87850dd593363c6573bc2c12ccda7c1ba2be817ad4189a0ae159e7ea83f40e5f22a79eebb04fcb199de3432a97f13cb0ffdc229289be7a3e845d99922333c7f5c4a7237b871e264b60df65ee9d7594943335a6d38b3dbeefce7895672732702ff4b6ab0d93457f3526d1ff09d5b04f34b7b774cbcb8a57b8b6fa721289b55de8cb90a0856addd349f1e6c9664bd334802938f94f7b72a9c999fbdc2fa844eb8620db3b23b4037e4ac7cec566fb657ba5161fa5db463499d769c01d4f6f49cf6d0f401421d7595a1dc461fa8dc94a6cd01d16ec1d5622ea8054222fcd527c8b7b995f59707704f69fc4f0956d3070fd6b70118501133a5bbcd231ffd91a18fd3af12e02a3eab00911484ba76c47a77b3bf4c6b0f7dd7698044a9d1799e5aab6cbb8c779d38a9515c250e57fdc8be2268e927c1e8f1cdd1be0af4e53d40938d77ee1359afdf9b69b425a33feeb82073c03541d055fa24f68b73c164b963ecb8221df2117f52ae2abb58e5a9d1256064d67b275af87f78211e5db3a3a5bf79cf0ce6638b005263650350cd222703666b9adb89f255e1621b74c9d4db943862d56a29af3fa106c9a8495c5eda9be39494a61e011052c1fffcd47ef3700fd9ab608b531d52a3905900c2a56e838d881b3a13f8c598aeea3745aa9e800325296fac3b36b4eab0e6f366bc050fbda26e6180ddb695d6ffb3f174858588ba14a05ff902d13bf005cf2734c3fbd1aae33a13f8765f6ef5fd29184a9e40d58b5d7a96a9114e8efdeda2bcada53fa72d96ffc5d905457c5fbc2ecc3e692f62209b2fad1057a8572de8a905f57496ee705c5662972fe44c64d7f65d3b4132d6b63b6be8852e91d4cd388392ecd70fb8764d631b55d5001345f68fc409fd8044a30a2026c9b10a699c9774d066f9c8aa5b3b0b740f9d5838e285e5a3e60a5d245f4781ef41070586b4308719b91b39499a280ce55ed6c2cbad3a615f5b876344daa56297d3fe36fb8df8a9580c89209cecac491150d21c7a04a1ffc35555fdcca75709b7cae4dca4ca3f2a7c3397db5bd93ffc8d075ef59c54a9bbb931aab37bab7982e18331ccf6731737e03e65aa4834d7058171cc59adff04894950a32404d1970f26835032fbcc501d64f92b9ce2911b8da08812fdccbb9140bcb7512f18df7d487080bc3a8de8631e988bfc02ffeb0918659e9551d576e1bad5a3acfaa8561e1757b88205f7b09496083ada1cbf6d2d2e56e99710bfdd603b8282a828b9f5403ae546e93496c96e7b27babc838c34166ffdbacf9008a5a8091b51562d88c9a71973af07753eaf3279e03f6442423fcc96ab853fb049a3029e805dd8a1f2478adf1a70570aceb11b0bd6c9c113f44f2ae40a438d85406683813a5e8ac0acc2b4fcfc1f670a99e7b35642f722f4d566c59912be79596c22a1084f9d7a42020648d07a84c027c84ca87f77fd3e36ddcf25d5d0ca02fd67a10a2b17ba7c67ecd6bc77dd4f3a7ce89655fb6945663d5a7a6b7946504a8bf73a0b4549e1506e02b60b75993a03a5eab7f32aef694235d61e693ec7158c08828a4930667efd9e1f3ce9f149c1a0a49400b34d48c5f1039bd4c060e1ea21b3882f0ed1019ec79a6b34db298cb77df41d133be36a25578d7747f04398875a2b307ebd409378f362a032aba9919541b99881cd0220cb41bfc48b38cc41aa4148cfd0bef65a6d51dff04881349c2f4e9d0de1a83f5cd95fdde3a7a652d65914128511369f0a59bdeaf0360e0059eecaa6f81a1e330d25a8f74732798ef62319d5b177412b7ae504d0bfd1043ae45c4255b57a38eeccacd32920d22f5b2761a43f2c7f4cd8bc4dcacfb0a3e5e180dba451ba1996d7d2b10984fc1ef8c78b02a3ab89400f4066e54f94451537f762de6ca2f30f1a4785cbdcb26c1e37d14b8d9bf0dc6dbacfe7f1d9aa743b829ec4e45c2cd6e073d37217114906953a27046b9157cb37fc5b11a53af77cced416bdde2b5398b8c36409b8dae6d4d55cb2d31661b1d85fb911b6a90c348536b5607ebe50436f6ac4573a87d2aa37970a45e05004c300fcb74bef8891d912cc2c196d948f1ee0f573b57fad5e6b2f31ee8b3051d501e09c1881ee831e3c01a8ae9fe5eb00f2c6f3489168c05e5cd613617b274ccee73e4ec03c9f052ab6e9c4a4d528cedf32d75d568620855a4620f201a3578668f4697f51cad4ed9723347ad4fa1104626345342531de221a543abca03db2cf7edc38a846d4ab9eac2ce5ea13c4dde4798067f9dfe3649c2cf6be18137858c9fc7e6a7f6369f050208c1827d7355e2e3077fe8aa273e12108a0d0d2e99f863fa61b38b343b2f102c63e44d328751cde30a508a8e87ac05ba78595a9bddf7cb899dab83261a48a58ad9ee83b79eda8dc399b94b864214e8fc26d84e2c9c1965cd7dcfda6bb866034cccdc08b2d5060dd11e2f9340511a6c09b11b94d2e54c45d283ed36e308dc5e296567a7ced7b38614cab70259a8fd796e95aff7b6dad3dd4b7da8d6c139dc3ea7a744e3741247ba3894aa46b165099847389ef7678b94716a364b885f93cd186414622b74a43242c31ec7407715631726ce17b80aea04603180aadef0ed38c8d65f1bb8e93cd593551eafc89587ff435cfcbe3f51f2a8f29d063f098fe576032182aeb8f85ecabcc3eb18c5944094e27e380710361e67dee4b73de821e394100c504df4ba722266c21c8843d849be3f51016255d65739ec5fa2f52598ab937e47879cb1a41597c98ca00000000000000000000000000000000000000000000000000050e1315181e"
+          "text": "B4RkRy_co2t-SiuKfXPHlU5es2uIAfVB_WJ8artzk1efysbPS2uf5bdHL7krPJXl1ZV31V-rdxoXv1ESppt27vrwNAd2NnxWkjH9Dnif3SyV8ZY2fxe0X-_hDFVfdst75PK69kAbhCDPaMjczGLVKCFh34fGQVScKIlfsswAuzYPQaTNmt6Zg98lGlWG7oZJ1dXR89NBTYEHk2vJBWS_-qDu28hGUiGpgjK60GNxo0m9JAHvGC_SkURCtRlIydqr1o1sI_ZOIgU43EFYhYrafPrWtx6by6wRSdlRKjKSIDHkuobUsVYruanR6aPdbpjFf31Ez3sFBmn3c1VjqBOl4vBUOBapAVbbj3lnwd6eJC1psRYLgcgqPkLe2sq2i6FhlxDeBX9h9T7qI1hiWmTAwdt3W9CeR00IXIQNE_0OH_THREAv2RE-pBFtg447EwfVpvK1T-3oiPsqrgRq-zoOc5jWqfzY-CLl9lOLE5pO_bAbzzglRNs8oDbfoxSKbhl09GTFbLr5mQ3PGfReVlzL9s-wO4DTYX7zmuVPCEQY5NldKhXHXsPtNrrgedWnpsdIeHsMJ-M_z6gOmhmzctMcf1c8fPluVYmYa6-h5pEIuvmWpkWOVLVZoI7aADx5v1sDXNPokBSo6TY4g8SB2_gcxERbmSp8_BXumw-9RAtwNx0fWkqmJAzZJOLgX-cYOwQyVQvuZv_HhMFtUhhSFEzg6cHQJmbhaTLqVa7iiiJMXU-vPmpro0kf5eKw2nkbrEZ6lnH2-eniGRpycY1PsyRThIkosGwv-9SlMvieR1qMsHxr_p3SfAAvtRupWrFIUZfCECTYx5l9IuV7PEQPxvUiYjAE41NKJ2SX5d_AiX62TYfZDmuRRG5cg7cA6IhD8Uf0sm3_eLErf3dify4uEy7ftvqqQqUHdm-rVaHPp9UdK_7knXvSqXBnfch1ZORlo9e5_nG9KT0zF2Gp6AhcoDYjtXVLVjF_3mmc7SmY6gCNQuqhyrLZLzXOtMmNXM-g_Wg-Wy9KISyfHtOp86HA_mjzGNxOO470A5iQuI-nF_L4kLmhQv1PsVrusUDRNx7dyqBqhIBTetL9uU8a-2dXuBIn-5Qe01XxcnZcmDazq1BPQoeUSgYD30sBAaqEgOZ89nOB7u9nmyB5iirWH9-ejdnx9wkR2wIoB4y9ohwEG3-Gs776uNrTUI73vEHTYrcZNBod432Fnr-iibMsTMa8B_G-EZ4PXIqxzyi7j-SkGK4uVRfsPxhLsC8EvcbtHzyhRczCEhVUFHlikoFUdEoNMze09wq_d8st6OsEobm0WZr6nPlqiJ-gPJWsY0WA7Q_w1Ql5W1M-x0ThkeGxw_RMo_IScHchZ36OodPGm_n0Zjbdh-S_pnlKr8l8YUb6AtIEkOtyhl0ZBHdHTIeJZbSCNNtSaFjKmHwvDdK79CaR4vgN7y2X7aZkVlMwrCmMTydhK_8mvryyhkr6eSQb2A4faz-yzhac09e0abg6_-dXZKr7QWxD3f_3-V42y1AcmemYwKti_RFgE3koDZGY0ghZu851hvRgNzJx0iI6Yz4sdxlzD2GQ_xGKdoZjZLPXeO_Z4PKd6Gb77i-ekutyKDzy3l9g2gaKB8L5T2O9NPWPju3IqFaVzAiwH0qSzxtO6wTk99jVfX6qOBNkgcoJYp1DgQXheDGj5AS7AYWFIrI29uA7PYCEAL_DWT1-nEQFJGZ3vUlsMWRevEg4BnB_64Xw1SvKDpC9dlrot2AWe9Y6K1bcpU2ZObp2kUD7S1hgRGjpjz31Lon4iSdCdhEhXmFU9FQ9zf3K7X_oV8NFYmaUgUk8rFP2jBFG3OmCuMY2lgWN39kh5Vp6KSvvZ4GAcgds5FzUIO3sVfmEWECxnzFPvnJtWaloj2rarXLF50F6FWIJeaJsPks-4D9SB5RiLRE9OT7P-jg9F1asn7D3oE0VfOa1mW1erVL6eHbVV4l_IQCZlRMXzg7V8naaSXXE4mcRC7IA3aq7nHGmTqr2RdzJNpHXebDqL37k7myswdHyX1bHUb--Ku45s9WZwECCXfSfFzKmnGRl_2tOSix5ypPLtJZj4e11usS391NVr7lgUgQBfRAUqrBkx0yhkDc4_ChvfXGdyacRkzmu7kkDZx7PnHGQsvrtSGimxYx9Fa13dRZcW4tH4sFBhc0oUM10yGsjEXhfK0o4zAz94N_Glw5kH-kFtGPkFLTwUEECISWD7xpHVIiNSfM4YtJsNkWXbBtj0UYM57MuGDzbPqDkCnrhHBl2AhHJ5eKz4byR8ouf6i5xQQIG8NU-4cGyiGErUze1QUYQx-10xi1Q8p9Ibz3ejHpSIXmJxUyUMToqTgOA-eQqn073VyLZrc9_AYmSdT9BT1UE56jl7tITcEq0ix_Th0A5zdSoVw5lp_iXrv5V1cy-2Z_rvbjoc6Bw6NikjsKQrX5we9n8hQ-R8ugYW1eIUP-B91inNBWLp8UtY98LE5c8-CulvVJavFjQZXdpC1_Gy8s-GB1QdYfZdoLlbjrojhN-p_HG2L67eakv4hNrgNHJjMs2VvDKuGNZTOF_AFg8QBUWnD5onGwDKt1LhkzCpSgH-qjM79a5AhZPlNrk99jum_TcdKxsBZgjoU3kbs5Nvgb-MHx0tyr35A1r6O18jyBHBH61-KsVu1b3CH6sUVlZ3Vpbl5rGHi02Kv3gf2Z76Oe7rjDmgEtCwp9otovvpBrJxadkdoIOexK45Nw9ZjlArqDxfBAuIeY0VQySHyUQvRJiLC3_1SF8a4d8qnHNlmBEdYnH2bXtnvlBiaF0ZknjCy6IRynUWGYN3kEnE9MjwLWsx1DHdstewkMhq_U5qtxvh6RUmrANXB97GK17vj9E6uCfndQfq_AzSB3WEmWxXHwLDwII7cyN90FwthhxbRM-HfL0Mzj61ljk1fZXtbB9-uRw1S4KqqxJqMxe5giSzZ8A4yhL91ILt5Z6_gvxwCbZEP_BAJut2tCdSu6X6rcCiO0eIyM8MsvXGlBOsY0M_7jvbHJVA86NF8dV6k0uxsN-r1B-0Mg1AOEGt_8gC2YzhN0a6-4PDycJFHsaWFbgoSJZbM_Uy4OEg6QTG4WYaLcjbXES-UzTF1BHsjSO8BEKDHexDlJN_wY2EXJaAoUiPu1JPVjWemHBSNy-HvZGIpdXZ7XSOnBYtCbCVf3khiNNoY6NlhoZtDx5Y92xJlDcVupuq8CBsVZY8ruHd5XVlgFD8QfDKWjzyVqjKQ2yitWOtX6FY443axjZOykFWS_fBwehTV7NVX_yvYiVLFjeJ0XG_9DZqofn8cVg71FBC4AuY1_CdjPnHPlUPPUeEY9NdSyUMDqGDiLTHSWNvhFUbi4La5loNjugGEyvvHmlx6_YFKSJ747WH64AdLSnvNsQ7jgPQtD5rlxUDfdGS_0rE10jfvZGJo_sABL7DIAzi79ecyVCyG0PG3fCfNWHa7iTT6rk8KYRBC4mFhrLmdM3mIe57xu5rMdg1axkXsPOn8heZ-QZyxlSQXXTFEf70S9bgfFT86xs83Cp1k2KaEzlCYnoPxOJOUNdthWv5Skp-OszV5cwUMq5u4Wlei5V1SRzN1ydS27r60I2_JdWg5ymLRlvj5wL1eeaeB7LZF4ROd6uxDmbErX1zPPuSaHMopqEBJOWc-wjFfKF2Hdz4riu6_tYvmbYdrbQVh8ciGOlY4oQX_7EwrCD1fBzDXVtAk59DeyVL6uiFwWRuXTlmYb0yHk4YAnv3pN4BZGX0d6hacYQIbVZFyfRHKE3BmGWamgiLH1-q1OIcpAVfALQcKEjrR666EstrZN_wk2Ydwruu_-Lgj9TPE2eRc-AVYVb-2p29KE1rBkpIkLTHtUqjvIt3YeMv-N2gfVWsPVhr7VtR7vUhzkIASUDBQ3udRiWEQRI2TsFQjgBoNyDCmtBSEJY8eEHd9lA1Jyh2ZLXMVpLNxskklrAz7Xse51jjcbtlHWlHw26pmPHpXfpYxxEQE2JXTbBAvTsa5ei3A7ObX9Cg22ghgv6eMq2zX3-eHurDyZhsSuqd6WSdETenn8HmuEVWybbize-m9AfKQaH5YZN7jUL-nUgbBiOz217AbduaOY9dcnn6-sQPGoik6RxWfHN6r94ox62zRXHxLPwn8A9ycZVAX31Yvi42j435NB5gtwVK3PvykKS0iht2tWkBacQP9R5sFPGgy-mDQ2y8QeRa6rA3Ezyr36wk6OJec9oVd7AqBfXvnI9IiQ3HyeDswRGzukXMncJ0zao4l6hvXP2uE_n6Yhbc1wr_hM2OdQodTirJPaqeS8igmjIeMGhw2RqO1lxI7YII0RswgIDC2SYpsvq-JvP4voJDkFJcXd6kbjd_CcqQFiLEyCS2wAAAAAAAAAAAAAAAAAAAAAABQ4SHSIm",
+          "value": "078464472fdca36b7e4a2b8a7d73c7954e5eb36b8801f541fd627c6abb7393579fcac6cf4b6b9fe5b7472fb92b3c95e5d59577d55fab771a17bf5112a69b76eefaf0340776367c569231fd0e789fdd2c95f196367f17b45fefe10c555f76cb7be4f2baf6401b8420cf68c8dccc62d5282161df87c641549c28895fb2cc00bb360f41a4cd9ade9983df251a5586ee8649d5d5d1f3d3414d8107936bc90564bffaa0eedbc8465221a98232bad06371a349bd2401ef182fd2914442b51948c9daabd68d6c23f64e220538dc4158858ada7cfad6b71e9bcbac1149d9512a32922031e4ba86d4b1562bb9a9d1e9a3dd6e98c57f7d44cf7b050669f7735563a813a5e2f0543816a90156db8f7967c1de9e242d69b1160b81c82a3e42dedacab68ba1619710de057f61f53eea2358625a64c0c1db775bd09e474d085c840d13fd0e1ff4c744402fd9113ea4116d838e3b1307d5a6f2b54fede888fb2aae046afb3a0e7398d6a9fcd8f822e5f6538b139a4efdb01bcf382544db3ca036dfa3148a6e1974f464c56cbaf9990dcf19f45e565ccbf6cfb03b80d3617ef39ae54f084418e4d95d2a15c75ec3ed36bae079d5a7a6c748787b0c27e33fcfa80e9a19b372d31c7f573c7cf96e5589986bafa1e69108baf996a6458e54b559a08eda003c79bf5b035cd3e89014a8e9363883c481dbf81cc4445b992a7cfc15ee9b0fbd440b70371d1f5a4aa6240cd924e2e05fe7183b0432550bee66ffc784c16d521852144ce0e9c1d02666e16932ea55aee28a224c5d4faf3e6a6ba3491fe5e2b0da791bac467a9671f6f9e9e2191a72718d4fb32453848928b06c2ffbd4a532f89e475a8cb07c6bfe9dd27c002fb51ba95ab1485197c21024d8c7997d22e57b3c440fc6f522623004e3534a276497e5dfc0897eb64d87d90e6b91446e5c83b700e88843f147f4b26dff78b12b7f77627f2e2e132edfb6faaa42a507766fab55a1cfa7d51d2bfee49d7bd2a970677dc87564e465a3d7b9fe71bd293d331761a9e8085ca03623b5754b56317fde699ced2998ea008d42eaa1cab2d92f35ceb4c98d5ccfa0fd683e5b2f4a212c9f1ed3a9f3a1c0fe68f318dc4e3b8ef4039890b88fa717f2f890b9a142fd4fb15aeeb140d1371eddcaa06a8480537ad2fdb94f1afb6757b81227fb941ed355f172765c9836b3ab504f4287944a0603df4b0101aa8480e67cf67381eeef679b20798a2ad61fdf9e8dd9f1f70911db0228078cbda21c041b7f86b3befab8dad3508ef7bc41d362b719341a1de37d859ebfa289b32c4cc6bc07f1be119e0f5c8ab1cf28bb8fe4a418ae2e5517ec3f184bb02f04bdc6ed1f3ca145ccc2121554147962928154744a0d3337b4f70abf77cb2de8eb04a1b9b4599afa9cf96a889fa03c95ac634580ed0ff0d509795b533ec744e191e1b1c3f44ca3f212707721677e8ea1d3c69bf9f46636dd87e4bfa6794aafc97c6146fa02d20490eb72865d190477474c878965b48234db526858ca987c2f0dd2bbf42691e2f80def2d97eda664565330ac298c4f27612bff26bebcb2864afa79241bd80e1f6b3fb2ce169cd3d7b469b83affe75764aafb416c43ddfff7f95e36cb501c99e998c0ab62fd11601379280d9198d20859bbce7586f460373271d2223a633e2c7719730f6190ff118a76866364b3d778efd9e0f29de866fbee2f9e92eb72283cf2de5f60da068a07c2f94f63bd34f58f8eedc8a85695cc08b01f4a92cf1b4eeb04e4f7d8d57d7eaa38136481ca09629d438105e17831a3e404bb01858522b236f6e03b3d808400bfc3593d7e9c4405246677bd496c31645ebc483806707feb85f0d52bca0e90bd765ae8b760167bd63a2b56dca54d9939ba769140fb4b58604468e98f3df52e89f88927427611215e6154f4543dcdfdcaed7fe857c34562669481493cac53f68c1146dce982b8c63696058ddfd921e55a7a292bef67818072076ce45cd420edec55f9845840b19f314fbe726d59a9688f6adaad72c5e7417a15620979a26c3e4b3ee03f520794622d113d393ecffa383d1756ac9fb0f7a04d157ce6b5996d5ead52fa7876d557897f210099951317ce0ed5f2769a4975c4e267110bb200ddaabb9c71a64eaaf645dcc93691d779b0ea2f7ee4ee6cacc1d1f25f56c751bfbe2aee39b3d599c040825df49f1732a69c6465ff6b4e4a2c79ca93cbb49663e1ed75bac4b7f75355afb9605204017d1014aab064c74ca1903738fc286f7d719dc9a7119339aeee4903671ecf9c7190b2faed4868a6c58c7d15ad7775165c5b8b47e2c14185cd2850cd74c86b2311785f2b4a38cc0cfde0dfc6970e641fe905b463e414b4f0504102212583ef1a4754888d49f33862d26c3645976c1b63d1460ce7b32e183cdb3ea0e40a7ae11c19760211c9e5e2b3e1bc91f28b9fea2e71410206f0d53ee1c1b288612b5337b5414610c7ed74c62d50f29f486f3dde8c7a52217989c54c94313a2a4e0380f9e42a9f4ef75722d9adcf7f018992753f414f5504e7a8e5eed213704ab48b1fd3874039cdd4a8570e65a7f897aefe55d5ccbed99febbdb8e873a070e8d8a48ec290ad7e707bd9fc850f91f2e8185b578850ff81f758a734158ba7c52d63df0b13973cf82ba5bd525abc58d06577690b5fc6cbcb3e181d507587d97682e56e3ae88e137ea7f1c6d8bebb79a92fe2136b80d1c98ccb3656f0cab863594ce17f00583c4015169c3e689c6c032add4b864cc2a52807faa8ccefd6b902164f94dae4f7d8ee9bf4dc74ac6c059823a14de46ece4dbe06fe307c74b72af7e40d6be8ed7c8f2047047eb5f8ab15bb56f7087eac515959dd5a5b979ac61e2d362afde07f667be8e7bbae30e6804b42c29f68b68befa41ac9c5a76476820e7b12b8e4dc3d663940aea0f17c102e21e634550c921f2510bd12622c2dffd5217c6b877caa71cd9660447589c7d9b5ed9ef94189a1746649e30b2e884729d458660dde412713d323c0b5acc750c776cb5ec24321abf539aadc6f87a4549ab00d5c1f7b18ad7bbe3f44eae09f9dd41fabf033481dd61265b15c7c0b0f0208edcc8df74170b618716d133e1df2f43338fad658e4d5f657b5b07dfae470d52e0aaaac49a8cc5ee60892cd9f00e3284bf7520bb7967afe0bf1c026d910ffc1009baddad09d4aee97eab70288ed1e23233c32cbd71a504eb18d0cffb8ef6c725503ce8d17c755ea4d2ec6c37eaf507ed0c83500e106b7ff200b663384dd1aebee0f0f2709147b1a5856e0a122596ccfd4cb838483a4131b859868b7236d7112f94cd3175047b2348ef0110a0c77b10e524dff063611725a0285223eed493d58d67a61c148dcbe1ef64622975767b5d23a7058b426c255fde486234da18e8d961a19b43c7963ddb12650dc56ea6eabc081b15658f2bb877795d5960143f107c32968f3c95aa3290db28ad58eb57e85638e376b18d93b2905592fdf0707a14d5ecd557ff2bd88952c58de2745c6ffd0d9aa87e7f1c560ef51410b802e635fc27633e71cf9543cf51e118f4d752c94303a860e22d31d258dbe11546e2e0b6b9968363ba0184cafbc79a5c7afd814a489ef8ed61fae0074b4a7bcdb10ee380f42d0f9ae5c540df7464bfd2b135d237ef646268fec0012fb0c80338bbf5e732542c86d0f1b77c27cd5876bb8934faae4f0a611042e26161acb99d3379887b9ef1bb9acc760d5ac645ec3ce9fc85e67e419cb19524175d31447fbd12f5b81f153f3ac6cf370a9d64d8a684ce50989e83f138939435db615afe52929f8eb3357973050cab9bb85a57a2e55d52473375c9d4b6eebeb4236fc9756839ca62d196f8f9c0bd5e79a781ecb645e1139deaec4399b12b5f5ccf3ee49a1cca29a8404939673ec2315f285d87773e2b8aeebfb58be66d876b6d0561f1c8863a5638a105ffec4c2b083d5f0730d756d024e7d0dec952faba2170591b974e59986f4c879386009efde9378059197d1dea169c61021b5591727d11ca1370661966a68222c7d7eab53887290157c02d070a123ad1ebae84b2dad937fc24d98770aeebbff8b823f533c4d9e45cf8055855bfb6a76f4a135ac19292242d31ed52a8ef22ddd878cbfe37681f556b0f561afb56d47bbd4873908012503050dee751896110448d93b05423801a0dc830a6b41484258f1e10777d940d49ca1d992d7315a4b371b24925ac0cfb5ec7b9d638dc6ed9475a51f0dbaa663c7a577e9631c44404d895d36c102f4ec6b97a2dc0ece6d7f42836da0860bfa78cab6cd7dfe787bab0f2661b12baa77a5927444de9e7f079ae1155b26db8b37be9bd01f290687e5864dee350bfa75206c188ecf6d7b01b76e68e63d75c9e7ebeb103c6a2293a47159f1cdeabf78a31eb6cd15c7c4b3f09fc03dc9c655017df562f8b8da3e37e4d07982dc152b73efca4292d2286ddad5a405a7103fd479b053c6832fa60d0db2f107916baac0dc4cf2af7eb093a38979cf6855dec0a817d7be723d2224371f2783b30446cee917327709d336a8e25ea1bd73f6b84fe7e9885b735c2bfe133639d4287538ab24f6aa792f228268c878c1a1c3646a3b597123b60823446cc202030b6498a6cbeaf89bcfe2fa090e414971777a91b8ddfc272a40588b132092db0000000000000000000000000000000000050e121d2226"
         }
       ],
       "sender": "pq_alice",


### PR DESCRIPTION
The version marker carried MAJOR in the count code's identifier and split
the two-character count into two six-bit halves, for MINOR and PATCH. That
made revision 3 encode as `YTSP-ABA`, whose count is 64 — so read as
MAJOR.MINOR it announced itself as **0.64**, where revision 2 reads as 0.1:

| marker | count | as MAJOR.MINOR |
| --- | --- | --- |
| `YTSP-AAB` (Rev 2) | 1 | 0.1 |
| `YTSP-ABA` (Rev 3, before) | 64 | **0.64** |
| `YTSP-AAC` (Rev 3, after) | 2 | **0.2** |

The specification now defines the marker as MAJOR in the first character
and MINOR in the following two (§9.2.1: *"The current version is
`YTSP-AAC` (0.2)"*). This drops the split to match: MINOR becomes the whole
count, and `TSP_VERSION` becomes a pair rather than a triple.

Gating is unaffected either way — MAJOR is the same first character under
both readings, so `decode_version` still rejects on a differing MAJOR and
still ignores MINOR.

## Two places rendered the old split

`cesr::segments`, the field walker, reported `0.0.2` for the new marker
because it was still halving the count. It now prints MAJOR.MINOR, and its
note no longer mentions a patch level. This matters beyond the tests: the
walker's output is what the generated wire documentation and Appendix A
are rendered from.

## Regenerated vectors

Every message changes, since the version is inside the signed content.
Payloads change only where they depend on it, which is a useful check that
nothing else moved:

| | payload changed | why |
| --- | --- | --- |
| `direct-sealed-box`, `direct-hpke-base`, `direct-signed-only`, `direct-hpke-base-pq` | no | nothing version-dependent in the payload |
| the four `control-*` vectors | yes | each carries a Digest computed over the version |
| `nested-direct`, `routed` | yes | each embeds an inner message with its own marker |

Identifiers and their keys are untouched. Regenerated with
`cargo run -p tsp_sdk --example generate_test_vectors`, which reproduces
the file deterministically from the recorded seeds.

`cargo fmt --check`, `clippy --workspace --all-targets --deny warnings` and
all 179 tests pass, including the four that open and regenerate every
vector.

Appendix A and the wire page are generated from `rev3.json` by renderers
kept outside this repository, so both need re-running after this merges.