### PR TITLE
Segment the version marker where the specification divides it

### DIFF
--- a/tsp_sdk/src/cesr/segments.rs
+++ b/tsp_sdk/src/cesr/segments.rs
@@ -189,11 +189,14 @@ fn walk(text: &str) -> Vec<Segment> {
             continue;
         }
 
-        // the TSP genus, then a count code carrying MAJOR and MINOR
+        // the five-character protocol code, then the three-character version
+        // (spec 9.2.1). The bytes are produced by the count-code encoder, which
+        // puts the `-` with what follows, but the specification divides them
+        // here: `YTSP-` is the protocol code, and is also the HPKE `info`.
         if h4 == "YTSP" {
-            let version = at(i + 4, 4);
+            let version = at(i + 5, 3);
             let value = match (
-                version.as_bytes().get(1).copied().and_then(b64_index),
+                version.as_bytes().first().copied().and_then(b64_index),
                 count(at(i + 6, 2)),
             ) {
                 (Some(major), Some(minor)) => Some(format!("{major}.{minor}")),
@@ -201,16 +204,16 @@ fn walk(text: &str) -> Vec<Segment> {
             };
             out.push(seg(
                 SegmentKind::Code,
-                "TSP_Version code",
-                h4,
-                "the TSP genus",
+                "TSP protocol code",
+                at(i, 5),
+                "unique in the CESR code; also the HPKE info",
                 None,
             ));
             out.push(seg(
                 SegmentKind::Data,
                 "TSP_Version",
                 version,
-                "MAJOR in the count code's identifier, MINOR in its count",
+                "MAJOR is the first character, MINOR the following two",
                 value,
             ));
             i += 8;

--- a/tsp_sdk/test_vectors/rev3.json
+++ b/tsp_sdk/test_vectors/rev3.json
@@ -108,19 +108,19 @@
           "value": "88 quadlets = 264 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -304,19 +304,19 @@
           "value": "69 quadlets = 207 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -496,19 +496,19 @@
           "value": "55 quadlets = 165 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -761,19 +761,19 @@
           "value": "82 quadlets = 246 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -967,19 +967,19 @@
           "value": "85 quadlets = 255 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -1155,19 +1155,19 @@
           "value": "74 quadlets = 222 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -1388,19 +1388,19 @@
           "value": "101 quadlets = 303 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -1627,19 +1627,19 @@
           "value": "69 quadlets = 207 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -1735,19 +1735,19 @@
           "value": "158 quadlets = 474 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -2012,19 +2012,19 @@
           "value": "69 quadlets = 207 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -2120,19 +2120,19 @@
           "value": "198 quadlets = 594 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {
@@ -2312,19 +2312,19 @@
           "value": "432 quadlets = 1296 bytes"
         },
         {
-          "chars": 4,
-          "field": "TSP_Version code",
+          "chars": 5,
+          "field": "TSP protocol code",
           "kind": "code",
-          "note": "the TSP genus",
-          "text": "YTSP",
+          "note": "unique in the CESR code; also the HPKE info",
+          "text": "YTSP-",
           "value": null
         },
         {
-          "chars": 4,
+          "chars": 3,
           "field": "TSP_Version",
           "kind": "data",
-          "note": "MAJOR in the count code's identifier, MINOR in its count",
-          "text": "-AAC",
+          "note": "MAJOR is the first character, MINOR the following two",
+          "text": "AAC",
           "value": "0.2"
         },
         {


### PR DESCRIPTION
The field walker split `YTSP-AAC` after four characters, labelling `YTSP` as the code and attaching the `-` to the version. That mirrored how the bytes are produced — `encode_version` emits the genus and then calls `encode_count` — but it is not how section 9.2.1 divides them: `YTSP-` is the five-character protocol code, and `###` is the version.

The distinction matters for the generated wire document, which stated that the HPKE `info` is "the five bytes `YTSP-`" while drawing the field boundary after four, so those five bytes could not be located in the annotated message.

Before:

| chars | field | text | value |
| --- | --- | --- | --- |
| 4 | TSP_Version code | `YTSP` | — |
| 4 | TSP_Version | `-AAC` | 0.2 |

After:

| chars | field | text | value |
| --- | --- | --- | --- |
| 5 | TSP protocol code | `YTSP-` | — |
| 3 | TSP_Version | `AAC` | 0.2 |

Only the annotation changes. The encoder is untouched, and every message, payload and VID in `rev3.json` is byte-identical; the diff there is confined to `segments` and `payload_segments`.