### PR TITLE
Version 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "async-stream",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "tsp_javascript"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "tsp_python"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "futures",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "tsp_sdk"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arbitrary",
  "aries-askar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["tsp_sdk", "examples", "fuzz", "tsp_python", "tsp_javascript"]
 exclude = ["demo"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/openwallet-foundation-labs/tsp"
@@ -107,4 +107,4 @@ clap = { version = "4.5", features = ["derive"] }
 axum = { version = "0.8.1", features = ["ws", "macros"] }
 tower-http = { version = "0.6.2", features = ["cors"] }
 
-tsp_sdk = { path = "./tsp_sdk", version = "0.10.0" }
+tsp_sdk = { path = "./tsp_sdk", version = "0.11.0" }


### PR DESCRIPTION
The wire version changed: messages carry `YTSP-AAC` (0.2) where 0.10.0 carried `YTSP-ABA`, matching revision 3 of the specification as published. The two do not interoperate, which before 1.0 belongs in the minor rather than the patch.

Since 0.10.0:

| | |
| --- | --- |
| wire version | `YTSP-ABA` → `YTSP-AAC` (breaking, deliberate) |
| encryption key type | named `MLKEM768-X25519` per IANA HPKE KEM `0x647a`, with a serde alias so 0.10.0 wallets and identity files still load |
| bug fix | the connection map lock is no longer held across a send, which could block unrelated peers behind one slow one |
| also | version marker segmented as the specification divides it, HTTP loopback benchmark, node binding docs, container `latest` tag |

Verified beyond the test suite, on the built release binary: a real `did:peer` send over TCP puts `61348ff80002` on the wire — the binary form of `YTSP-AAC` — with the 0.10.0 bytes `61348ff80040` absent. A second identity received that message, decrypted it and authenticated the sender, recovering the payload.